### PR TITLE
Chore/test coverage baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for considering a contribution. This document covers how to get the proje
 **Clone and start:**
 
 ```bash
-git clone https://github.com/your-org/kotauth.git
+git clone https://github.com/inumansoul/kotauth.git
 cd kotauth
 
 # Start the PostgreSQL dependency only
@@ -80,15 +80,47 @@ When adding a new feature:
 
 ---
 
-## Running Tests
+## Testing Philosophy and Conventions
 
 ```bash
 ./gradlew test
 ```
 
-The test suite uses in-memory fakes (not mocks) for all adapters — no database required. New domain logic should have unit tests using the fake adapters in `src/test/kotlin/fakes/`.
+The test suite runs entirely in-memory — no database, no network, no Docker. All tests should pass on a fresh clone with just `./gradlew test`.
 
-When adding a new repository, add a corresponding fake in `src/test/kotlin/fakes/` that implements the port interface with an in-memory `MutableMap`.
+### Fakes over mocks
+
+Every port interface has a corresponding in-memory fake in `src/test/kotlin/com/kauth/fakes/`. Fakes are deterministic `MutableMap`-backed implementations that behave like the real adapter minus the database. Use fakes for all dependencies the test exercises directly. Reserve `mockk(relaxed = true)` only for dependencies that are not the focus of the test and whose behavior is irrelevant (e.g., `KeyProvisioningService` when testing login).
+
+When adding a new repository port, add a matching fake with the same name prefixed with `Fake` (e.g., `UserRepository` → `FakeUserRepository`). The fake must implement `clear()` for `@BeforeTest` resets.
+
+### Test layers
+
+The test suite follows a two-layer pyramid.
+
+**Domain service unit tests** (`domain/service/*Test.kt`) — test business logic in isolation. Each service is constructed with fakes for all its ports. These validate rules, error paths, and edge cases. This is where the bulk of the logic coverage lives.
+
+**Route integration tests** (`adapter/web/**/*Test.kt`) — use Ktor's `testApplication` with real routing wired to fakes. These validate HTTP concerns that the domain layer cannot see: authentication guards, session cookies, scope enforcement, DTO serialization, status codes, redirect behavior, and cross-tenant isolation. They do not duplicate the domain logic tests — they test the wiring.
+
+### Writing a route integration test
+
+Follow the established pattern:
+
+1. Construct fakes and services as class-level properties.
+2. In `@BeforeTest`, call `clear()` on every fake and seed the minimum fixtures (tenant, user, API key or session).
+3. Write a private `installTestApp()` extension on `Application` that installs `ContentNegotiation { json() }`, any auth/session plugins, and the route module under test.
+4. Each test calls `testApplication { application { installTestApp() } ... }`.
+5. For admin routes behind a session guard, use `createClient { install(HttpCookies) }` and call a `login()` helper before hitting protected endpoints.
+6. For API routes behind bearer auth, use `bearerAuth(rawApiKey)` where `rawApiKey` comes from `ApiKeyService.create()` in `@BeforeTest`.
+7. When testing redirects, use `createClient { followRedirects = false }` and assert on `HttpStatusCode.Found` + the `Location` header.
+
+### Known serialization gotcha
+
+Ktor's `ContentNegotiation { json() }` uses kotlinx.serialization under the hood. Responding with `mapOf("key" to someBoolean)` produces `Map<String, Any>`, and kotlinx.serialization cannot serialize the polymorphic `Any` type. Always use `buildJsonObject { put("key", value) }` instead of `mapOf(...)` when the response contains mixed types (String, Boolean, Long). The OIDC discovery endpoint is the reference implementation of this pattern.
+
+### Test file organization
+
+Group tests by route module. One test class per route file is the default. Split into separate files when a single test class exceeds ~40 tests or when distinct concerns emerge (e.g., `AdminRoutesTest` for auth guard vs. `AdminSettingsTest` for workspace settings vs. `AdminApiKeysTest` for key management). Shared wiring duplication across sibling test classes is acceptable — prefer locality over DRY in tests.
 
 ---
 

--- a/TESTS_ROADMAP.md
+++ b/TESTS_ROADMAP.md
@@ -1,0 +1,1 @@
+This file is obsolete. Testing conventions are now documented in CONTRIBUTING.md under "Testing Philosophy and Conventions".

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # KotAuth — Implementation Status
 
-> Last updated: 2026-03-19
-> Current version: 1.0.0 (Phase 4 Webhooks complete — Phase 5 Documentation next)
+> Last updated: 2026-03-21
+> Current version: 1.0.3 (Phases 0–5 shipped)
 
 This document is the living record of what has been built, what compiles and runs, what is intentionally deferred, and what the next milestone requires. It supplements the strategic `ROADMAP.md`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Kotauth — Product Roadmap
 
-> Last updated: 2026-03-17
-> Status: V1.0 complete — Phases 0–5 shipped
+> Last updated: 2026-03-21
+> Status: V1.0.3 — Phases 0–5 shipped
 
 ---
 

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
@@ -1403,20 +1403,26 @@ fun Route.authRoutes(
         get("/protocol/openid-connect/userinfo") {
             val bearerToken =
                 extractBearerToken(call)
-                    ?: return@get call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "invalid_token"))
+                    ?: return@get call.respond(
+                        HttpStatusCode.Unauthorized,
+                        buildJsonObject { put("error", "invalid_token") },
+                    )
 
             val userInfo =
                 oauthService.getUserInfo(bearerToken)
-                    ?: return@get call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "invalid_token"))
+                    ?: return@get call.respond(
+                        HttpStatusCode.Unauthorized,
+                        buildJsonObject { put("error", "invalid_token") },
+                    )
 
             call.respond(
-                mapOf(
-                    "sub" to userInfo.sub,
-                    "preferred_username" to userInfo.username,
-                    "email" to userInfo.email,
-                    "email_verified" to userInfo.emailVerified,
-                    "name" to userInfo.name,
-                ),
+                buildJsonObject {
+                    put("sub", userInfo.sub)
+                    put("preferred_username", userInfo.username)
+                    put("email", userInfo.email)
+                    put("email_verified", userInfo.emailVerified)
+                    put("name", userInfo.name)
+                },
             )
         }
 
@@ -1429,10 +1435,10 @@ fun Route.authRoutes(
             val token =
                 params["token"] ?: return@post call.respond(
                     HttpStatusCode.BadRequest,
-                    mapOf(
-                        "error" to "invalid_request",
-                        "error_description" to "token parameter is required",
-                    ),
+                    buildJsonObject {
+                        put("error", "invalid_request")
+                        put("error_description", "token parameter is required")
+                    },
                 )
 
             oauthService.revokeToken(token)
@@ -1451,18 +1457,19 @@ fun Route.authRoutes(
             val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
 
             when (val result = oauthService.introspectToken(slug, token, typeHint)) {
-                is IntrospectionResult.Inactive -> call.respond(mapOf("active" to false))
+                is IntrospectionResult.Inactive ->
+                    call.respond(buildJsonObject { put("active", false) })
                 is IntrospectionResult.Active ->
                     call.respond(
-                        mapOf(
-                            "active" to true,
-                            "sub" to result.sub,
-                            "username" to (result.username ?: ""),
-                            "email" to (result.email ?: ""),
-                            "scope" to result.scopes.joinToString(" "),
-                            "exp" to result.expiresAt,
-                            "client_id" to (result.clientId ?: ""),
-                        ),
+                        buildJsonObject {
+                            put("active", true)
+                            put("sub", result.sub)
+                            put("username", result.username ?: "")
+                            put("email", result.email ?: "")
+                            put("scope", result.scopes.joinToString(" "))
+                            put("exp", result.expiresAt)
+                            put("client_id", result.clientId ?: "")
+                        },
                     )
             }
         }

--- a/src/test/kotlin/com/kauth/adapter/web/HealthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/HealthRoutesTest.kt
@@ -1,0 +1,127 @@
+package com.kauth.adapter.web
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [healthRoutes].
+ *
+ * GET /health — liveness probe (always 200 if JVM is alive)
+ * GET /health/ready — readiness probe (checks DB + config)
+ *
+ * No database is wired in the test engine, so the readiness probe
+ * naturally exercises the "not_ready" path (DB unreachable).
+ */
+class HealthRoutesTest {
+    // =========================================================================
+    // GET /health — liveness
+    // =========================================================================
+
+    @Test
+    fun `GET health returns 200 with status up`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+        }
+
+        val response = client.get("/health")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"status\":\"up\"") || body.contains("\"status\": \"up\""))
+    }
+
+    @Test
+    fun `GET health response contains ISO timestamp`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+        }
+
+        val body = client.get("/health").bodyAsText()
+
+        assertTrue(body.contains("\"timestamp\""))
+        // ISO-8601 timestamps contain 'T' separator (e.g. 2026-03-21T12:00:00Z)
+        assertTrue(body.contains("T"), "Timestamp must be ISO-8601 format")
+    }
+
+    // =========================================================================
+    // GET /health/ready — readiness
+    // =========================================================================
+
+    @Test
+    fun `GET health ready returns 503 when database is not available`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+        }
+
+        val response = client.get("/health/ready")
+
+        // No Exposed database is configured in the test engine, so
+        // pingDatabase() throws → dbCheck.status = "error" → 503
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        val body = response.bodyAsText()
+        assertTrue(
+            body.contains("\"status\":\"not_ready\"") || body.contains("\"status\": \"not_ready\""),
+        )
+    }
+
+    @Test
+    fun `GET health ready includes database check details`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+        }
+
+        val body = client.get("/health/ready").bodyAsText()
+
+        assertTrue(body.contains("\"database\""), "Response must include database check")
+        assertTrue(body.contains("\"config\""), "Response must include config check")
+        assertTrue(body.contains("\"checks\""), "Response must include checks envelope")
+    }
+
+    // =========================================================================
+    // Config check — warnings for non-HTTPS, missing secret key
+    // =========================================================================
+
+    @Test
+    fun `checkConfig reports warning for non-HTTPS non-localhost base URL`() {
+        val result = checkConfig("http://production.example.com")
+
+        assertEquals("warn", result.status)
+        assertTrue(result.warnings.any { it.contains("HTTPS") })
+        assertEquals(false, result.httpsEnforced)
+    }
+
+    @Test
+    fun `checkConfig returns ok for localhost even without HTTPS`() {
+        val result = checkConfig("http://localhost:8080")
+
+        // Localhost is exempted from the HTTPS warning
+        assertTrue(
+            result.warnings.none { it.contains("HTTPS") },
+            "Localhost should not trigger HTTPS warning",
+        )
+    }
+
+    @Test
+    fun `checkConfig returns ok for HTTPS base URL`() {
+        val result = checkConfig("https://auth.example.com")
+
+        assertEquals(true, result.httpsEnforced)
+        assertTrue(
+            result.warnings.none { it.contains("HTTPS") },
+            "HTTPS URL should not trigger HTTPS warning",
+        )
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/HealthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/HealthRoutesTest.kt
@@ -27,68 +27,72 @@ class HealthRoutesTest {
     // =========================================================================
 
     @Test
-    fun `GET health returns 200 with status up`() = testApplication {
-        application {
-            install(ContentNegotiation) { json() }
-            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+    fun `GET health returns 200 with status up`() =
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                routing { healthRoutes(baseUrl = "http://localhost:8080") }
+            }
+
+            val response = client.get("/health")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"status\":\"up\"") || body.contains("\"status\": \"up\""))
         }
-
-        val response = client.get("/health")
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("\"status\":\"up\"") || body.contains("\"status\": \"up\""))
-    }
 
     @Test
-    fun `GET health response contains ISO timestamp`() = testApplication {
-        application {
-            install(ContentNegotiation) { json() }
-            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+    fun `GET health response contains ISO timestamp`() =
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                routing { healthRoutes(baseUrl = "http://localhost:8080") }
+            }
+
+            val body = client.get("/health").bodyAsText()
+
+            assertTrue(body.contains("\"timestamp\""))
+            // ISO-8601 timestamps contain 'T' separator (e.g. 2026-03-21T12:00:00Z)
+            assertTrue(body.contains("T"), "Timestamp must be ISO-8601 format")
         }
-
-        val body = client.get("/health").bodyAsText()
-
-        assertTrue(body.contains("\"timestamp\""))
-        // ISO-8601 timestamps contain 'T' separator (e.g. 2026-03-21T12:00:00Z)
-        assertTrue(body.contains("T"), "Timestamp must be ISO-8601 format")
-    }
 
     // =========================================================================
     // GET /health/ready — readiness
     // =========================================================================
 
     @Test
-    fun `GET health ready returns 503 when database is not available`() = testApplication {
-        application {
-            install(ContentNegotiation) { json() }
-            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+    fun `GET health ready returns 503 when database is not available`() =
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                routing { healthRoutes(baseUrl = "http://localhost:8080") }
+            }
+
+            val response = client.get("/health/ready")
+
+            // No Exposed database is configured in the test engine, so
+            // pingDatabase() throws → dbCheck.status = "error" → 503
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+            val body = response.bodyAsText()
+            assertTrue(
+                body.contains("\"status\":\"not_ready\"") || body.contains("\"status\": \"not_ready\""),
+            )
         }
-
-        val response = client.get("/health/ready")
-
-        // No Exposed database is configured in the test engine, so
-        // pingDatabase() throws → dbCheck.status = "error" → 503
-        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
-        val body = response.bodyAsText()
-        assertTrue(
-            body.contains("\"status\":\"not_ready\"") || body.contains("\"status\": \"not_ready\""),
-        )
-    }
 
     @Test
-    fun `GET health ready includes database check details`() = testApplication {
-        application {
-            install(ContentNegotiation) { json() }
-            routing { healthRoutes(baseUrl = "http://localhost:8080") }
+    fun `GET health ready includes database check details`() =
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                routing { healthRoutes(baseUrl = "http://localhost:8080") }
+            }
+
+            val body = client.get("/health/ready").bodyAsText()
+
+            assertTrue(body.contains("\"database\""), "Response must include database check")
+            assertTrue(body.contains("\"config\""), "Response must include config check")
+            assertTrue(body.contains("\"checks\""), "Response must include checks envelope")
         }
-
-        val body = client.get("/health/ready").bodyAsText()
-
-        assertTrue(body.contains("\"database\""), "Response must include database check")
-        assertTrue(body.contains("\"config\""), "Response must include config check")
-        assertTrue(body.contains("\"checks\""), "Response must include checks envelope")
-    }
 
     // =========================================================================
     // Config check — warnings for non-HTTPS, missing secret key

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -62,52 +62,83 @@ class AdminApiKeysTest {
 
     private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
 
-    private val apiKeyService = ApiKeyService(
-        apiKeyRepository = apiKeyRepo,
-        tenantRepository = tenantRepo,
-    )
+    private val apiKeyService =
+        ApiKeyService(
+            apiKeyRepository = apiKeyRepo,
+            tenantRepository = tenantRepo,
+        )
 
-    private val masterTenant = Tenant(
-        id = 1, slug = "master", displayName = "Master",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val masterTenant =
+        Tenant(
+            id = 1,
+            slug = "master",
+            displayName = "Master",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val workspace = Tenant(
-        id = 2, slug = "acme", displayName = "Acme Corp",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val workspace =
+        Tenant(
+            id = 2,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val adminUser = User(
-        id = 1, tenantId = 1, username = "admin",
-        email = "admin@kotauth.dev", fullName = "Admin",
-        passwordHash = hasher.hash("admin-pass"), enabled = true,
-    )
+    private val adminUser =
+        User(
+            id = 1,
+            tenantId = 1,
+            username = "admin",
+            email = "admin@kotauth.dev",
+            fullName = "Admin",
+            passwordHash = hasher.hash("admin-pass"),
+            enabled = true,
+        )
 
-    private fun buildAuthService() = AuthService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        tokenPort = tokenPort, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-    )
+    private fun buildAuthService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+        )
 
-    private fun buildSelfService() = UserSelfServiceService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
-        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
-    )
+    private fun buildSelfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = FakeEmailPort(),
+        )
 
-    private fun buildAdminService() = AdminService(
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-        selfServiceService = buildSelfService(),
-    )
+    private fun buildAdminService() =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService = buildSelfService(),
+        )
 
-    private fun buildRoleGroupService() = RoleGroupService(
-        roleRepository = roleRepo, groupRepository = groupRepo,
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, auditLog = auditLogPort,
-    )
+    private fun buildRoleGroupService() =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
 
     @BeforeTest
     fun setup() {
@@ -126,77 +157,87 @@ class AdminApiKeysTest {
     // =========================================================================
 
     @Test
-    fun `GET api-keys list returns 200`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET api-keys list returns 200`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings/api-keys")
+            val response = authed.get("/admin/workspaces/acme/settings/api-keys")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
-
-    @Test
-    fun `POST api-keys creates a key and shows raw key`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/api-keys",
-            formParameters = Parameters.build {
-                append("name", "Test Key")
-                append("scopes", ApiScope.USERS_READ)
-                append("scopes", ApiScope.USERS_WRITE)
-            },
-        )
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("kauth_"), "Response must show the raw API key")
-    }
-
-    @Test
-    fun `POST api-keys revoke redirects back to list`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+            assertEquals(HttpStatusCode.OK, response.status)
         }
-        login(authed)
-
-        val created = apiKeyService.create(2, "Revokable", listOf(ApiScope.USERS_READ))
-        val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/api-keys/$keyId/revoke",
-            formParameters = Parameters.build { },
-        )
-
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
-    }
 
     @Test
-    fun `POST api-keys delete redirects back to list`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+    fun `POST api-keys creates a key and shows raw key`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/api-keys",
+                    formParameters =
+                        Parameters.build {
+                            append("name", "Test Key")
+                            append("scopes", ApiScope.USERS_READ)
+                            append("scopes", ApiScope.USERS_WRITE)
+                        },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("kauth_"), "Response must show the raw API key")
         }
-        login(authed)
 
-        val created = apiKeyService.create(2, "Deletable", listOf(ApiScope.ROLES_READ))
-        val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
+    @Test
+    fun `POST api-keys revoke redirects back to list`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
 
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/api-keys/$keyId/delete",
-            formParameters = Parameters.build { },
-        )
+            val created = apiKeyService.create(2, "Revokable", listOf(ApiScope.USERS_READ))
+            val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
-    }
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/api-keys/$keyId/revoke",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
+        }
+
+    @Test
+    fun `POST api-keys delete redirects back to list`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val created = apiKeyService.create(2, "Deletable", listOf(ApiScope.ROLES_READ))
+            val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/api-keys/$keyId/delete",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
+        }
 
     // =========================================================================
     // Helpers
@@ -205,10 +246,11 @@ class AdminApiKeysTest {
     private suspend fun login(client: io.ktor.client.HttpClient) {
         client.submitForm(
             url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "admin")
-                append("password", "admin-pass")
-            },
+            formParameters =
+                Parameters.build {
+                    append("username", "admin")
+                    append("password", "admin-pass")
+                },
         )
     }
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -1,0 +1,236 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.ApiKeyService
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApiKeyRepository
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.KeyProvisioningService
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for admin API key management UI routes.
+ */
+class AdminApiKeysTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val apiKeyRepo = FakeApiKeyRepository()
+    private val hasher = FakePasswordHasher()
+    private val tokenPort = FakeTokenPort()
+
+    private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+
+    private val apiKeyService = ApiKeyService(
+        apiKeyRepository = apiKeyRepo,
+        tenantRepository = tenantRepo,
+    )
+
+    private val masterTenant = Tenant(
+        id = 1, slug = "master", displayName = "Master",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val workspace = Tenant(
+        id = 2, slug = "acme", displayName = "Acme Corp",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val adminUser = User(
+        id = 1, tenantId = 1, username = "admin",
+        email = "admin@kotauth.dev", fullName = "Admin",
+        passwordHash = hasher.hash("admin-pass"), enabled = true,
+    )
+
+    private fun buildAuthService() = AuthService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        tokenPort = tokenPort, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+    )
+
+    private fun buildSelfService() = UserSelfServiceService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
+        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
+    )
+
+    private fun buildAdminService() = AdminService(
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+        selfServiceService = buildSelfService(),
+    )
+
+    private fun buildRoleGroupService() = RoleGroupService(
+        roleRepository = roleRepo, groupRepository = groupRepo,
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, auditLog = auditLogPort,
+    )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        apiKeyRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+        tenantRepo.add(masterTenant)
+        tenantRepo.add(workspace)
+        userRepo.add(adminUser)
+    }
+
+    // =========================================================================
+    // API key management
+    // =========================================================================
+
+    @Test
+    fun `GET api-keys list returns 200`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings/api-keys")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST api-keys creates a key and shows raw key`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/api-keys",
+            formParameters = Parameters.build {
+                append("name", "Test Key")
+                append("scopes", ApiScope.USERS_READ)
+                append("scopes", ApiScope.USERS_WRITE)
+            },
+        )
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("kauth_"), "Response must show the raw API key")
+    }
+
+    @Test
+    fun `POST api-keys revoke redirects back to list`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val created = apiKeyService.create(2, "Revokable", listOf(ApiScope.USERS_READ))
+        val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/api-keys/$keyId/revoke",
+            formParameters = Parameters.build { },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
+    }
+
+    @Test
+    fun `POST api-keys delete redirects back to list`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val created = apiKeyService.create(2, "Deletable", listOf(ApiScope.ROLES_READ))
+        val keyId = (created as com.kauth.domain.service.ApiKeyResult.Success).value.apiKey.id!!
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/api-keys/$keyId/delete",
+            formParameters = Parameters.build { },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/settings/api-keys") == true)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private suspend fun login(client: io.ktor.client.HttpClient) {
+        client.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "admin")
+                append("password", "admin-pass")
+            },
+        )
+    }
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<AdminSession>("KOTAUTH_ADMIN")
+        }
+        routing {
+            adminRoutes(
+                authService = buildAuthService(),
+                adminService = buildAdminService(),
+                roleGroupService = buildRoleGroupService(),
+                appInfo = AppInfo(),
+                tenantRepository = tenantRepo,
+                applicationRepository = appRepo,
+                userRepository = userRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                keyProvisioningService = keyProvisioningService,
+                apiKeyService = apiKeyService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
@@ -58,64 +58,70 @@ class AdminRoutesTest {
     private val hasher = FakePasswordHasher()
     private val tokenPort = FakeTokenPort()
 
-    private val masterTenant = Tenant(
-        id = 1,
-        slug = "master",
-        displayName = "Master",
-        issuerUrl = null,
-        theme = TenantTheme.DEFAULT,
-    )
+    private val masterTenant =
+        Tenant(
+            id = 1,
+            slug = "master",
+            displayName = "Master",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val adminUser = User(
-        id = 1,
-        tenantId = 1,
-        username = "admin",
-        email = "admin@kotauth.dev",
-        fullName = "Admin",
-        passwordHash = hasher.hash("admin-pass"),
-        enabled = true,
-    )
+    private val adminUser =
+        User(
+            id = 1,
+            tenantId = 1,
+            username = "admin",
+            email = "admin@kotauth.dev",
+            fullName = "Admin",
+            passwordHash = hasher.hash("admin-pass"),
+            enabled = true,
+        )
 
     private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
 
-    private fun buildAuthService() = AuthService(
-        userRepository = userRepo,
-        tenantRepository = tenantRepo,
-        tokenPort = tokenPort,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        sessionRepository = sessionRepo,
-    )
+    private fun buildAuthService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+        )
 
-    private fun buildSelfService() = UserSelfServiceService(
-        userRepository = userRepo,
-        tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        evTokenRepo = FakeEmailVerificationTokenRepository(),
-        prTokenRepo = FakePasswordResetTokenRepository(),
-        emailPort = FakeEmailPort(),
-    )
+    private fun buildSelfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = FakeEmailPort(),
+        )
 
-    private fun buildAdminService() = AdminService(
-        tenantRepository = tenantRepo,
-        userRepository = userRepo,
-        applicationRepository = appRepo,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        sessionRepository = sessionRepo,
-        selfServiceService = buildSelfService(),
-    )
+    private fun buildAdminService() =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService = buildSelfService(),
+        )
 
-    private fun buildRoleGroupService() = RoleGroupService(
-        roleRepository = roleRepo,
-        groupRepository = groupRepo,
-        tenantRepository = tenantRepo,
-        userRepository = userRepo,
-        applicationRepository = appRepo,
-        auditLog = auditLogPort,
-    )
+    private fun buildRoleGroupService() =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
 
     @BeforeTest
     fun setup() {
@@ -132,119 +138,133 @@ class AdminRoutesTest {
     // =========================================================================
 
     @Test
-    fun `GET admin redirects to login when no session cookie is present`() = testApplication {
-        application { installTestApp() }
+    fun `GET admin redirects to login when no session cookie is present`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.get("/admin")
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/admin")
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        val location = response.headers["Location"] ?: ""
-        assertTrue(location.contains("/admin/login"))
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.contains("/admin/login"))
+        }
 
     @Test
-    fun `GET admin settings redirects to login when unauthenticated`() = testApplication {
-        application { installTestApp() }
+    fun `GET admin settings redirects to login when unauthenticated`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.get("/admin/settings")
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/admin/settings")
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
+        }
 
     // =========================================================================
     // GET /admin/login
     // =========================================================================
 
     @Test
-    fun `GET admin login returns 200 with login form`() = testApplication {
-        application { installTestApp() }
+    fun `GET admin login returns 200 with login form`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/admin/login")
+            val response = client.get("/admin/login")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
+        }
 
     // =========================================================================
     // POST /admin/login
     // =========================================================================
 
     @Test
-    fun `POST admin login with valid credentials sets session and redirects`() = testApplication {
-        application { installTestApp() }
+    fun `POST admin login with valid credentials sets session and redirects`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.submitForm(
-            url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "admin")
-                append("password", "admin-pass")
-            },
-        )
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/admin/login",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "admin")
+                            append("password", "admin-pass")
+                        },
+                )
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        val location = response.headers["Location"] ?: ""
-        assertTrue(location.endsWith("/admin") || location.contains("/admin"), "Must redirect to /admin")
-        // Session cookie must be set
-        val cookies = response.headers.getAll("Set-Cookie")
-        assertTrue(
-            cookies?.any { it.contains("KOTAUTH_ADMIN") } == true,
-            "KOTAUTH_ADMIN session cookie must be set on successful login",
-        )
-    }
-
-    @Test
-    fun `POST admin login with invalid credentials returns 401`() = testApplication {
-        application { installTestApp() }
-
-        val response = client.submitForm(
-            url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "admin")
-                append("password", "wrong-password")
-            },
-        )
-
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertTrue(response.bodyAsText().contains("Invalid credentials"))
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.endsWith("/admin") || location.contains("/admin"), "Must redirect to /admin")
+            // Session cookie must be set
+            val cookies = response.headers.getAll("Set-Cookie")
+            assertTrue(
+                cookies?.any { it.contains("KOTAUTH_ADMIN") } == true,
+                "KOTAUTH_ADMIN session cookie must be set on successful login",
+            )
+        }
 
     @Test
-    fun `POST admin login with blank username returns 401`() = testApplication {
-        application { installTestApp() }
+    fun `POST admin login with invalid credentials returns 401`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.submitForm(
-            url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "")
-                append("password", "admin-pass")
-            },
-        )
+            val response =
+                client.submitForm(
+                    url = "/admin/login",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "admin")
+                            append("password", "wrong-password")
+                        },
+                )
 
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-    }
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().contains("Invalid credentials"))
+        }
+
+    @Test
+    fun `POST admin login with blank username returns 401`() =
+        testApplication {
+            application { installTestApp() }
+
+            val response =
+                client.submitForm(
+                    url = "/admin/login",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "")
+                            append("password", "admin-pass")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
 
     // =========================================================================
     // POST /admin/logout
     // =========================================================================
 
     @Test
-    fun `POST admin logout redirects to login`() = testApplication {
-        application { installTestApp() }
+    fun `POST admin logout redirects to login`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.submitForm(
-            url = "/admin/logout",
-            formParameters = Parameters.build { },
-        )
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/admin/logout",
+                    formParameters = Parameters.build { },
+                )
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
+        }
 
     // =========================================================================
     // Test app wiring

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
@@ -1,0 +1,273 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.KeyProvisioningService
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [adminRoutes] — session guard and login/logout.
+ *
+ * Focus: the authentication boundary, not the 70+ CRUD endpoints behind it.
+ * CRUD is already validated at the domain service layer.
+ */
+class AdminRoutesTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val hasher = FakePasswordHasher()
+    private val tokenPort = FakeTokenPort()
+
+    private val masterTenant = Tenant(
+        id = 1,
+        slug = "master",
+        displayName = "Master",
+        issuerUrl = null,
+        theme = TenantTheme.DEFAULT,
+    )
+
+    private val adminUser = User(
+        id = 1,
+        tenantId = 1,
+        username = "admin",
+        email = "admin@kotauth.dev",
+        fullName = "Admin",
+        passwordHash = hasher.hash("admin-pass"),
+        enabled = true,
+    )
+
+    private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+
+    private fun buildAuthService() = AuthService(
+        userRepository = userRepo,
+        tenantRepository = tenantRepo,
+        tokenPort = tokenPort,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        sessionRepository = sessionRepo,
+    )
+
+    private fun buildSelfService() = UserSelfServiceService(
+        userRepository = userRepo,
+        tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        evTokenRepo = FakeEmailVerificationTokenRepository(),
+        prTokenRepo = FakePasswordResetTokenRepository(),
+        emailPort = FakeEmailPort(),
+    )
+
+    private fun buildAdminService() = AdminService(
+        tenantRepository = tenantRepo,
+        userRepository = userRepo,
+        applicationRepository = appRepo,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        sessionRepository = sessionRepo,
+        selfServiceService = buildSelfService(),
+    )
+
+    private fun buildRoleGroupService() = RoleGroupService(
+        roleRepository = roleRepo,
+        groupRepository = groupRepo,
+        tenantRepository = tenantRepo,
+        userRepository = userRepo,
+        applicationRepository = appRepo,
+        auditLog = auditLogPort,
+    )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+        tenantRepo.add(masterTenant)
+        userRepo.add(adminUser)
+    }
+
+    // =========================================================================
+    // Session guard — unauthenticated access
+    // =========================================================================
+
+    @Test
+    fun `GET admin redirects to login when no session cookie is present`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.get("/admin")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        val location = response.headers["Location"] ?: ""
+        assertTrue(location.contains("/admin/login"))
+    }
+
+    @Test
+    fun `GET admin settings redirects to login when unauthenticated`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.get("/admin/settings")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
+    }
+
+    // =========================================================================
+    // GET /admin/login
+    // =========================================================================
+
+    @Test
+    fun `GET admin login returns 200 with login form`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/admin/login")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
+    }
+
+    // =========================================================================
+    // POST /admin/login
+    // =========================================================================
+
+    @Test
+    fun `POST admin login with valid credentials sets session and redirects`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "admin")
+                append("password", "admin-pass")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        val location = response.headers["Location"] ?: ""
+        assertTrue(location.endsWith("/admin") || location.contains("/admin"), "Must redirect to /admin")
+        // Session cookie must be set
+        val cookies = response.headers.getAll("Set-Cookie")
+        assertTrue(
+            cookies?.any { it.contains("KOTAUTH_ADMIN") } == true,
+            "KOTAUTH_ADMIN session cookie must be set on successful login",
+        )
+    }
+
+    @Test
+    fun `POST admin login with invalid credentials returns 401`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "admin")
+                append("password", "wrong-password")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid credentials"))
+    }
+
+    @Test
+    fun `POST admin login with blank username returns 401`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "")
+                append("password", "admin-pass")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    // =========================================================================
+    // POST /admin/logout
+    // =========================================================================
+
+    @Test
+    fun `POST admin logout redirects to login`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.submitForm(
+            url = "/admin/logout",
+            formParameters = Parameters.build { },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/admin/login") == true)
+    }
+
+    // =========================================================================
+    // Test app wiring
+    // =========================================================================
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<AdminSession>("KOTAUTH_ADMIN")
+        }
+        routing {
+            adminRoutes(
+                authService = buildAuthService(),
+                adminService = buildAdminService(),
+                roleGroupService = buildRoleGroupService(),
+                appInfo = AppInfo(),
+                tenantRepository = tenantRepo,
+                applicationRepository = appRepo,
+                userRepository = userRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                keyProvisioningService = keyProvisioningService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -1,0 +1,294 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.KeyProvisioningService
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for admin workspace settings routes:
+ * general settings, SMTP, security policy, branding.
+ *
+ * All routes live behind the session guard — tests login first,
+ * then exercise the settings endpoints with a cookie jar.
+ */
+class AdminSettingsTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val hasher = FakePasswordHasher()
+    private val tokenPort = FakeTokenPort()
+
+    private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+
+    private val masterTenant = Tenant(
+        id = 1, slug = "master", displayName = "Master",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val workspace = Tenant(
+        id = 2, slug = "acme", displayName = "Acme Corp",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val adminUser = User(
+        id = 1, tenantId = 1, username = "admin",
+        email = "admin@kotauth.dev", fullName = "Admin",
+        passwordHash = hasher.hash("admin-pass"), enabled = true,
+    )
+
+    private fun buildAuthService() = AuthService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        tokenPort = tokenPort, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+    )
+
+    private fun buildSelfService() = UserSelfServiceService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
+        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
+    )
+
+    private fun buildAdminService() = AdminService(
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+        selfServiceService = buildSelfService(),
+    )
+
+    private fun buildRoleGroupService() = RoleGroupService(
+        roleRepository = roleRepo, groupRepository = groupRepo,
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, auditLog = auditLogPort,
+    )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+        tenantRepo.add(masterTenant)
+        tenantRepo.add(workspace)
+        userRepo.add(adminUser)
+    }
+
+    // =========================================================================
+    // General workspace settings
+    // =========================================================================
+
+    @Test
+    fun `GET workspace settings returns 200 for authenticated admin`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST workspace settings saves and redirects with saved flag`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings",
+            formParameters = Parameters.build {
+                append("displayName", "Acme Updated")
+                append("tokenExpirySeconds", "7200")
+                append("refreshTokenExpirySeconds", "172800")
+                append("registrationEnabled", "true")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
+    }
+
+    // =========================================================================
+    // SMTP settings
+    // =========================================================================
+
+    @Test
+    fun `GET smtp settings returns 200 for authenticated admin`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings/smtp")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST smtp settings saves and redirects with saved flag`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/smtp",
+            formParameters = Parameters.build {
+                append("smtpHost", "smtp.example.com")
+                append("smtpPort", "587")
+                append("smtpFromAddress", "no-reply@acme.dev")
+                append("smtpTlsEnabled", "true")
+                append("smtpEnabled", "true")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
+    }
+
+    // =========================================================================
+    // Security policy settings
+    // =========================================================================
+
+    @Test
+    fun `GET security settings returns 200 for authenticated admin`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings/security")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST security settings saves password policy and redirects`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/security",
+            formParameters = Parameters.build {
+                append("passwordPolicyMinLength", "12")
+                append("passwordPolicyRequireSpecial", "true")
+                append("passwordPolicyRequireUppercase", "true")
+                append("passwordPolicyRequireNumber", "true")
+                append("mfaPolicy", "required")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
+    }
+
+    // =========================================================================
+    // Branding settings
+    // =========================================================================
+
+    @Test
+    fun `GET branding settings returns 200 for authenticated admin`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings/branding")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST workspace settings for unknown slug returns 404`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/ghost/settings")
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private suspend fun login(client: io.ktor.client.HttpClient) {
+        client.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "admin")
+                append("password", "admin-pass")
+            },
+        )
+    }
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<AdminSession>("KOTAUTH_ADMIN")
+        }
+        routing {
+            adminRoutes(
+                authService = buildAuthService(),
+                adminService = buildAdminService(),
+                roleGroupService = buildRoleGroupService(),
+                appInfo = AppInfo(),
+                tenantRepository = tenantRepo,
+                applicationRepository = appRepo,
+                userRepository = userRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                keyProvisioningService = keyProvisioningService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -25,7 +25,6 @@ import com.kauth.infrastructure.KeyProvisioningService
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.serialization.kotlinx.json.json
@@ -62,47 +61,77 @@ class AdminSettingsTest {
 
     private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
 
-    private val masterTenant = Tenant(
-        id = 1, slug = "master", displayName = "Master",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val masterTenant =
+        Tenant(
+            id = 1,
+            slug = "master",
+            displayName = "Master",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val workspace = Tenant(
-        id = 2, slug = "acme", displayName = "Acme Corp",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val workspace =
+        Tenant(
+            id = 2,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val adminUser = User(
-        id = 1, tenantId = 1, username = "admin",
-        email = "admin@kotauth.dev", fullName = "Admin",
-        passwordHash = hasher.hash("admin-pass"), enabled = true,
-    )
+    private val adminUser =
+        User(
+            id = 1,
+            tenantId = 1,
+            username = "admin",
+            email = "admin@kotauth.dev",
+            fullName = "Admin",
+            passwordHash = hasher.hash("admin-pass"),
+            enabled = true,
+        )
 
-    private fun buildAuthService() = AuthService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        tokenPort = tokenPort, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-    )
+    private fun buildAuthService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+        )
 
-    private fun buildSelfService() = UserSelfServiceService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
-        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
-    )
+    private fun buildSelfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = FakeEmailPort(),
+        )
 
-    private fun buildAdminService() = AdminService(
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-        selfServiceService = buildSelfService(),
-    )
+    private fun buildAdminService() =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService = buildSelfService(),
+        )
 
-    private fun buildRoleGroupService() = RoleGroupService(
-        roleRepository = roleRepo, groupRepository = groupRepo,
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, auditLog = auditLogPort,
-    )
+    private fun buildRoleGroupService() =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
 
     @BeforeTest
     fun setup() {
@@ -120,142 +149,159 @@ class AdminSettingsTest {
     // =========================================================================
 
     @Test
-    fun `GET workspace settings returns 200 for authenticated admin`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET workspace settings returns 200 for authenticated admin`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings")
+            val response = authed.get("/admin/workspaces/acme/settings")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
 
     @Test
-    fun `POST workspace settings saves and redirects with saved flag`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+    fun `POST workspace settings saves and redirects with saved flag`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings",
+                    formParameters =
+                        Parameters.build {
+                            append("displayName", "Acme Updated")
+                            append("tokenExpirySeconds", "7200")
+                            append("refreshTokenExpirySeconds", "172800")
+                            append("registrationEnabled", "true")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("saved=true") == true)
         }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings",
-            formParameters = Parameters.build {
-                append("displayName", "Acme Updated")
-                append("tokenExpirySeconds", "7200")
-                append("refreshTokenExpirySeconds", "172800")
-                append("registrationEnabled", "true")
-            },
-        )
-
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
-    }
 
     // =========================================================================
     // SMTP settings
     // =========================================================================
 
     @Test
-    fun `GET smtp settings returns 200 for authenticated admin`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET smtp settings returns 200 for authenticated admin`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings/smtp")
+            val response = authed.get("/admin/workspaces/acme/settings/smtp")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
 
     @Test
-    fun `POST smtp settings saves and redirects with saved flag`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+    fun `POST smtp settings saves and redirects with saved flag`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/smtp",
+                    formParameters =
+                        Parameters.build {
+                            append("smtpHost", "smtp.example.com")
+                            append("smtpPort", "587")
+                            append("smtpFromAddress", "no-reply@acme.dev")
+                            append("smtpTlsEnabled", "true")
+                            append("smtpEnabled", "true")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("saved=true") == true)
         }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/smtp",
-            formParameters = Parameters.build {
-                append("smtpHost", "smtp.example.com")
-                append("smtpPort", "587")
-                append("smtpFromAddress", "no-reply@acme.dev")
-                append("smtpTlsEnabled", "true")
-                append("smtpEnabled", "true")
-            },
-        )
-
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
-    }
 
     // =========================================================================
     // Security policy settings
     // =========================================================================
 
     @Test
-    fun `GET security settings returns 200 for authenticated admin`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET security settings returns 200 for authenticated admin`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings/security")
+            val response = authed.get("/admin/workspaces/acme/settings/security")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
 
     @Test
-    fun `POST security settings saves password policy and redirects`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+    fun `POST security settings saves password policy and redirects`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters =
+                        Parameters.build {
+                            append("passwordPolicyMinLength", "12")
+                            append("passwordPolicyRequireSpecial", "true")
+                            append("passwordPolicyRequireUppercase", "true")
+                            append("passwordPolicyRequireNumber", "true")
+                            append("mfaPolicy", "required")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("saved=true") == true)
         }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/security",
-            formParameters = Parameters.build {
-                append("passwordPolicyMinLength", "12")
-                append("passwordPolicyRequireSpecial", "true")
-                append("passwordPolicyRequireUppercase", "true")
-                append("passwordPolicyRequireNumber", "true")
-                append("mfaPolicy", "required")
-            },
-        )
-
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("saved=true") == true)
-    }
 
     // =========================================================================
     // Branding settings
     // =========================================================================
 
     @Test
-    fun `GET branding settings returns 200 for authenticated admin`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET branding settings returns 200 for authenticated admin`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings/branding")
+            val response = authed.get("/admin/workspaces/acme/settings/branding")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
 
     @Test
-    fun `POST workspace settings for unknown slug returns 404`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `POST workspace settings for unknown slug returns 404`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/ghost/settings")
+            val response = authed.get("/admin/workspaces/ghost/settings")
 
-        assertEquals(HttpStatusCode.NotFound, response.status)
-    }
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
 
     // =========================================================================
     // Helpers
@@ -264,10 +310,11 @@ class AdminSettingsTest {
     private suspend fun login(client: io.ktor.client.HttpClient) {
         client.submitForm(
             url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "admin")
-                append("password", "admin-pass")
-            },
+            formParameters =
+                Parameters.build {
+                    append("username", "admin")
+                    append("password", "admin-pass")
+                },
         )
     }
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -1,0 +1,234 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.domain.service.WebhookService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.fakes.FakeWebhookDeliveryRepository
+import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.infrastructure.KeyProvisioningService
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for admin webhook management UI routes.
+ */
+class AdminWebhooksTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val webhookEndpointRepo = FakeWebhookEndpointRepository()
+    private val webhookDeliveryRepo = FakeWebhookDeliveryRepository()
+    private val hasher = FakePasswordHasher()
+    private val tokenPort = FakeTokenPort()
+
+    private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+
+    private val webhookService = WebhookService(
+        endpointRepository = webhookEndpointRepo,
+        deliveryRepository = webhookDeliveryRepo,
+    )
+
+    private val masterTenant = Tenant(
+        id = 1, slug = "master", displayName = "Master",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val workspace = Tenant(
+        id = 2, slug = "acme", displayName = "Acme Corp",
+        issuerUrl = null, theme = TenantTheme.DEFAULT,
+    )
+
+    private val adminUser = User(
+        id = 1, tenantId = 1, username = "admin",
+        email = "admin@kotauth.dev", fullName = "Admin",
+        passwordHash = hasher.hash("admin-pass"), enabled = true,
+    )
+
+    private fun buildAuthService() = AuthService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        tokenPort = tokenPort, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+    )
+
+    private fun buildSelfService() = UserSelfServiceService(
+        userRepository = userRepo, tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
+        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
+    )
+
+    private fun buildAdminService() = AdminService(
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, passwordHasher = hasher,
+        auditLog = auditLogPort, sessionRepository = sessionRepo,
+        selfServiceService = buildSelfService(),
+    )
+
+    private fun buildRoleGroupService() = RoleGroupService(
+        roleRepository = roleRepo, groupRepository = groupRepo,
+        tenantRepository = tenantRepo, userRepository = userRepo,
+        applicationRepository = appRepo, auditLog = auditLogPort,
+    )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        webhookEndpointRepo.clear()
+        webhookDeliveryRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+        tenantRepo.add(masterTenant)
+        tenantRepo.add(workspace)
+        userRepo.add(adminUser)
+    }
+
+    // =========================================================================
+    // Webhook management
+    // =========================================================================
+
+    @Test
+    fun `GET webhooks list returns 200`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.get("/admin/workspaces/acme/settings/webhooks")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST webhooks creates endpoint and returns 200`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/webhooks",
+            formParameters = Parameters.build {
+                append("url", "https://hooks.example.com/kotauth")
+                append("description", "CI/CD hook")
+                append("events", "user.created")
+                append("events", "user.deleted")
+            },
+        )
+
+        assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `POST webhooks with blank URL returns 422`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient { install(HttpCookies) }
+        login(authed)
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/webhooks",
+            formParameters = Parameters.build {
+                append("url", "")
+                append("events", "user.created")
+            },
+        )
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+    }
+
+    @Test
+    fun `POST webhooks delete redirects back to list`() = testApplication {
+        application { installTestApp() }
+        val authed = createClient {
+            install(HttpCookies)
+            followRedirects = false
+        }
+        login(authed)
+
+        val created = webhookService.createEndpoint(
+            2, "https://hooks.example.com/test", setOf("user.created"), "test",
+        )
+        val endpointId = (created as com.kauth.domain.service.WebhookResult.Success).endpoint.id!!
+
+        val response = authed.submitForm(
+            url = "/admin/workspaces/acme/settings/webhooks/$endpointId/delete",
+            formParameters = Parameters.build { },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/settings/webhooks") == true)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private suspend fun login(client: io.ktor.client.HttpClient) {
+        client.submitForm(
+            url = "/admin/login",
+            formParameters = Parameters.build {
+                append("username", "admin")
+                append("password", "admin-pass")
+            },
+        )
+    }
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<AdminSession>("KOTAUTH_ADMIN")
+        }
+        routing {
+            adminRoutes(
+                authService = buildAuthService(),
+                adminService = buildAdminService(),
+                roleGroupService = buildRoleGroupService(),
+                appInfo = AppInfo(),
+                tenantRepository = tenantRepo,
+                applicationRepository = appRepo,
+                userRepository = userRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                keyProvisioningService = keyProvisioningService,
+                webhookService = webhookService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -62,52 +62,83 @@ class AdminWebhooksTest {
 
     private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
 
-    private val webhookService = WebhookService(
-        endpointRepository = webhookEndpointRepo,
-        deliveryRepository = webhookDeliveryRepo,
-    )
+    private val webhookService =
+        WebhookService(
+            endpointRepository = webhookEndpointRepo,
+            deliveryRepository = webhookDeliveryRepo,
+        )
 
-    private val masterTenant = Tenant(
-        id = 1, slug = "master", displayName = "Master",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val masterTenant =
+        Tenant(
+            id = 1,
+            slug = "master",
+            displayName = "Master",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val workspace = Tenant(
-        id = 2, slug = "acme", displayName = "Acme Corp",
-        issuerUrl = null, theme = TenantTheme.DEFAULT,
-    )
+    private val workspace =
+        Tenant(
+            id = 2,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val adminUser = User(
-        id = 1, tenantId = 1, username = "admin",
-        email = "admin@kotauth.dev", fullName = "Admin",
-        passwordHash = hasher.hash("admin-pass"), enabled = true,
-    )
+    private val adminUser =
+        User(
+            id = 1,
+            tenantId = 1,
+            username = "admin",
+            email = "admin@kotauth.dev",
+            fullName = "Admin",
+            passwordHash = hasher.hash("admin-pass"),
+            enabled = true,
+        )
 
-    private fun buildAuthService() = AuthService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        tokenPort = tokenPort, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-    )
+    private fun buildAuthService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+        )
 
-    private fun buildSelfService() = UserSelfServiceService(
-        userRepository = userRepo, tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, evTokenRepo = FakeEmailVerificationTokenRepository(),
-        prTokenRepo = FakePasswordResetTokenRepository(), emailPort = FakeEmailPort(),
-    )
+    private fun buildSelfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = FakeEmailPort(),
+        )
 
-    private fun buildAdminService() = AdminService(
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, passwordHasher = hasher,
-        auditLog = auditLogPort, sessionRepository = sessionRepo,
-        selfServiceService = buildSelfService(),
-    )
+    private fun buildAdminService() =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService = buildSelfService(),
+        )
 
-    private fun buildRoleGroupService() = RoleGroupService(
-        roleRepository = roleRepo, groupRepository = groupRepo,
-        tenantRepository = tenantRepo, userRepository = userRepo,
-        applicationRepository = appRepo, auditLog = auditLogPort,
-    )
+    private fun buildRoleGroupService() =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
 
     @BeforeTest
     fun setup() {
@@ -127,74 +158,88 @@ class AdminWebhooksTest {
     // =========================================================================
 
     @Test
-    fun `GET webhooks list returns 200`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
+    fun `GET webhooks list returns 200`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.get("/admin/workspaces/acme/settings/webhooks")
+            val response = authed.get("/admin/workspaces/acme/settings/webhooks")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
-
-    @Test
-    fun `POST webhooks creates endpoint and returns 200`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/webhooks",
-            formParameters = Parameters.build {
-                append("url", "https://hooks.example.com/kotauth")
-                append("description", "CI/CD hook")
-                append("events", "user.created")
-                append("events", "user.deleted")
-            },
-        )
-
-        assertEquals(HttpStatusCode.OK, response.status)
-    }
-
-    @Test
-    fun `POST webhooks with blank URL returns 422`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient { install(HttpCookies) }
-        login(authed)
-
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/webhooks",
-            formParameters = Parameters.build {
-                append("url", "")
-                append("events", "user.created")
-            },
-        )
-
-        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
-    }
-
-    @Test
-    fun `POST webhooks delete redirects back to list`() = testApplication {
-        application { installTestApp() }
-        val authed = createClient {
-            install(HttpCookies)
-            followRedirects = false
+            assertEquals(HttpStatusCode.OK, response.status)
         }
-        login(authed)
 
-        val created = webhookService.createEndpoint(
-            2, "https://hooks.example.com/test", setOf("user.created"), "test",
-        )
-        val endpointId = (created as com.kauth.domain.service.WebhookResult.Success).endpoint.id!!
+    @Test
+    fun `POST webhooks creates endpoint and returns 200`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
 
-        val response = authed.submitForm(
-            url = "/admin/workspaces/acme/settings/webhooks/$endpointId/delete",
-            formParameters = Parameters.build { },
-        )
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/webhooks",
+                    formParameters =
+                        Parameters.build {
+                            append("url", "https://hooks.example.com/kotauth")
+                            append("description", "CI/CD hook")
+                            append("events", "user.created")
+                            append("events", "user.deleted")
+                        },
+                )
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/settings/webhooks") == true)
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `POST webhooks with blank URL returns 422`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/webhooks",
+                    formParameters =
+                        Parameters.build {
+                            append("url", "")
+                            append("events", "user.created")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    @Test
+    fun `POST webhooks delete redirects back to list`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val created =
+                webhookService.createEndpoint(
+                    2,
+                    "https://hooks.example.com/test",
+                    setOf("user.created"),
+                    "test",
+                )
+            val endpointId = (created as com.kauth.domain.service.WebhookResult.Success).endpoint.id!!
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/webhooks/$endpointId/delete",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/settings/webhooks") == true)
+        }
 
     // =========================================================================
     // Helpers
@@ -203,10 +248,11 @@ class AdminWebhooksTest {
     private suspend fun login(client: io.ktor.client.HttpClient) {
         client.submitForm(
             url = "/admin/login",
-            formParameters = Parameters.build {
-                append("username", "admin")
-                append("password", "admin-pass")
-            },
+            formParameters =
+                Parameters.build {
+                    append("username", "admin")
+                    append("password", "admin-pass")
+                },
         )
     }
 

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -1,8 +1,11 @@
 package com.kauth.adapter.web.api
 
+import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Application
 import com.kauth.domain.model.AuditEvent
 import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
@@ -25,8 +28,10 @@ import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeUserRepository
 import com.kauth.infrastructure.ApiKeyPrincipal
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -39,6 +44,7 @@ import io.ktor.server.auth.bearer
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import java.time.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -375,6 +381,299 @@ class ApiRoutesTest {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
         assertTrue(body.contains("LOGIN_SUCCESS"))
+    }
+
+    // =========================================================================
+    // Roles CRUD
+    // =========================================================================
+
+    @Test
+    fun `POST roles creates a new role and returns 201`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.post("/t/acme/api/v1/roles") {
+            bearerAuth(rawApiKey)
+            contentType(ContentType.Application.Json)
+            setBody("""{"name":"editor","description":"Can edit content"}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("editor"))
+    }
+
+    @Test
+    fun `GET roles returns list of roles for tenant`() = testApplication {
+        application { installTestApp() }
+
+        roleGroupService.createRole(1, "viewer", "Read only", com.kauth.domain.model.RoleScope.TENANT, null)
+
+        val response = client.get("/t/acme/api/v1/roles") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("viewer"))
+    }
+
+    @Test
+    fun `PUT roles updates an existing role`() = testApplication {
+        application { installTestApp() }
+
+        val created = roleGroupService.createRole(1, "old-name", null, com.kauth.domain.model.RoleScope.TENANT, null)
+        val roleId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+
+        val response = client.put("/t/acme/api/v1/roles/$roleId") {
+            bearerAuth(rawApiKey)
+            contentType(ContentType.Application.Json)
+            setBody("""{"name":"new-name","description":"Updated"}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("new-name"))
+    }
+
+    @Test
+    fun `DELETE roles removes a role and returns 204`() = testApplication {
+        application { installTestApp() }
+
+        val created = roleGroupService.createRole(1, "temp-role", null, com.kauth.domain.model.RoleScope.TENANT, null)
+        val roleId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+
+        val response = client.delete("/t/acme/api/v1/roles/$roleId") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    // =========================================================================
+    // Groups CRUD
+    // =========================================================================
+
+    @Test
+    fun `POST groups creates a new group and returns 201`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.post("/t/acme/api/v1/groups") {
+            bearerAuth(rawApiKey)
+            contentType(ContentType.Application.Json)
+            setBody("""{"name":"engineering","description":"Eng team"}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("engineering"))
+    }
+
+    @Test
+    fun `GET group by id returns 404 for group in different tenant`() = testApplication {
+        application { installTestApp() }
+
+        groupRepo.add(
+            com.kauth.domain.model.Group(
+                id = 100,
+                tenantId = 50,
+                name = "other-group",
+            ),
+        )
+
+        val response = client.get("/t/acme/api/v1/groups/100") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `DELETE groups removes a group and returns 204`() = testApplication {
+        application { installTestApp() }
+
+        val created = roleGroupService.createGroup(1, "temp-group", null, null)
+        val groupId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+
+        val response = client.delete("/t/acme/api/v1/groups/$groupId") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `POST group member adds user to group and returns 204`() = testApplication {
+        application { installTestApp() }
+
+        val created = roleGroupService.createGroup(1, "dev-team", null, null)
+        val groupId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+
+        val response = client.post("/t/acme/api/v1/groups/$groupId/members/10") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    // =========================================================================
+    // Applications CRUD
+    // =========================================================================
+
+    @Test
+    fun `GET applications returns empty list when none exist`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/applications") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"data\""))
+    }
+
+    @Test
+    fun `GET application by id returns 200 for existing app`() = testApplication {
+        application { installTestApp() }
+
+        appRepo.add(
+            Application(
+                id = 1,
+                tenantId = 1,
+                clientId = "spa-app",
+                name = "SPA",
+                description = "Single page app",
+                accessType = AccessType.PUBLIC,
+                enabled = true,
+            ),
+        )
+
+        val response = client.get("/t/acme/api/v1/applications/1") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("spa-app"))
+    }
+
+    @Test
+    fun `GET application by id returns 404 for app in different tenant`() = testApplication {
+        application { installTestApp() }
+
+        appRepo.add(
+            Application(
+                id = 2,
+                tenantId = 50,
+                clientId = "other-app",
+                name = "Other",
+                description = null,
+                accessType = AccessType.CONFIDENTIAL,
+                enabled = true,
+            ),
+        )
+
+        val response = client.get("/t/acme/api/v1/applications/2") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    // =========================================================================
+    // Sessions
+    // =========================================================================
+
+    @Test
+    fun `GET sessions returns active sessions for tenant`() = testApplication {
+        application { installTestApp() }
+
+        sessionRepo.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "hash1",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        val response = client.get("/t/acme/api/v1/sessions") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"data\""))
+    }
+
+    @Test
+    fun `DELETE session revokes session and returns 204`() = testApplication {
+        application { installTestApp() }
+
+        val saved = sessionRepo.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "hash-to-revoke",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        val response = client.delete("/t/acme/api/v1/sessions/${saved.id}") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `DELETE session returns 404 for session in different tenant`() = testApplication {
+        application { installTestApp() }
+
+        val saved = sessionRepo.save(
+            Session(
+                tenantId = 50,
+                userId = 99,
+                clientId = null,
+                accessTokenHash = "other-hash",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        val response = client.delete("/t/acme/api/v1/sessions/${saved.id}") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    // =========================================================================
+    // Audit logs — filtered query
+    // =========================================================================
+
+    @Test
+    fun `GET audit-logs with userId filter returns only matching events`() = testApplication {
+        application { installTestApp() }
+
+        auditLogRepo.add(
+            AuditEvent(tenantId = 1, userId = 10, clientId = null, eventType = AuditEventType.LOGIN_SUCCESS, ipAddress = "127.0.0.1", userAgent = "test"),
+        )
+        auditLogRepo.add(
+            AuditEvent(tenantId = 1, userId = 99, clientId = null, eventType = AuditEventType.LOGIN_FAILED, ipAddress = "127.0.0.1", userAgent = "test"),
+        )
+
+        val auditKey = apiKeyService.create(1, "Audit Key 2", listOf(ApiScope.AUDIT_LOGS_READ))
+        val auditRawKey = (auditKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+
+        val response = client.get("/t/acme/api/v1/audit-logs?userId=10") {
+            bearerAuth(auditRawKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("LOGIN_SUCCESS"))
+        assertTrue(!body.contains("LOGIN_FAILED"), "Must not include events for other users")
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -9,6 +9,7 @@ import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
 import com.kauth.domain.service.RoleGroupService
@@ -75,70 +76,77 @@ class ApiRoutesTest {
     private val auditLogPort = FakeAuditLogPort()
     private val hasher = FakePasswordHasher()
 
-    private val tenant = Tenant(
-        id = 1,
-        slug = "acme",
-        displayName = "Acme Corp",
-        issuerUrl = null,
-        theme = TenantTheme.DEFAULT,
-    )
+    private val tenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val otherTenant = Tenant(
-        id = 50,
-        slug = "other",
-        displayName = "Other Corp",
-        issuerUrl = null,
-        theme = TenantTheme.DEFAULT,
-    )
+    private val otherTenant =
+        Tenant(
+            id = 50,
+            slug = "other",
+            displayName = "Other Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val user = User(
-        id = 10,
-        tenantId = 1,
-        username = "alice",
-        email = "alice@example.com",
-        fullName = "Alice Smith",
-        passwordHash = hasher.hash("password123"),
-        enabled = true,
-    )
+    private val user =
+        User(
+            id = 10,
+            tenantId = 1,
+            username = "alice",
+            email = "alice@example.com",
+            fullName = "Alice Smith",
+            passwordHash = hasher.hash("password123"),
+            enabled = true,
+        )
 
     private val evTokenRepo = FakeEmailVerificationTokenRepository()
     private val prTokenRepo = FakePasswordResetTokenRepository()
     private val emailPort = FakeEmailPort()
 
-    private val apiKeyService = ApiKeyService(
-        apiKeyRepository = apiKeyRepo,
-        tenantRepository = tenantRepo,
-    )
+    private val apiKeyService =
+        ApiKeyService(
+            apiKeyRepository = apiKeyRepo,
+            tenantRepository = tenantRepo,
+        )
 
-    private val selfServiceService = UserSelfServiceService(
-        userRepository = userRepo,
-        tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        evTokenRepo = evTokenRepo,
-        prTokenRepo = prTokenRepo,
-        emailPort = emailPort,
-    )
+    private val selfServiceService =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = evTokenRepo,
+            prTokenRepo = prTokenRepo,
+            emailPort = emailPort,
+        )
 
-    private val adminService = AdminService(
-        tenantRepository = tenantRepo,
-        userRepository = userRepo,
-        applicationRepository = appRepo,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        sessionRepository = sessionRepo,
-        selfServiceService = selfServiceService,
-    )
+    private val adminService =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService = selfServiceService,
+        )
 
-    private val roleGroupService = RoleGroupService(
-        roleRepository = roleRepo,
-        groupRepository = groupRepo,
-        tenantRepository = tenantRepo,
-        userRepository = userRepo,
-        applicationRepository = appRepo,
-        auditLog = auditLogPort,
-    )
+    private val roleGroupService =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
 
     private var rawApiKey: String = ""
 
@@ -161,11 +169,12 @@ class ApiRoutesTest {
         tenantRepo.add(otherTenant)
         userRepo.add(user)
 
-        val created = apiKeyService.create(
-            tenantId = 1,
-            name = "Test Key",
-            scopes = ApiScope.ALL,
-        )
+        val created =
+            apiKeyService.create(
+                tenantId = 1,
+                name = "Test Key",
+                scopes = ApiScope.ALL,
+            )
         rawApiKey = (created as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
     }
 
@@ -174,507 +183,596 @@ class ApiRoutesTest {
     // =========================================================================
 
     @Test
-    fun `GET users returns 401 when no Bearer token is provided`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 401 when no Bearer token is provided`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/api/v1/users")
+            val response = client.get("/t/acme/api/v1/users")
 
-        // Ktor's bearer challenge fires before the route intercept — body is empty
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-    }
-
-    @Test
-    fun `GET users returns 401 when Bearer token does not start with kauth_`() = testApplication {
-        application { installTestApp() }
-
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth("not-a-valid-prefix-token")
+            // Ktor's bearer challenge fires before the route intercept — body is empty
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-    }
-
     @Test
-    fun `GET users returns 401 when Bearer token is unknown`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 401 when Bearer token does not start with kauth_`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth("kauth_acme_thiskeyDoesNotExistInTheRepo0000000")
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth("not-a-valid-prefix-token")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertTrue(response.bodyAsText().contains("Invalid API key"))
-    }
-
     @Test
-    fun `GET users returns 401 when API key belongs to a different tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 401 when Bearer token is unknown`() =
+        testApplication {
+            application { installTestApp() }
 
-        val otherKey = apiKeyService.create(
-            tenantId = 50,
-            name = "Other Tenant Key",
-            scopes = ApiScope.ALL,
-        )
-        val otherRawKey = (otherKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth("kauth_acme_thiskeyDoesNotExistInTheRepo0000000")
+                }
 
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth(otherRawKey)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().contains("Invalid API key"))
         }
 
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-    }
-
     @Test
-    fun `GET users returns 401 when API key is revoked`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 401 when API key belongs to a different tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        val revokedResult = apiKeyService.create(
-            tenantId = 1,
-            name = "Revoked Key",
-            scopes = ApiScope.ALL,
-        )
-        val revokedKey = (revokedResult as com.kauth.domain.service.ApiKeyResult.Success).value
-        apiKeyService.revoke(revokedKey.apiKey.id!!, tenantId = 1)
+            val otherKey =
+                apiKeyService.create(
+                    tenantId = 50,
+                    name = "Other Tenant Key",
+                    scopes = ApiScope.ALL,
+                )
+            val otherRawKey = (otherKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
 
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth(revokedKey.rawKey)
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth(otherRawKey)
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
-    }
-
     @Test
-    fun `GET users returns 404 for unknown tenant slug`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 401 when API key is revoked`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/ghost/api/v1/users") {
-            bearerAuth(rawApiKey)
+            val revokedResult =
+                apiKeyService.create(
+                    tenantId = 1,
+                    name = "Revoked Key",
+                    scopes = ApiScope.ALL,
+                )
+            val revokedKey = (revokedResult as com.kauth.domain.service.ApiKeyResult.Success).value
+            apiKeyService.revoke(revokedKey.apiKey.id!!, tenantId = 1)
+
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth(revokedKey.rawKey)
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
-        assertEquals(HttpStatusCode.NotFound, response.status)
-        assertTrue(response.bodyAsText().contains("Tenant not found"))
-    }
+    @Test
+    fun `GET users returns 404 for unknown tenant slug`() =
+        testApplication {
+            application { installTestApp() }
+
+            val response =
+                client.get("/t/ghost/api/v1/users") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("Tenant not found"))
+        }
 
     // =========================================================================
     // Scope enforcement
     // =========================================================================
 
     @Test
-    fun `GET users returns 403 when API key lacks users_read scope`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 403 when API key lacks users_read scope`() =
+        testApplication {
+            application { installTestApp() }
 
-        val limitedResult = apiKeyService.create(
-            tenantId = 1,
-            name = "Roles Only Key",
-            scopes = listOf(ApiScope.ROLES_READ),
-        )
-        val limitedRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+            val limitedResult =
+                apiKeyService.create(
+                    tenantId = 1,
+                    name = "Roles Only Key",
+                    scopes = listOf(ApiScope.ROLES_READ),
+                )
+            val limitedRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
 
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth(limitedRawKey)
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth(limitedRawKey)
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertTrue(response.bodyAsText().contains("Insufficient scope"))
         }
-
-        assertEquals(HttpStatusCode.Forbidden, response.status)
-        assertTrue(response.bodyAsText().contains("Insufficient scope"))
-    }
 
     // =========================================================================
     // User CRUD
     // =========================================================================
 
     @Test
-    fun `GET users returns 200 with user list for valid API key`() = testApplication {
-        application { installTestApp() }
+    fun `GET users returns 200 with user list for valid API key`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/api/v1/users") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/users") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"data\""), "Response must contain data envelope")
+            assertTrue(body.contains("alice"), "Response must include alice user")
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("\"data\""), "Response must contain data envelope")
-        assertTrue(body.contains("alice"), "Response must include alice user")
-    }
 
     @Test
-    fun `GET users by id returns 200 with user details`() = testApplication {
-        application { installTestApp() }
+    fun `GET users by id returns 200 with user details`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/api/v1/users/10") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/users/10") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("alice"))
+            assertTrue(body.contains("alice@example.com"))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("alice"))
-        assertTrue(body.contains("alice@example.com"))
-    }
 
     @Test
-    fun `GET users by id returns 404 for user in different tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET users by id returns 404 for user in different tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        userRepo.add(
-            User(
-                id = 20,
-                tenantId = 50,
-                username = "bob",
-                email = "bob@other.com",
-                fullName = "Bob",
-                passwordHash = hasher.hash("pass"),
-                enabled = true,
-            ),
-        )
+            userRepo.add(
+                User(
+                    id = 20,
+                    tenantId = 50,
+                    username = "bob",
+                    email = "bob@other.com",
+                    fullName = "Bob",
+                    passwordHash = hasher.hash("pass"),
+                    enabled = true,
+                ),
+            )
 
-        val response = client.get("/t/acme/api/v1/users/20") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/users/20") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
         }
-
-        assertEquals(HttpStatusCode.NotFound, response.status)
-    }
 
     @Test
-    fun `POST users creates a new user and returns 201`() = testApplication {
-        application { installTestApp() }
+    fun `POST users creates a new user and returns 201`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.post("/t/acme/api/v1/users") {
-            bearerAuth(rawApiKey)
-            contentType(ContentType.Application.Json)
-            setBody("""{"username":"charlie","email":"charlie@example.com","fullName":"Charlie Brown","password":"StrongP@ss1"}""")
+            val response =
+                client.post("/t/acme/api/v1/users") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"username":"charlie","email":"charlie@example.com","fullName":"Charlie Brown","password":"StrongP@ss1"}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("charlie"))
         }
-
-        assertEquals(HttpStatusCode.Created, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("charlie"))
-    }
 
     // =========================================================================
     // Audit log query
     // =========================================================================
 
     @Test
-    fun `GET audit-logs returns events for the tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET audit-logs returns events for the tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        auditLogRepo.add(
-            AuditEvent(
-                tenantId = 1,
-                userId = 10,
-                clientId = null,
-                eventType = AuditEventType.LOGIN_SUCCESS,
-                ipAddress = "127.0.0.1",
-                userAgent = "test",
-            ),
-        )
+            auditLogRepo.add(
+                AuditEvent(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    eventType = AuditEventType.LOGIN_SUCCESS,
+                    ipAddress = "127.0.0.1",
+                    userAgent = "test",
+                ),
+            )
 
-        val limitedResult = apiKeyService.create(
-            tenantId = 1,
-            name = "Audit Key",
-            scopes = listOf(ApiScope.AUDIT_LOGS_READ),
-        )
-        val auditRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+            val limitedResult =
+                apiKeyService.create(
+                    tenantId = 1,
+                    name = "Audit Key",
+                    scopes = listOf(ApiScope.AUDIT_LOGS_READ),
+                )
+            val auditRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
 
-        val response = client.get("/t/acme/api/v1/audit-logs") {
-            bearerAuth(auditRawKey)
+            val response =
+                client.get("/t/acme/api/v1/audit-logs") {
+                    bearerAuth(auditRawKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("LOGIN_SUCCESS"))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("LOGIN_SUCCESS"))
-    }
 
     // =========================================================================
     // Roles CRUD
     // =========================================================================
 
     @Test
-    fun `POST roles creates a new role and returns 201`() = testApplication {
-        application { installTestApp() }
+    fun `POST roles creates a new role and returns 201`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.post("/t/acme/api/v1/roles") {
-            bearerAuth(rawApiKey)
-            contentType(ContentType.Application.Json)
-            setBody("""{"name":"editor","description":"Can edit content"}""")
+            val response =
+                client.post("/t/acme/api/v1/roles") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"name":"editor","description":"Can edit content"}""")
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(response.bodyAsText().contains("editor"))
         }
-
-        assertEquals(HttpStatusCode.Created, response.status)
-        assertTrue(response.bodyAsText().contains("editor"))
-    }
 
     @Test
-    fun `GET roles returns list of roles for tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET roles returns list of roles for tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        roleGroupService.createRole(1, "viewer", "Read only", com.kauth.domain.model.RoleScope.TENANT, null)
+            roleGroupService.createRole(1, "viewer", "Read only", com.kauth.domain.model.RoleScope.TENANT, null)
 
-        val response = client.get("/t/acme/api/v1/roles") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/roles") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("viewer"))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("viewer"))
-    }
 
     @Test
-    fun `PUT roles updates an existing role`() = testApplication {
-        application { installTestApp() }
+    fun `PUT roles updates an existing role`() =
+        testApplication {
+            application { installTestApp() }
 
-        val created = roleGroupService.createRole(1, "old-name", null, com.kauth.domain.model.RoleScope.TENANT, null)
-        val roleId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+            val created =
+                roleGroupService.createRole(
+                    1,
+                    "old-name",
+                    null,
+                    com.kauth.domain.model.RoleScope.TENANT,
+                    null,
+                )
+            val roleId = (created as AdminResult.Success).value.id
 
-        val response = client.put("/t/acme/api/v1/roles/$roleId") {
-            bearerAuth(rawApiKey)
-            contentType(ContentType.Application.Json)
-            setBody("""{"name":"new-name","description":"Updated"}""")
+            val response =
+                client.put("/t/acme/api/v1/roles/$roleId") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"name":"new-name","description":"Updated"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("new-name"))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("new-name"))
-    }
 
     @Test
-    fun `DELETE roles removes a role and returns 204`() = testApplication {
-        application { installTestApp() }
+    fun `DELETE roles removes a role and returns 204`() =
+        testApplication {
+            application { installTestApp() }
 
-        val created = roleGroupService.createRole(1, "temp-role", null, com.kauth.domain.model.RoleScope.TENANT, null)
-        val roleId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+            val created =
+                roleGroupService.createRole(
+                    1,
+                    "temp-role",
+                    null,
+                    com.kauth.domain.model.RoleScope.TENANT,
+                    null,
+                )
+            val roleId = (created as AdminResult.Success).value.id
 
-        val response = client.delete("/t/acme/api/v1/roles/$roleId") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.delete("/t/acme/api/v1/roles/$roleId") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
         }
-
-        assertEquals(HttpStatusCode.NoContent, response.status)
-    }
 
     // =========================================================================
     // Groups CRUD
     // =========================================================================
 
     @Test
-    fun `POST groups creates a new group and returns 201`() = testApplication {
-        application { installTestApp() }
+    fun `POST groups creates a new group and returns 201`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.post("/t/acme/api/v1/groups") {
-            bearerAuth(rawApiKey)
-            contentType(ContentType.Application.Json)
-            setBody("""{"name":"engineering","description":"Eng team"}""")
+            val response =
+                client.post("/t/acme/api/v1/groups") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"name":"engineering","description":"Eng team"}""")
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(response.bodyAsText().contains("engineering"))
         }
-
-        assertEquals(HttpStatusCode.Created, response.status)
-        assertTrue(response.bodyAsText().contains("engineering"))
-    }
 
     @Test
-    fun `GET group by id returns 404 for group in different tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET group by id returns 404 for group in different tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        groupRepo.add(
-            com.kauth.domain.model.Group(
-                id = 100,
-                tenantId = 50,
-                name = "other-group",
-            ),
-        )
+            groupRepo.add(
+                com.kauth.domain.model.Group(
+                    id = 100,
+                    tenantId = 50,
+                    name = "other-group",
+                ),
+            )
 
-        val response = client.get("/t/acme/api/v1/groups/100") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/groups/100") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
         }
-
-        assertEquals(HttpStatusCode.NotFound, response.status)
-    }
 
     @Test
-    fun `DELETE groups removes a group and returns 204`() = testApplication {
-        application { installTestApp() }
+    fun `DELETE groups removes a group and returns 204`() =
+        testApplication {
+            application { installTestApp() }
 
-        val created = roleGroupService.createGroup(1, "temp-group", null, null)
-        val groupId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+            val created = roleGroupService.createGroup(1, "temp-group", null, null)
+            val groupId = (created as AdminResult.Success).value.id
 
-        val response = client.delete("/t/acme/api/v1/groups/$groupId") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.delete("/t/acme/api/v1/groups/$groupId") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
         }
-
-        assertEquals(HttpStatusCode.NoContent, response.status)
-    }
 
     @Test
-    fun `POST group member adds user to group and returns 204`() = testApplication {
-        application { installTestApp() }
+    fun `POST group member adds user to group and returns 204`() =
+        testApplication {
+            application { installTestApp() }
 
-        val created = roleGroupService.createGroup(1, "dev-team", null, null)
-        val groupId = (created as com.kauth.domain.service.AdminResult.Success).value.id
+            val created = roleGroupService.createGroup(1, "dev-team", null, null)
+            val groupId = (created as AdminResult.Success).value.id
 
-        val response = client.post("/t/acme/api/v1/groups/$groupId/members/10") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.post("/t/acme/api/v1/groups/$groupId/members/10") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
         }
-
-        assertEquals(HttpStatusCode.NoContent, response.status)
-    }
 
     // =========================================================================
     // Applications CRUD
     // =========================================================================
 
     @Test
-    fun `GET applications returns empty list when none exist`() = testApplication {
-        application { installTestApp() }
+    fun `GET applications returns empty list when none exist`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/api/v1/applications") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/applications") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"data\""))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("\"data\""))
-    }
 
     @Test
-    fun `GET application by id returns 200 for existing app`() = testApplication {
-        application { installTestApp() }
+    fun `GET application by id returns 200 for existing app`() =
+        testApplication {
+            application { installTestApp() }
 
-        appRepo.add(
-            Application(
-                id = 1,
-                tenantId = 1,
-                clientId = "spa-app",
-                name = "SPA",
-                description = "Single page app",
-                accessType = AccessType.PUBLIC,
-                enabled = true,
-            ),
-        )
+            appRepo.add(
+                Application(
+                    id = 1,
+                    tenantId = 1,
+                    clientId = "spa-app",
+                    name = "SPA",
+                    description = "Single page app",
+                    accessType = AccessType.PUBLIC,
+                    enabled = true,
+                ),
+            )
 
-        val response = client.get("/t/acme/api/v1/applications/1") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/applications/1") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("spa-app"))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("spa-app"))
-    }
 
     @Test
-    fun `GET application by id returns 404 for app in different tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET application by id returns 404 for app in different tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        appRepo.add(
-            Application(
-                id = 2,
-                tenantId = 50,
-                clientId = "other-app",
-                name = "Other",
-                description = null,
-                accessType = AccessType.CONFIDENTIAL,
-                enabled = true,
-            ),
-        )
+            appRepo.add(
+                Application(
+                    id = 2,
+                    tenantId = 50,
+                    clientId = "other-app",
+                    name = "Other",
+                    description = null,
+                    accessType = AccessType.CONFIDENTIAL,
+                    enabled = true,
+                ),
+            )
 
-        val response = client.get("/t/acme/api/v1/applications/2") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/applications/2") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
         }
-
-        assertEquals(HttpStatusCode.NotFound, response.status)
-    }
 
     // =========================================================================
     // Sessions
     // =========================================================================
 
     @Test
-    fun `GET sessions returns active sessions for tenant`() = testApplication {
-        application { installTestApp() }
+    fun `GET sessions returns active sessions for tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        sessionRepo.save(
-            Session(
-                tenantId = 1,
-                userId = 10,
-                clientId = null,
-                accessTokenHash = "hash1",
-                refreshTokenHash = null,
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-            ),
-        )
+            sessionRepo.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    accessTokenHash = "hash1",
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
 
-        val response = client.get("/t/acme/api/v1/sessions") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.get("/t/acme/api/v1/sessions") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"data\""))
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("\"data\""))
-    }
 
     @Test
-    fun `DELETE session revokes session and returns 204`() = testApplication {
-        application { installTestApp() }
+    fun `DELETE session revokes session and returns 204`() =
+        testApplication {
+            application { installTestApp() }
 
-        val saved = sessionRepo.save(
-            Session(
-                tenantId = 1,
-                userId = 10,
-                clientId = null,
-                accessTokenHash = "hash-to-revoke",
-                refreshTokenHash = null,
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-            ),
-        )
+            val saved =
+                sessionRepo.save(
+                    Session(
+                        tenantId = 1,
+                        userId = 10,
+                        clientId = null,
+                        accessTokenHash = "hash-to-revoke",
+                        refreshTokenHash = null,
+                        scopes = "openid",
+                        expiresAt = Instant.now().plusSeconds(3600),
+                    ),
+                )
 
-        val response = client.delete("/t/acme/api/v1/sessions/${saved.id}") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.delete("/t/acme/api/v1/sessions/${saved.id}") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
         }
-
-        assertEquals(HttpStatusCode.NoContent, response.status)
-    }
 
     @Test
-    fun `DELETE session returns 404 for session in different tenant`() = testApplication {
-        application { installTestApp() }
+    fun `DELETE session returns 404 for session in different tenant`() =
+        testApplication {
+            application { installTestApp() }
 
-        val saved = sessionRepo.save(
-            Session(
-                tenantId = 50,
-                userId = 99,
-                clientId = null,
-                accessTokenHash = "other-hash",
-                refreshTokenHash = null,
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-            ),
-        )
+            val saved =
+                sessionRepo.save(
+                    Session(
+                        tenantId = 50,
+                        userId = 99,
+                        clientId = null,
+                        accessTokenHash = "other-hash",
+                        refreshTokenHash = null,
+                        scopes = "openid",
+                        expiresAt = Instant.now().plusSeconds(3600),
+                    ),
+                )
 
-        val response = client.delete("/t/acme/api/v1/sessions/${saved.id}") {
-            bearerAuth(rawApiKey)
+            val response =
+                client.delete("/t/acme/api/v1/sessions/${saved.id}") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
         }
-
-        assertEquals(HttpStatusCode.NotFound, response.status)
-    }
 
     // =========================================================================
     // Audit logs — filtered query
     // =========================================================================
 
     @Test
-    fun `GET audit-logs with userId filter returns only matching events`() = testApplication {
-        application { installTestApp() }
+    fun `GET audit-logs with userId filter returns only matching events`() =
+        testApplication {
+            application { installTestApp() }
 
-        auditLogRepo.add(
-            AuditEvent(tenantId = 1, userId = 10, clientId = null, eventType = AuditEventType.LOGIN_SUCCESS, ipAddress = "127.0.0.1", userAgent = "test"),
-        )
-        auditLogRepo.add(
-            AuditEvent(tenantId = 1, userId = 99, clientId = null, eventType = AuditEventType.LOGIN_FAILED, ipAddress = "127.0.0.1", userAgent = "test"),
-        )
+            auditLogRepo.add(
+                AuditEvent(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    eventType = AuditEventType.LOGIN_SUCCESS,
+                    ipAddress = "127.0.0.1",
+                    userAgent = "test",
+                ),
+            )
+            auditLogRepo.add(
+                AuditEvent(
+                    tenantId = 1,
+                    userId = 99,
+                    clientId = null,
+                    eventType = AuditEventType.LOGIN_FAILED,
+                    ipAddress = "127.0.0.1",
+                    userAgent = "test",
+                ),
+            )
 
-        val auditKey = apiKeyService.create(1, "Audit Key 2", listOf(ApiScope.AUDIT_LOGS_READ))
-        val auditRawKey = (auditKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+            val auditKey = apiKeyService.create(1, "Audit Key 2", listOf(ApiScope.AUDIT_LOGS_READ))
+            val auditRawKey = (auditKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
 
-        val response = client.get("/t/acme/api/v1/audit-logs?userId=10") {
-            bearerAuth(auditRawKey)
+            val response =
+                client.get("/t/acme/api/v1/audit-logs?userId=10") {
+                    bearerAuth(auditRawKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("LOGIN_SUCCESS"))
+            assertTrue(!body.contains("LOGIN_FAILED"), "Must not include events for other users")
         }
-
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("LOGIN_SUCCESS"))
-        assertTrue(!body.contains("LOGIN_FAILED"), "Must not include events for other users")
-    }
 
     // =========================================================================
     // Test application wiring

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -1,0 +1,413 @@
+package com.kauth.adapter.web.api
+
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.AuditEvent
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.ApiKeyService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApiKeyRepository
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.ApiKeyPrincipal
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.bearer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [apiRoutes].
+ *
+ * Spins up Ktor's in-memory test engine with the real routing, real auth
+ * intercept, and real scope guard — wired to fakes for all persistence.
+ *
+ * Focus areas:
+ *   1. API key authentication guard (missing, invalid, wrong tenant, expired, revoked)
+ *   2. Scope enforcement (missing scope → 403)
+ *   3. User CRUD through the API (list, get, create)
+ *   4. Cross-tenant isolation
+ *   5. Audit log query endpoint
+ */
+class ApiRoutesTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val apiKeyRepo = FakeApiKeyRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val hasher = FakePasswordHasher()
+
+    private val tenant = Tenant(
+        id = 1,
+        slug = "acme",
+        displayName = "Acme Corp",
+        issuerUrl = null,
+        theme = TenantTheme.DEFAULT,
+    )
+
+    private val otherTenant = Tenant(
+        id = 50,
+        slug = "other",
+        displayName = "Other Corp",
+        issuerUrl = null,
+        theme = TenantTheme.DEFAULT,
+    )
+
+    private val user = User(
+        id = 10,
+        tenantId = 1,
+        username = "alice",
+        email = "alice@example.com",
+        fullName = "Alice Smith",
+        passwordHash = hasher.hash("password123"),
+        enabled = true,
+    )
+
+    private val evTokenRepo = FakeEmailVerificationTokenRepository()
+    private val prTokenRepo = FakePasswordResetTokenRepository()
+    private val emailPort = FakeEmailPort()
+
+    private val apiKeyService = ApiKeyService(
+        apiKeyRepository = apiKeyRepo,
+        tenantRepository = tenantRepo,
+    )
+
+    private val selfServiceService = UserSelfServiceService(
+        userRepository = userRepo,
+        tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        evTokenRepo = evTokenRepo,
+        prTokenRepo = prTokenRepo,
+        emailPort = emailPort,
+    )
+
+    private val adminService = AdminService(
+        tenantRepository = tenantRepo,
+        userRepository = userRepo,
+        applicationRepository = appRepo,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        sessionRepository = sessionRepo,
+        selfServiceService = selfServiceService,
+    )
+
+    private val roleGroupService = RoleGroupService(
+        roleRepository = roleRepo,
+        groupRepository = groupRepo,
+        tenantRepository = tenantRepo,
+        userRepository = userRepo,
+        applicationRepository = appRepo,
+        auditLog = auditLogPort,
+    )
+
+    private var rawApiKey: String = ""
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        roleRepo.clear()
+        groupRepo.clear()
+        appRepo.clear()
+        sessionRepo.clear()
+        apiKeyRepo.clear()
+        auditLogRepo.clear()
+        auditLogPort.clear()
+        evTokenRepo.clear()
+        prTokenRepo.clear()
+        emailPort.clear()
+
+        tenantRepo.add(tenant)
+        tenantRepo.add(otherTenant)
+        userRepo.add(user)
+
+        val created = apiKeyService.create(
+            tenantId = 1,
+            name = "Test Key",
+            scopes = ApiScope.ALL,
+        )
+        rawApiKey = (created as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+    }
+
+    // =========================================================================
+    // Auth guard — missing / invalid / wrong-tenant / expired / revoked key
+    // =========================================================================
+
+    @Test
+    fun `GET users returns 401 when no Bearer token is provided`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/users")
+
+        // Ktor's bearer challenge fires before the route intercept — body is empty
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET users returns 401 when Bearer token does not start with kauth_`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth("not-a-valid-prefix-token")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET users returns 401 when Bearer token is unknown`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth("kauth_acme_thiskeyDoesNotExistInTheRepo0000000")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid API key"))
+    }
+
+    @Test
+    fun `GET users returns 401 when API key belongs to a different tenant`() = testApplication {
+        application { installTestApp() }
+
+        val otherKey = apiKeyService.create(
+            tenantId = 50,
+            name = "Other Tenant Key",
+            scopes = ApiScope.ALL,
+        )
+        val otherRawKey = (otherKey as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth(otherRawKey)
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET users returns 401 when API key is revoked`() = testApplication {
+        application { installTestApp() }
+
+        val revokedResult = apiKeyService.create(
+            tenantId = 1,
+            name = "Revoked Key",
+            scopes = ApiScope.ALL,
+        )
+        val revokedKey = (revokedResult as com.kauth.domain.service.ApiKeyResult.Success).value
+        apiKeyService.revoke(revokedKey.apiKey.id!!, tenantId = 1)
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth(revokedKey.rawKey)
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `GET users returns 404 for unknown tenant slug`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/ghost/api/v1/users") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertTrue(response.bodyAsText().contains("Tenant not found"))
+    }
+
+    // =========================================================================
+    // Scope enforcement
+    // =========================================================================
+
+    @Test
+    fun `GET users returns 403 when API key lacks users_read scope`() = testApplication {
+        application { installTestApp() }
+
+        val limitedResult = apiKeyService.create(
+            tenantId = 1,
+            name = "Roles Only Key",
+            scopes = listOf(ApiScope.ROLES_READ),
+        )
+        val limitedRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth(limitedRawKey)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertTrue(response.bodyAsText().contains("Insufficient scope"))
+    }
+
+    // =========================================================================
+    // User CRUD
+    // =========================================================================
+
+    @Test
+    fun `GET users returns 200 with user list for valid API key`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/users") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"data\""), "Response must contain data envelope")
+        assertTrue(body.contains("alice"), "Response must include alice user")
+    }
+
+    @Test
+    fun `GET users by id returns 200 with user details`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/api/v1/users/10") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("alice"))
+        assertTrue(body.contains("alice@example.com"))
+    }
+
+    @Test
+    fun `GET users by id returns 404 for user in different tenant`() = testApplication {
+        application { installTestApp() }
+
+        userRepo.add(
+            User(
+                id = 20,
+                tenantId = 50,
+                username = "bob",
+                email = "bob@other.com",
+                fullName = "Bob",
+                passwordHash = hasher.hash("pass"),
+                enabled = true,
+            ),
+        )
+
+        val response = client.get("/t/acme/api/v1/users/20") {
+            bearerAuth(rawApiKey)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `POST users creates a new user and returns 201`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.post("/t/acme/api/v1/users") {
+            bearerAuth(rawApiKey)
+            contentType(ContentType.Application.Json)
+            setBody("""{"username":"charlie","email":"charlie@example.com","fullName":"Charlie Brown","password":"StrongP@ss1"}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("charlie"))
+    }
+
+    // =========================================================================
+    // Audit log query
+    // =========================================================================
+
+    @Test
+    fun `GET audit-logs returns events for the tenant`() = testApplication {
+        application { installTestApp() }
+
+        auditLogRepo.add(
+            AuditEvent(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                eventType = AuditEventType.LOGIN_SUCCESS,
+                ipAddress = "127.0.0.1",
+                userAgent = "test",
+            ),
+        )
+
+        val limitedResult = apiKeyService.create(
+            tenantId = 1,
+            name = "Audit Key",
+            scopes = listOf(ApiScope.AUDIT_LOGS_READ),
+        )
+        val auditRawKey = (limitedResult as com.kauth.domain.service.ApiKeyResult.Success).value.rawKey
+
+        val response = client.get("/t/acme/api/v1/audit-logs") {
+            bearerAuth(auditRawKey)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("LOGIN_SUCCESS"))
+    }
+
+    // =========================================================================
+    // Test application wiring
+    // =========================================================================
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Authentication) {
+            bearer("api-key") {
+                realm = "KotAuth REST API"
+                authenticate { tokenCredential ->
+                    if (tokenCredential.token.startsWith("kauth_")) {
+                        ApiKeyPrincipal(rawToken = tokenCredential.token)
+                    } else {
+                        null
+                    }
+                }
+            }
+        }
+        routing {
+            apiRoutes(
+                apiKeyService = apiKeyService,
+                tenantRepository = tenantRepo,
+                userRepository = userRepo,
+                roleRepository = roleRepo,
+                groupRepository = groupRepo,
+                applicationRepository = appRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                roleGroupService = roleGroupService,
+                adminService = adminService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -844,18 +844,19 @@ class AuthRoutesTest {
                     expiresAt = Instant.now().plusSeconds(3600),
                 ),
             )
-            tokenPort.claimsToReturn = AccessTokenClaims(
-                sub = "10",
-                iss = "http://localhost/t/acme",
-                aud = "spa-app",
-                tenantId = 1,
-                username = "alice",
-                email = "alice@example.com",
-                scopes = listOf("openid", "profile"),
-                issuedAt = Instant.now().epochSecond,
-                expiresAt = Instant.now().plusSeconds(3600).epochSecond,
-                realmRoles = emptyList(),
-            )
+            tokenPort.claimsToReturn =
+                AccessTokenClaims(
+                    sub = "10",
+                    iss = "http://localhost/t/acme",
+                    aud = "spa-app",
+                    tenantId = 1,
+                    username = "alice",
+                    email = "alice@example.com",
+                    scopes = listOf("openid", "profile"),
+                    issuedAt = Instant.now().epochSecond,
+                    expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+                    realmRoles = emptyList(),
+                )
 
             application {
                 install(ContentNegotiation) { json() }

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -1,8 +1,10 @@
 package com.kauth.adapter.web.auth
 
+import com.kauth.domain.model.AccessTokenClaims
 import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.Application
 import com.kauth.domain.model.AuthorizationCode
+import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
@@ -21,6 +23,7 @@ import com.kauth.fakes.FakeTokenPort
 import com.kauth.fakes.FakeUserRepository
 import com.kauth.infrastructure.EncryptionService
 import com.kauth.infrastructure.RateLimiter
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -146,6 +149,7 @@ class AuthRoutesTest {
         authCodeRepo.clear()
         sessionRepo.clear()
         auditLog.clear()
+        tokenPort.reset()
         tenantRepo.add(tenant)
         userRepo.add(user)
         appRepo.add(publicApp)
@@ -715,9 +719,492 @@ class AuthRoutesTest {
             )
         }
 
+    // =========================================================================
+    // POST /t/{slug}/protocol/openid-connect/revoke — RFC 7009
+    // =========================================================================
+
+    @Test
+    fun `POST revoke returns 200 for a valid access token`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-revoke"
+            val hash = sha256Hex(accessToken)
+            sessionRepo.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = 1,
+                    accessTokenHash = hash,
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/revoke",
+                    formParameters = Parameters.build { append("token", accessToken) },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `POST revoke returns 200 even for unknown token (RFC 7009 compliance)`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/revoke",
+                    formParameters = Parameters.build { append("token", "completely-unknown-token") },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status, "RFC 7009: always return 200")
+        }
+
+    @Test
+    fun `POST revoke returns 400 when token param is missing`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/revoke",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    // =========================================================================
+    // POST /t/{slug}/protocol/openid-connect/introspect — RFC 7662
+    // =========================================================================
+
+    @Test
+    fun `POST introspect returns active=true for a valid session with claims`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-introspect"
+            val hash = sha256Hex(accessToken)
+            sessionRepo.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = 1,
+                    accessTokenHash = hash,
+                    refreshTokenHash = null,
+                    scopes = "openid profile",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+            tokenPort.claimsToReturn = AccessTokenClaims(
+                sub = "10",
+                iss = "http://localhost/t/acme",
+                aud = "spa-app",
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                scopes = listOf("openid", "profile"),
+                issuedAt = Instant.now().epochSecond,
+                expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+                realmRoles = emptyList(),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/introspect",
+                    formParameters = Parameters.build { append("token", accessToken) },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"active\":true") || body.contains("\"active\": true"))
+            assertTrue(body.contains("\"sub\":\"10\"") || body.contains("\"sub\": \"10\""))
+        }
+
+    @Test
+    fun `POST introspect returns active=false for unknown token`() =
+        testApplication {
+            resetFixtures()
+            tokenPort.claimsToReturn = null
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/introspect",
+                    formParameters = Parameters.build { append("token", "unknown-token") },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"active\":false") || body.contains("\"active\": false"))
+        }
+
+    // =========================================================================
+    // GET /t/{slug}/protocol/openid-connect/userinfo — OIDC Core §5.3
+    // =========================================================================
+
+    @Test
+    fun `GET userinfo returns user claims for valid bearer token`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-userinfo"
+            val hash = sha256Hex(accessToken)
+            sessionRepo.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = 1,
+                    accessTokenHash = hash,
+                    refreshTokenHash = null,
+                    scopes = "openid profile",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.get("/t/acme/protocol/openid-connect/userinfo") {
+                    bearerAuth(accessToken)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("alice"), "Must contain username")
+            assertTrue(body.contains("alice@example.com"), "Must contain email")
+        }
+
+    @Test
+    fun `GET userinfo returns 401 when no bearer token is provided`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response = client.get("/t/acme/protocol/openid-connect/userinfo")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `GET userinfo returns 401 for expired session`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-expired"
+            val hash = sha256Hex(accessToken)
+            sessionRepo.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = 1,
+                    accessTokenHash = hash,
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().minusSeconds(3600),
+                ),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.get("/t/acme/protocol/openid-connect/userinfo") {
+                    bearerAuth(accessToken)
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    // =========================================================================
+    // POST /t/{slug}/register — registration flow
+    // =========================================================================
+
+    @Test
+    fun `POST register redirects to login with registered=true on success`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/register",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "newuser")
+                            append("email", "newuser@example.com")
+                            append("fullName", "New User")
+                            append("password", "StrongP@ss123")
+                            append("confirmPassword", "StrongP@ss123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.contains("registered=true"), "Must redirect with registered=true")
+        }
+
+    @Test
+    fun `POST register returns 422 for duplicate username`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/register",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("email", "different@example.com")
+                            append("fullName", "Alice Clone")
+                            append("password", "StrongP@ss123")
+                            append("confirmPassword", "StrongP@ss123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            assertTrue(response.bodyAsText().contains("already taken"))
+        }
+
+    @Test
+    fun `POST register returns 422 for mismatched passwords`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/register",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "newuser2")
+                            append("email", "newuser2@example.com")
+                            append("fullName", "New User 2")
+                            append("password", "StrongP@ss123")
+                            append("confirmPassword", "DifferentPass456")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    @Test
+    fun `POST register returns 429 when rate limited`() =
+        testApplication {
+            resetFixtures()
+            val tightRegisterLimiter = RateLimiter(maxRequests = 1, windowSeconds = 60)
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = tightRegisterLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        selfServiceService = selfService,
+                    )
+                }
+            }
+
+            // First request consumes the quota
+            client.submitForm(
+                url = "/t/acme/register",
+                formParameters =
+                    Parameters.build {
+                        append("username", "first")
+                        append("email", "first@example.com")
+                        append("fullName", "First")
+                        append("password", "StrongP@ss123")
+                        append("confirmPassword", "StrongP@ss123")
+                    },
+            )
+
+            // Second request should be rate limited
+            val response =
+                client.submitForm(
+                    url = "/t/acme/register",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "second")
+                            append("email", "second@example.com")
+                            append("fullName", "Second")
+                            append("password", "StrongP@ss123")
+                            append("confirmPassword", "StrongP@ss123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.TooManyRequests, response.status)
+        }
+
     // -------------------------------------------------------------------------
     // Utility
     // -------------------------------------------------------------------------
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
 
     private fun sha256Base64Url(input: String): String {
         val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))

--- a/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
@@ -47,43 +47,47 @@ class PortalRoutesTest {
     private val hasher = FakePasswordHasher()
     private val tokenPort = FakeTokenPort()
 
-    private val tenant = Tenant(
-        id = 1,
-        slug = "acme",
-        displayName = "Acme Corp",
-        issuerUrl = null,
-        theme = TenantTheme.DEFAULT,
-    )
+    private val tenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
 
-    private val user = User(
-        id = 10,
-        tenantId = 1,
-        username = "alice",
-        email = "alice@acme.dev",
-        fullName = "Alice",
-        passwordHash = hasher.hash("secret"),
-        enabled = true,
-    )
+    private val user =
+        User(
+            id = 10,
+            tenantId = 1,
+            username = "alice",
+            email = "alice@acme.dev",
+            fullName = "Alice",
+            passwordHash = hasher.hash("secret"),
+            enabled = true,
+        )
 
-    private fun buildAuthService() = AuthService(
-        userRepository = userRepo,
-        tenantRepository = tenantRepo,
-        tokenPort = tokenPort,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        sessionRepository = sessionRepo,
-    )
+    private fun buildAuthService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+        )
 
-    private fun buildSelfService() = UserSelfServiceService(
-        userRepository = userRepo,
-        tenantRepository = tenantRepo,
-        sessionRepository = sessionRepo,
-        passwordHasher = hasher,
-        auditLog = auditLogPort,
-        evTokenRepo = FakeEmailVerificationTokenRepository(),
-        prTokenRepo = FakePasswordResetTokenRepository(),
-        emailPort = FakeEmailPort(),
-    )
+    private fun buildSelfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = FakeEmailPort(),
+        )
 
     @BeforeTest
     fun setup() {
@@ -100,94 +104,103 @@ class PortalRoutesTest {
     // =========================================================================
 
     @Test
-    fun `GET profile redirects to login when no session cookie is present`() = testApplication {
-        application { installTestApp() }
+    fun `GET profile redirects to login when no session cookie is present`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.get("/t/acme/account/profile")
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/profile")
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        val location = response.headers["Location"] ?: ""
-        assertTrue(location.contains("/t/acme/account/login"), "Must redirect to portal login")
-    }
-
-    @Test
-    fun `GET security redirects to login when no session cookie is present`() = testApplication {
-        application { installTestApp() }
-
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.get("/t/acme/account/security")
-
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.contains("/t/acme/account/login"), "Must redirect to portal login")
+        }
 
     @Test
-    fun `POST change-password redirects to login when no session cookie is present`() = testApplication {
-        application { installTestApp() }
+    fun `GET security redirects to login when no session cookie is present`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.submitForm(
-            url = "/t/acme/account/change-password",
-            formParameters = Parameters.build {
-                append("current_password", "secret")
-                append("new_password", "new-secret")
-                append("confirm_password", "new-secret")
-            },
-        )
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/security")
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+        }
+
+    @Test
+    fun `POST change-password redirects to login when no session cookie is present`() =
+        testApplication {
+            application { installTestApp() }
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/account/change-password",
+                    formParameters =
+                        Parameters.build {
+                            append("current_password", "secret")
+                            append("new_password", "new-secret")
+                            append("confirm_password", "new-secret")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+        }
 
     // =========================================================================
     // GET /login (fallback — no oauthService wired)
     // =========================================================================
 
     @Test
-    fun `GET login returns 200 with login form when oauthService is null`() = testApplication {
-        application { installTestApp() }
+    fun `GET login returns 200 with login form when oauthService is null`() =
+        testApplication {
+            application { installTestApp() }
 
-        val response = client.get("/t/acme/account/login")
+            val response = client.get("/t/acme/account/login")
 
-        assertEquals(HttpStatusCode.OK, response.status)
-        val body = response.bodyAsText()
-        assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
-    }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
+        }
 
     // =========================================================================
     // GET /callback — error paths
     // =========================================================================
 
     @Test
-    fun `GET callback redirects to login when no code and no oauthService`() = testApplication {
-        application { installTestApp() }
+    fun `GET callback redirects to login when no code and no oauthService`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.get("/t/acme/account/callback")
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/callback")
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        val location = response.headers["Location"] ?: ""
-        assertTrue(location.contains("/t/acme/account/login"), "Must redirect to login on missing code")
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.contains("/t/acme/account/login"), "Must redirect to login on missing code")
+        }
 
     // =========================================================================
     // POST /logout
     // =========================================================================
 
     @Test
-    fun `POST logout redirects to login`() = testApplication {
-        application { installTestApp() }
+    fun `POST logout redirects to login`() =
+        testApplication {
+            application { installTestApp() }
 
-        val noFollow = createClient { followRedirects = false }
-        val response = noFollow.submitForm(
-            url = "/t/acme/account/logout",
-            formParameters = Parameters.build { },
-        )
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/account/logout",
+                    formParameters = Parameters.build { },
+                )
 
-        assertEquals(HttpStatusCode.Found, response.status)
-        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
-    }
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+        }
 
     // =========================================================================
     // Test app wiring

--- a/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
@@ -1,0 +1,209 @@
+package com.kauth.adapter.web.portal
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.testApplication
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [portalRoutes] — session guard and OAuth flow edges.
+ *
+ * Focus: unauthenticated access redirects + logout + callback error paths.
+ * The full OAuth PKCE exchange (EncryptionService.signCookie / verifyCookie)
+ * depends on KAUTH_SECRET_KEY and is tested at the domain/infra layer.
+ * Here we verify the route wiring behaves correctly at the boundary.
+ */
+class PortalRoutesTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val hasher = FakePasswordHasher()
+    private val tokenPort = FakeTokenPort()
+
+    private val tenant = Tenant(
+        id = 1,
+        slug = "acme",
+        displayName = "Acme Corp",
+        issuerUrl = null,
+        theme = TenantTheme.DEFAULT,
+    )
+
+    private val user = User(
+        id = 10,
+        tenantId = 1,
+        username = "alice",
+        email = "alice@acme.dev",
+        fullName = "Alice",
+        passwordHash = hasher.hash("secret"),
+        enabled = true,
+    )
+
+    private fun buildAuthService() = AuthService(
+        userRepository = userRepo,
+        tenantRepository = tenantRepo,
+        tokenPort = tokenPort,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        sessionRepository = sessionRepo,
+    )
+
+    private fun buildSelfService() = UserSelfServiceService(
+        userRepository = userRepo,
+        tenantRepository = tenantRepo,
+        sessionRepository = sessionRepo,
+        passwordHasher = hasher,
+        auditLog = auditLogPort,
+        evTokenRepo = FakeEmailVerificationTokenRepository(),
+        prTokenRepo = FakePasswordResetTokenRepository(),
+        emailPort = FakeEmailPort(),
+    )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+        tenantRepo.add(tenant)
+        userRepo.add(user)
+    }
+
+    // =========================================================================
+    // Session guard — unauthenticated access
+    // =========================================================================
+
+    @Test
+    fun `GET profile redirects to login when no session cookie is present`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.get("/t/acme/account/profile")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        val location = response.headers["Location"] ?: ""
+        assertTrue(location.contains("/t/acme/account/login"), "Must redirect to portal login")
+    }
+
+    @Test
+    fun `GET security redirects to login when no session cookie is present`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.get("/t/acme/account/security")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+    }
+
+    @Test
+    fun `POST change-password redirects to login when no session cookie is present`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.submitForm(
+            url = "/t/acme/account/change-password",
+            formParameters = Parameters.build {
+                append("current_password", "secret")
+                append("new_password", "new-secret")
+                append("confirm_password", "new-secret")
+            },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+    }
+
+    // =========================================================================
+    // GET /login (fallback — no oauthService wired)
+    // =========================================================================
+
+    @Test
+    fun `GET login returns 200 with login form when oauthService is null`() = testApplication {
+        application { installTestApp() }
+
+        val response = client.get("/t/acme/account/login")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("login") || body.contains("Login") || body.contains("form"))
+    }
+
+    // =========================================================================
+    // GET /callback — error paths
+    // =========================================================================
+
+    @Test
+    fun `GET callback redirects to login when no code and no oauthService`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.get("/t/acme/account/callback")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        val location = response.headers["Location"] ?: ""
+        assertTrue(location.contains("/t/acme/account/login"), "Must redirect to login on missing code")
+    }
+
+    // =========================================================================
+    // POST /logout
+    // =========================================================================
+
+    @Test
+    fun `POST logout redirects to login`() = testApplication {
+        application { installTestApp() }
+
+        val noFollow = createClient { followRedirects = false }
+        val response = noFollow.submitForm(
+            url = "/t/acme/account/logout",
+            formParameters = Parameters.build { },
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
+    }
+
+    // =========================================================================
+    // Test app wiring
+    // =========================================================================
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<PortalSession>("KOTAUTH_PORTAL")
+        }
+        routing {
+            portalRoutes(
+                authService = buildAuthService(),
+                selfServiceService = buildSelfService(),
+                tenantRepository = tenantRepo,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -1,0 +1,466 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordPolicyPort
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [AdminService].
+ *
+ * Covers: workspace settings, user CRUD, application management,
+ * client secret regeneration, SMTP config, admin-initiated password reset.
+ */
+class AdminServiceTest {
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val apps = FakeApplicationRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val sessions = FakeSessionRepository()
+    private val passwordPolicy = FakePasswordPolicyPort()
+    private val evTokenRepo = FakeEmailVerificationTokenRepository()
+    private val prTokenRepo = FakePasswordResetTokenRepository()
+    private val emailPort = FakeEmailPort()
+
+    private val selfService =
+        UserSelfServiceService(
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = evTokenRepo,
+            prTokenRepo = prTokenRepo,
+            emailPort = emailPort,
+            passwordPolicy = passwordPolicy,
+        )
+
+    private val svc =
+        AdminService(
+            tenantRepository = tenants,
+            userRepository = users,
+            applicationRepository = apps,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessions,
+            selfServiceService = selfService,
+            passwordPolicy = passwordPolicy,
+        )
+
+    private val tenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            passwordPolicyMinLength = 8,
+            smtpHost = "smtp.example.com",
+            smtpFromAddress = "no-reply@acme.com",
+            smtpEnabled = true,
+        )
+
+    private val alice
+        get() =
+            User(
+                id = 10,
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                fullName = "Alice Test",
+                passwordHash = hasher.hash("pass"),
+                enabled = true,
+            )
+
+    private val testApp =
+        Application(
+            id = 100,
+            tenantId = 1,
+            clientId = "my-app",
+            name = "My App",
+            description = "Test app",
+            accessType = AccessType.CONFIDENTIAL,
+            enabled = true,
+            redirectUris = listOf("http://localhost/callback"),
+        )
+
+    private val defaultTheme = TenantTheme.DEFAULT
+
+    @BeforeTest
+    fun setup() {
+        tenants.clear()
+        users.clear()
+        apps.clear()
+        auditLog.clear()
+        sessions.clear()
+        passwordPolicy.clear()
+        evTokenRepo.clear()
+        prTokenRepo.clear()
+        emailPort.clear()
+        tenants.add(tenant)
+        users.add(alice)
+        apps.add(testApp, secretHash = hasher.hash("old-secret"))
+    }
+
+    // =========================================================================
+    // updateWorkspaceSettings
+    // =========================================================================
+
+    @Test
+    fun `updateWorkspaceSettings - tenant not found`() {
+        val result = callUpdateSettings(slug = "unknown")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - blank display name`() {
+        val result = callUpdateSettings(displayName = "  ")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - token expiry too low`() {
+        val result = callUpdateSettings(tokenExpirySeconds = 30)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - refresh expiry less than access expiry`() {
+        val result = callUpdateSettings(tokenExpirySeconds = 3600, refreshTokenExpirySeconds = 1800)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - password minLength out of range`() {
+        val result = callUpdateSettings(passwordPolicyMinLength = 3)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - invalid mfa policy`() {
+        val result = callUpdateSettings(mfaPolicy = "invalid")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateWorkspaceSettings - success updates tenant`() {
+        val result = callUpdateSettings(displayName = "New Name", tokenExpirySeconds = 7200)
+        assertIs<AdminResult.Success<Tenant>>(result)
+        assertEquals("New Name", result.value.displayName)
+        assertEquals(7200L, result.value.tokenExpirySeconds)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_TENANT_UPDATED))
+    }
+
+    // =========================================================================
+    // createUser
+    // =========================================================================
+
+    @Test
+    fun `createUser - tenant not found`() {
+        val result = svc.createUser(tenantId = 999, username = "bob", email = "bob@x.com", fullName = "Bob", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `createUser - blank username`() {
+        val result = svc.createUser(tenantId = 1, username = "  ", email = "bob@x.com", fullName = "Bob", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser - invalid username characters`() {
+        val result = svc.createUser(tenantId = 1, username = "bad user!", email = "bob@x.com", fullName = "Bob", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser - invalid email`() {
+        val result = svc.createUser(tenantId = 1, username = "bob", email = "not-email", fullName = "Bob", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser - duplicate username`() {
+        val result = svc.createUser(tenantId = 1, username = "alice", email = "new@x.com", fullName = "Alice 2", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `createUser - duplicate email`() {
+        val result = svc.createUser(tenantId = 1, username = "newuser", email = "alice@example.com", fullName = "New", password = "password123")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `createUser - password policy violation`() {
+        passwordPolicy.validationError = "Too weak"
+        val result = svc.createUser(tenantId = 1, username = "bob", email = "bob@x.com", fullName = "Bob", password = "weak")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser - success`() {
+        val result = svc.createUser(tenantId = 1, username = "bob", email = "bob@example.com", fullName = "Bob Test", password = "secure-pass-123")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("bob", result.value.username)
+        assertEquals(true, result.value.emailVerified, "Admin-created users should be email-verified")
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_CREATED))
+    }
+
+    // =========================================================================
+    // updateUser
+    // =========================================================================
+
+    @Test
+    fun `updateUser - user not found`() {
+        val result = svc.updateUser(userId = 999, tenantId = 1, email = "x@x.com", fullName = "X")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateUser - tenant mismatch`() {
+        val result = svc.updateUser(userId = 10, tenantId = 99, email = "x@x.com", fullName = "X")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateUser - success`() {
+        val result = svc.updateUser(userId = 10, tenantId = 1, email = "newalice@example.com", fullName = "Alice Updated")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("newalice@example.com", result.value.email)
+        assertEquals("Alice Updated", result.value.fullName)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_UPDATED))
+    }
+
+    // =========================================================================
+    // setUserEnabled
+    // =========================================================================
+
+    @Test
+    fun `setUserEnabled - user not found`() {
+        val result = svc.setUserEnabled(userId = 999, tenantId = 1, enabled = false)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `setUserEnabled - disables user`() {
+        val result = svc.setUserEnabled(userId = 10, tenantId = 1, enabled = false)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(false, users.findById(10)!!.enabled)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_DISABLED))
+    }
+
+    // =========================================================================
+    // updateApplication
+    // =========================================================================
+
+    @Test
+    fun `updateApplication - app not found`() {
+        val result = svc.updateApplication(appId = 999, tenantId = 1, name = "X", description = null, accessType = "public", redirectUris = emptyList())
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateApplication - tenant mismatch`() {
+        val result = svc.updateApplication(appId = 100, tenantId = 99, name = "X", description = null, accessType = "public", redirectUris = emptyList())
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateApplication - blank name`() {
+        val result = svc.updateApplication(appId = 100, tenantId = 1, name = "  ", description = null, accessType = "public", redirectUris = emptyList())
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateApplication - success`() {
+        val result = svc.updateApplication(appId = 100, tenantId = 1, name = "Renamed App", description = "Updated", accessType = "public", redirectUris = listOf("http://new/callback"))
+        assertIs<AdminResult.Success<Application>>(result)
+        assertEquals("Renamed App", result.value.name)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_UPDATED))
+    }
+
+    // =========================================================================
+    // setApplicationEnabled
+    // =========================================================================
+
+    @Test
+    fun `setApplicationEnabled - disables app`() {
+        val result = svc.setApplicationEnabled(appId = 100, tenantId = 1, enabled = false)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_DISABLED))
+    }
+
+    // =========================================================================
+    // regenerateClientSecret
+    // =========================================================================
+
+    @Test
+    fun `regenerateClientSecret - app not found`() {
+        val result = svc.regenerateClientSecret(appId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `regenerateClientSecret - success returns raw secret`() {
+        val result = svc.regenerateClientSecret(appId = 100, tenantId = 1)
+        assertIs<AdminResult.Success<String>>(result)
+        assertTrue(result.value.isNotBlank())
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_SECRET_REGENERATED))
+    }
+
+    // =========================================================================
+    // updateSmtpConfig
+    // =========================================================================
+
+    @Test
+    fun `updateSmtpConfig - tenant not found`() {
+        val result = svc.updateSmtpConfig("unknown", "host", 587, null, null, "a@b.com", null, true, true)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateSmtpConfig - enabled but no host`() {
+        val result = svc.updateSmtpConfig("acme", "  ", 587, null, null, "a@b.com", null, true, true)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateSmtpConfig - enabled but invalid from address`() {
+        val result = svc.updateSmtpConfig("acme", "smtp.host.com", 587, null, null, "bad-email", null, true, true)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateSmtpConfig - enabled but invalid port`() {
+        val result = svc.updateSmtpConfig("acme", "smtp.host.com", 0, null, null, "a@b.com", null, true, true)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateSmtpConfig - disabled skips validation`() {
+        val result = svc.updateSmtpConfig("acme", null, 587, null, null, null, null, false, false)
+        assertIs<AdminResult.Success<Tenant>>(result)
+        assertEquals(false, result.value.smtpEnabled)
+    }
+
+    @Test
+    fun `updateSmtpConfig - success`() {
+        val result = svc.updateSmtpConfig("acme", "smtp.new.com", 465, "user", "pass", "no-reply@new.com", "New Co", true, true)
+        assertIs<AdminResult.Success<Tenant>>(result)
+        assertEquals("smtp.new.com", result.value.smtpHost)
+        assertEquals(465, result.value.smtpPort)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_SMTP_UPDATED))
+    }
+
+    // =========================================================================
+    // sendPasswordResetEmail
+    // =========================================================================
+
+    @Test
+    fun `sendPasswordResetEmail - user not found`() {
+        val result = svc.sendPasswordResetEmail(userId = 999, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `sendPasswordResetEmail - success delegates to self-service`() {
+        val result = svc.sendPasswordResetEmail(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(1, emailPort.sent.size)
+        assertEquals("password_reset", emailPort.sent[0].type)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_PASSWORD_RESET))
+    }
+
+    // =========================================================================
+    // resendVerificationEmail
+    // =========================================================================
+
+    @Test
+    fun `resendVerificationEmail - success`() {
+        val result = svc.resendVerificationEmail(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(1, emailPort.sent.size)
+        assertEquals("verification", emailPort.sent[0].type)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun callUpdateSettings(
+        slug: String = "acme",
+        displayName: String = "Acme Corp",
+        issuerUrl: String? = null,
+        tokenExpirySeconds: Long = 3600L,
+        refreshTokenExpirySeconds: Long = 86400L,
+        registrationEnabled: Boolean = true,
+        emailVerificationRequired: Boolean = false,
+        passwordPolicyMinLength: Int = 8,
+        passwordPolicyRequireSpecial: Boolean = false,
+        mfaPolicy: String = "optional",
+    ) = svc.updateWorkspaceSettings(
+        slug = slug,
+        displayName = displayName,
+        issuerUrl = issuerUrl,
+        tokenExpirySeconds = tokenExpirySeconds,
+        refreshTokenExpirySeconds = refreshTokenExpirySeconds,
+        registrationEnabled = registrationEnabled,
+        emailVerificationRequired = emailVerificationRequired,
+        passwordPolicyMinLength = passwordPolicyMinLength,
+        passwordPolicyRequireSpecial = passwordPolicyRequireSpecial,
+        mfaPolicy = mfaPolicy,
+        themeAccentColor = defaultTheme.accentColor,
+        themeAccentHover = defaultTheme.accentHoverColor,
+        themeBgDeep = defaultTheme.bgDeep,
+        themeBgCard = defaultTheme.bgCard,
+        themeBgInput = defaultTheme.bgInput,
+        themeBorderColor = defaultTheme.borderColor,
+        themeBorderRadius = defaultTheme.borderRadius,
+        themeTextPrimary = defaultTheme.textPrimary,
+        themeTextMuted = defaultTheme.textMuted,
+        themeLogoUrl = null,
+        themeFaviconUrl = null,
+    )
+}

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -6,8 +6,8 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
-import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeEmailPort
 import com.kauth.fakes.FakeEmailVerificationTokenRepository
 import com.kauth.fakes.FakePasswordHasher
@@ -20,7 +20,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -181,42 +180,84 @@ class AdminServiceTest {
 
     @Test
     fun `createUser - tenant not found`() {
-        val result = svc.createUser(tenantId = 999, username = "bob", email = "bob@x.com", fullName = "Bob", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 999,
+                username = "bob",
+                email = "bob@x.com",
+                fullName = "Bob",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.NotFound>(result.error)
     }
 
     @Test
     fun `createUser - blank username`() {
-        val result = svc.createUser(tenantId = 1, username = "  ", email = "bob@x.com", fullName = "Bob", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "  ",
+                email = "bob@x.com",
+                fullName = "Bob",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createUser - invalid username characters`() {
-        val result = svc.createUser(tenantId = 1, username = "bad user!", email = "bob@x.com", fullName = "Bob", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "bad user!",
+                email = "bob@x.com",
+                fullName = "Bob",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createUser - invalid email`() {
-        val result = svc.createUser(tenantId = 1, username = "bob", email = "not-email", fullName = "Bob", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "bob",
+                email = "not-email",
+                fullName = "Bob",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createUser - duplicate username`() {
-        val result = svc.createUser(tenantId = 1, username = "alice", email = "new@x.com", fullName = "Alice 2", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "alice",
+                email = "new@x.com",
+                fullName = "Alice 2",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Conflict>(result.error)
     }
 
     @Test
     fun `createUser - duplicate email`() {
-        val result = svc.createUser(tenantId = 1, username = "newuser", email = "alice@example.com", fullName = "New", password = "password123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "newuser",
+                email = "alice@example.com",
+                fullName = "New",
+                password = "password123",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Conflict>(result.error)
     }
@@ -224,14 +265,28 @@ class AdminServiceTest {
     @Test
     fun `createUser - password policy violation`() {
         passwordPolicy.validationError = "Too weak"
-        val result = svc.createUser(tenantId = 1, username = "bob", email = "bob@x.com", fullName = "Bob", password = "weak")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "bob",
+                email = "bob@x.com",
+                fullName = "Bob",
+                password = "weak",
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createUser - success`() {
-        val result = svc.createUser(tenantId = 1, username = "bob", email = "bob@example.com", fullName = "Bob Test", password = "secure-pass-123")
+        val result =
+            svc.createUser(
+                tenantId = 1,
+                username = "bob",
+                email = "bob@example.com",
+                fullName = "Bob Test",
+                password = "secure-pass-123",
+            )
         assertIs<AdminResult.Success<User>>(result)
         assertEquals("bob", result.value.username)
         assertEquals(true, result.value.emailVerified, "Admin-created users should be email-verified")
@@ -258,7 +313,13 @@ class AdminServiceTest {
 
     @Test
     fun `updateUser - success`() {
-        val result = svc.updateUser(userId = 10, tenantId = 1, email = "newalice@example.com", fullName = "Alice Updated")
+        val result =
+            svc.updateUser(
+                userId = 10,
+                tenantId = 1,
+                email = "newalice@example.com",
+                fullName = "Alice Updated",
+            )
         assertIs<AdminResult.Success<User>>(result)
         assertEquals("newalice@example.com", result.value.email)
         assertEquals("Alice Updated", result.value.fullName)
@@ -289,28 +350,60 @@ class AdminServiceTest {
 
     @Test
     fun `updateApplication - app not found`() {
-        val result = svc.updateApplication(appId = 999, tenantId = 1, name = "X", description = null, accessType = "public", redirectUris = emptyList())
+        val result =
+            svc.updateApplication(
+                appId = 999,
+                tenantId = 1,
+                name = "X",
+                description = null,
+                accessType = "public",
+                redirectUris = emptyList(),
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.NotFound>(result.error)
     }
 
     @Test
     fun `updateApplication - tenant mismatch`() {
-        val result = svc.updateApplication(appId = 100, tenantId = 99, name = "X", description = null, accessType = "public", redirectUris = emptyList())
+        val result =
+            svc.updateApplication(
+                appId = 100,
+                tenantId = 99,
+                name = "X",
+                description = null,
+                accessType = "public",
+                redirectUris = emptyList(),
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.NotFound>(result.error)
     }
 
     @Test
     fun `updateApplication - blank name`() {
-        val result = svc.updateApplication(appId = 100, tenantId = 1, name = "  ", description = null, accessType = "public", redirectUris = emptyList())
+        val result =
+            svc.updateApplication(
+                appId = 100,
+                tenantId = 1,
+                name = "  ",
+                description = null,
+                accessType = "public",
+                redirectUris = emptyList(),
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `updateApplication - success`() {
-        val result = svc.updateApplication(appId = 100, tenantId = 1, name = "Renamed App", description = "Updated", accessType = "public", redirectUris = listOf("http://new/callback"))
+        val result =
+            svc.updateApplication(
+                appId = 100,
+                tenantId = 1,
+                name = "Renamed App",
+                description = "Updated",
+                accessType = "public",
+                redirectUris = listOf("http://new/callback"),
+            )
         assertIs<AdminResult.Success<Application>>(result)
         assertEquals("Renamed App", result.value.name)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_UPDATED))
@@ -386,7 +479,18 @@ class AdminServiceTest {
 
     @Test
     fun `updateSmtpConfig - success`() {
-        val result = svc.updateSmtpConfig("acme", "smtp.new.com", 465, "user", "pass", "no-reply@new.com", "New Co", true, true)
+        val result =
+            svc.updateSmtpConfig(
+                "acme",
+                "smtp.new.com",
+                465,
+                "user",
+                "pass",
+                "no-reply@new.com",
+                "New Co",
+                true,
+                true,
+            )
         assertIs<AdminResult.Success<Tenant>>(result)
         assertEquals("smtp.new.com", result.value.smtpHost)
         assertEquals(465, result.value.smtpPort)

--- a/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
@@ -1,0 +1,214 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.ApiKey
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Tenant
+import com.kauth.fakes.FakeApiKeyRepository
+import com.kauth.fakes.FakeTenantRepository
+import java.security.MessageDigest
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ApiKeyService].
+ *
+ * Covers: key creation, validation, listing, revocation, deletion.
+ */
+class ApiKeyServiceTest {
+    private val apiKeys = FakeApiKeyRepository()
+    private val tenants = FakeTenantRepository()
+
+    private val svc = ApiKeyService(apiKeyRepository = apiKeys, tenantRepository = tenants)
+
+    private val tenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+        )
+
+    @BeforeTest
+    fun setup() {
+        apiKeys.clear()
+        tenants.clear()
+        tenants.add(tenant)
+    }
+
+    // =========================================================================
+    // create
+    // =========================================================================
+
+    @Test
+    fun `create - blank name`() {
+        val result = svc.create(tenantId = 1, name = "  ", scopes = listOf(ApiScope.USERS_READ))
+        assertIs<ApiKeyResult.Failure>(result)
+        assertIs<ApiKeyError.Validation>(result.error)
+    }
+
+    @Test
+    fun `create - name too long`() {
+        val result = svc.create(tenantId = 1, name = "a".repeat(129), scopes = listOf(ApiScope.USERS_READ))
+        assertIs<ApiKeyResult.Failure>(result)
+        assertIs<ApiKeyError.Validation>(result.error)
+    }
+
+    @Test
+    fun `create - tenant not found`() {
+        val result = svc.create(tenantId = 999, name = "CI Key", scopes = listOf(ApiScope.USERS_READ))
+        assertIs<ApiKeyResult.Failure>(result)
+        assertIs<ApiKeyError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `create - no valid scopes`() {
+        val result = svc.create(tenantId = 1, name = "Bad Key", scopes = listOf("invalid:scope"))
+        assertIs<ApiKeyResult.Failure>(result)
+        assertIs<ApiKeyError.Validation>(result.error)
+    }
+
+    @Test
+    fun `create - filters invalid scopes keeps valid ones`() {
+        val result = svc.create(tenantId = 1, name = "Mixed Key", scopes = listOf(ApiScope.USERS_READ, "bogus:scope"))
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(result)
+        assertEquals(listOf(ApiScope.USERS_READ), result.value.apiKey.scopes)
+    }
+
+    @Test
+    fun `create - success returns raw key and persists hash`() {
+        val result = svc.create(tenantId = 1, name = "CI Pipeline", scopes = listOf(ApiScope.USERS_READ, ApiScope.USERS_WRITE))
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(result)
+
+        val created = result.value
+        assertTrue(created.rawKey.startsWith("kauth_acme_"), "Key should start with kauth_<slug>_")
+        assertEquals("CI Pipeline", created.apiKey.name)
+        assertEquals(listOf(ApiScope.USERS_READ, ApiScope.USERS_WRITE), created.apiKey.scopes)
+        assertTrue(created.apiKey.enabled)
+        assertNotNull(created.apiKey.id)
+
+        // Verify hash is stored correctly
+        val hash = sha256(created.rawKey)
+        assertEquals(hash, created.apiKey.keyHash)
+        assertNotNull(apiKeys.findByHash(hash))
+    }
+
+    @Test
+    fun `create - with expiry`() {
+        val expiry = Instant.now().plusSeconds(86400)
+        val result = svc.create(tenantId = 1, name = "Temp Key", scopes = listOf(ApiScope.USERS_READ), expiresAt = expiry)
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(result)
+        assertEquals(expiry, result.value.apiKey.expiresAt)
+    }
+
+    // =========================================================================
+    // validate
+    // =========================================================================
+
+    @Test
+    fun `validate - unknown key returns null`() {
+        assertNull(svc.validate("kauth_acme_nonexistent", expectedTenantId = 1))
+    }
+
+    @Test
+    fun `validate - valid key returns api key`() {
+        val created = (svc.create(1, "Key", listOf(ApiScope.USERS_READ)) as ApiKeyResult.Success).value
+        val result = svc.validate(created.rawKey, expectedTenantId = 1)
+        assertNotNull(result)
+        assertEquals(created.apiKey.id, result.id)
+    }
+
+    @Test
+    fun `validate - wrong tenant returns null`() {
+        val created = (svc.create(1, "Key", listOf(ApiScope.USERS_READ)) as ApiKeyResult.Success).value
+        assertNull(svc.validate(created.rawKey, expectedTenantId = 99))
+    }
+
+    @Test
+    fun `validate - disabled key returns null`() {
+        val created = (svc.create(1, "Key", listOf(ApiScope.USERS_READ)) as ApiKeyResult.Success).value
+        apiKeys.revoke(created.apiKey.id!!, 1)
+        assertNull(svc.validate(created.rawKey, expectedTenantId = 1))
+    }
+
+    @Test
+    fun `validate - expired key returns null`() {
+        val expiry = Instant.now().minusSeconds(3600) // already expired
+        val hash = sha256("kauth_acme_expired-key")
+        apiKeys.save(
+            ApiKey(
+                tenantId = 1,
+                name = "Expired",
+                keyPrefix = "kauth_acme_exp",
+                keyHash = hash,
+                scopes = listOf(ApiScope.USERS_READ),
+                expiresAt = expiry,
+                enabled = true,
+            ),
+        )
+        assertNull(svc.validate("kauth_acme_expired-key", expectedTenantId = 1))
+    }
+
+    // =========================================================================
+    // listForTenant
+    // =========================================================================
+
+    @Test
+    fun `listForTenant - returns keys for tenant only`() {
+        svc.create(1, "Key1", listOf(ApiScope.USERS_READ))
+        svc.create(1, "Key2", listOf(ApiScope.ROLES_READ))
+        assertEquals(2, svc.listForTenant(1).size)
+        assertEquals(0, svc.listForTenant(99).size)
+    }
+
+    // =========================================================================
+    // revoke
+    // =========================================================================
+
+    @Test
+    fun `revoke - not found`() {
+        val result = svc.revoke(id = 999, tenantId = 1)
+        assertIs<ApiKeyResult.Failure>(result)
+        assertIs<ApiKeyError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `revoke - success disables key`() {
+        val created = (svc.create(1, "Key", listOf(ApiScope.USERS_READ)) as ApiKeyResult.Success).value
+        val result = svc.revoke(created.apiKey.id!!, 1)
+        assertIs<ApiKeyResult.Success<Unit>>(result)
+        assertEquals(false, apiKeys.findByHash(created.apiKey.keyHash)!!.enabled)
+    }
+
+    // =========================================================================
+    // delete
+    // =========================================================================
+
+    @Test
+    fun `delete - not found`() {
+        val result = svc.delete(id = 999, tenantId = 1)
+        assertIs<ApiKeyResult.Failure>(result)
+    }
+
+    @Test
+    fun `delete - success removes key`() {
+        val created = (svc.create(1, "Key", listOf(ApiScope.USERS_READ)) as ApiKeyResult.Success).value
+        val result = svc.delete(created.apiKey.id!!, 1)
+        assertIs<ApiKeyResult.Success<Unit>>(result)
+        assertNull(apiKeys.findByHash(created.apiKey.keyHash))
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun sha256(input: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
@@ -82,7 +82,12 @@ class ApiKeyServiceTest {
 
     @Test
     fun `create - success returns raw key and persists hash`() {
-        val result = svc.create(tenantId = 1, name = "CI Pipeline", scopes = listOf(ApiScope.USERS_READ, ApiScope.USERS_WRITE))
+        val result =
+            svc.create(
+                tenantId = 1,
+                name = "CI Pipeline",
+                scopes = listOf(ApiScope.USERS_READ, ApiScope.USERS_WRITE),
+            )
         assertIs<ApiKeyResult.Success<CreatedApiKey>>(result)
 
         val created = result.value
@@ -101,7 +106,13 @@ class ApiKeyServiceTest {
     @Test
     fun `create - with expiry`() {
         val expiry = Instant.now().plusSeconds(86400)
-        val result = svc.create(tenantId = 1, name = "Temp Key", scopes = listOf(ApiScope.USERS_READ), expiresAt = expiry)
+        val result =
+            svc.create(
+                tenantId = 1,
+                name = "Temp Key",
+                scopes = listOf(ApiScope.USERS_READ),
+                expiresAt = expiry,
+            )
         assertIs<ApiKeyResult.Success<CreatedApiKey>>(result)
         assertEquals(expiry, result.value.apiKey.expiresAt)
     }

--- a/src/test/kotlin/com/kauth/domain/service/MfaServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/MfaServiceTest.kt
@@ -4,6 +4,7 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.MfaEnrollment
 import com.kauth.domain.model.MfaMethod
 import com.kauth.domain.model.MfaRecoveryCode
+import com.kauth.domain.model.Role
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.User
 import com.kauth.fakes.FakeAuditLogPort
@@ -314,5 +315,85 @@ class MfaServiceTest {
             ),
         )
         assertTrue(svc.shouldChallengeMfa(userId = 10))
+    }
+
+    // =========================================================================
+    // disableMfa
+    // =========================================================================
+
+    @Test
+    fun `disableMfa - removes enrollment and recovery codes`() {
+        val enrollResult = svc.beginEnrollment(userId = 10, tenantId = 1, issuer = "Acme")
+        val secret = (enrollResult as MfaResult.Success<EnrollmentResponse>).value.enrollment.secret
+        val validCode = TotpUtil.generateCode(secret)
+        svc.verifyEnrollment(userId = 10, code = validCode)
+
+        assertTrue(svc.shouldChallengeMfa(userId = 10), "MFA should be active before disable")
+
+        val result = svc.disableMfa(userId = 10, tenantId = 1)
+        assertIs<MfaResult.Success<Unit>>(result)
+
+        assertFalse(svc.shouldChallengeMfa(userId = 10), "MFA should not challenge after disable")
+        val updatedUser = users.findById(10)
+        assertNotNull(updatedUser)
+        assertFalse(updatedUser.mfaEnabled, "User.mfaEnabled should be false after disable")
+        assertTrue(auditLog.hasEvent(AuditEventType.MFA_DISABLED))
+    }
+
+    @Test
+    fun `disableMfa - succeeds even with no existing enrollment`() {
+        val result = svc.disableMfa(userId = 10, tenantId = 1)
+        assertIs<MfaResult.Success<Unit>>(result)
+        assertTrue(auditLog.hasEvent(AuditEventType.MFA_DISABLED))
+    }
+
+    @Test
+    fun `disableMfa - clears recovery codes so they cannot be used afterward`() {
+        svc.beginEnrollment(userId = 10, tenantId = 1, issuer = "Acme")
+        // Seed a known recovery code
+        mfaRepo.saveRecoveryCodes(
+            listOf(MfaRecoveryCode(userId = 10, tenantId = 1, codeHash = hasher.hash("RECOVERY1"))),
+        )
+
+        svc.disableMfa(userId = 10, tenantId = 1)
+
+        val recoveryResult = svc.verifyRecoveryCode(userId = 10, code = "RECOVERY1")
+        assertIs<MfaResult.Failure>(recoveryResult)
+        assertIs<MfaError.NoRecoveryCodesLeft>(recoveryResult.error)
+    }
+
+    // =========================================================================
+    // isMfaRequired
+    // =========================================================================
+
+    @Test
+    fun `isMfaRequired - optional policy returns false`() {
+        assertFalse(svc.isMfaRequired(testUser, tenantMfaPolicy = "optional"))
+    }
+
+    @Test
+    fun `isMfaRequired - required policy returns true for any user`() {
+        assertTrue(svc.isMfaRequired(testUser, tenantMfaPolicy = "required"))
+    }
+
+    @Test
+    fun `isMfaRequired - required_admins returns true only for users with admin role`() {
+        val adminRole = Role(id = 1, tenantId = 1, name = "admin")
+        val viewerRole = Role(id = 2, tenantId = 1, name = "viewer")
+
+        assertTrue(
+            svc.isMfaRequired(testUser, tenantMfaPolicy = "required_admins", userRoles = listOf(adminRole)),
+        )
+        assertFalse(
+            svc.isMfaRequired(testUser, tenantMfaPolicy = "required_admins", userRoles = listOf(viewerRole)),
+        )
+        assertFalse(
+            svc.isMfaRequired(testUser, tenantMfaPolicy = "required_admins", userRoles = emptyList()),
+        )
+    }
+
+    @Test
+    fun `isMfaRequired - unknown policy returns false (fail-open)`() {
+        assertFalse(svc.isMfaRequired(testUser, tenantMfaPolicy = "unknown_policy"))
     }
 }

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -544,17 +544,18 @@ class OAuthServiceTest {
             ),
         )
         val expiresAt = Instant.now().plusSeconds(3600).epochSecond
-        tokens.claimsToReturn = AccessTokenClaims(
-            sub = "10",
-            iss = "https://acme.example.com",
-            aud = "spa-app",
-            tenantId = 1,
-            username = "alice",
-            email = "alice@example.com",
-            scopes = listOf("openid", "profile"),
-            issuedAt = Instant.now().epochSecond,
-            expiresAt = expiresAt,
-        )
+        tokens.claimsToReturn =
+            AccessTokenClaims(
+                sub = "10",
+                iss = "https://acme.example.com",
+                aud = "spa-app",
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                scopes = listOf("openid", "profile"),
+                issuedAt = Instant.now().epochSecond,
+                expiresAt = expiresAt,
+            )
 
         val result = svc.introspectToken(tenantSlug = "acme", token = accessToken)
         assertIs<IntrospectionResult.Active>(result)
@@ -578,17 +579,18 @@ class OAuthServiceTest {
     @Test
     fun `revokeToken - revokes session by access token`() {
         val accessToken = "access-to-revoke"
-        val session = sessions.save(
-            Session(
-                tenantId = 1,
-                userId = 10,
-                clientId = publicClient.id,
-                accessTokenHash = OAuthService.sha256(accessToken),
-                refreshTokenHash = null,
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-            ),
-        )
+        val session =
+            sessions.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = publicClient.id,
+                    accessTokenHash = OAuthService.sha256(accessToken),
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
 
         svc.revokeToken(accessToken)
 
@@ -601,18 +603,19 @@ class OAuthServiceTest {
     @Test
     fun `revokeToken - revokes session by refresh token`() {
         val refreshToken = "refresh-to-revoke"
-        val session = sessions.save(
-            Session(
-                tenantId = 1,
-                userId = 10,
-                clientId = publicClient.id,
-                accessTokenHash = OAuthService.sha256("some-access"),
-                refreshTokenHash = OAuthService.sha256(refreshToken),
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-                refreshExpiresAt = Instant.now().plusSeconds(86400),
-            ),
-        )
+        val session =
+            sessions.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = publicClient.id,
+                    accessTokenHash = OAuthService.sha256("some-access"),
+                    refreshTokenHash = OAuthService.sha256(refreshToken),
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                    refreshExpiresAt = Instant.now().plusSeconds(86400),
+                ),
+            )
 
         svc.revokeToken(refreshToken)
 
@@ -705,17 +708,18 @@ class OAuthServiceTest {
     @Test
     fun `endSession - revokes single session`() {
         val accessToken = "session-to-end"
-        val session = sessions.save(
-            Session(
-                tenantId = 1,
-                userId = 10,
-                clientId = publicClient.id,
-                accessTokenHash = OAuthService.sha256(accessToken),
-                refreshTokenHash = null,
-                scopes = "openid",
-                expiresAt = Instant.now().plusSeconds(3600),
-            ),
-        )
+        val session =
+            sessions.save(
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = publicClient.id,
+                    accessTokenHash = OAuthService.sha256(accessToken),
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
         // Create a second session that should NOT be revoked
         sessions.save(
             Session(

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -1,9 +1,11 @@
 package com.kauth.domain.service
 
+import com.kauth.domain.model.AccessTokenClaims
 import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.Application
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.AuthorizationCode
+import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.User
 import com.kauth.fakes.FakeApplicationRepository
@@ -114,6 +116,7 @@ class OAuthServiceTest {
         authCodes.clear()
         sessions.clear()
         auditLog.clear()
+        tokens.reset()
 
         tenants.add(testTenant)
         users.add(testUser)
@@ -492,6 +495,295 @@ class OAuthServiceTest {
             )
         assertIs<OAuthResult.Failure>(replayResult)
         assertIs<OAuthError.InvalidGrant>(replayResult.error)
+    }
+
+    // =========================================================================
+    // introspectToken
+    // =========================================================================
+
+    @Test
+    fun `introspectToken returns Inactive for unknown token`() {
+        val result = svc.introspectToken(tenantSlug = "acme", token = "unknown-token")
+        assertIs<IntrospectionResult.Inactive>(result)
+    }
+
+    @Test
+    fun `introspectToken returns Inactive when session exists but token cannot be decoded`() {
+        // Create a session with a known access token hash
+        val accessToken = "valid-access-token"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        // FakeTokenPort.decodeAccessToken returns null by default
+        tokens.claimsToReturn = null
+
+        val result = svc.introspectToken(tenantSlug = "acme", token = accessToken)
+        assertIs<IntrospectionResult.Inactive>(result)
+    }
+
+    @Test
+    fun `introspectToken returns Active with claims when session and token are valid`() {
+        val accessToken = "valid-access-token"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid profile",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val expiresAt = Instant.now().plusSeconds(3600).epochSecond
+        tokens.claimsToReturn = AccessTokenClaims(
+            sub = "10",
+            iss = "https://acme.example.com",
+            aud = "spa-app",
+            tenantId = 1,
+            username = "alice",
+            email = "alice@example.com",
+            scopes = listOf("openid", "profile"),
+            issuedAt = Instant.now().epochSecond,
+            expiresAt = expiresAt,
+        )
+
+        val result = svc.introspectToken(tenantSlug = "acme", token = accessToken)
+        assertIs<IntrospectionResult.Active>(result)
+        assertEquals("10", result.sub)
+        assertEquals("alice", result.username)
+        assertEquals("alice@example.com", result.email)
+        assertEquals(listOf("openid", "profile"), result.scopes)
+        assertEquals(expiresAt, result.expiresAt)
+    }
+
+    // =========================================================================
+    // revokeToken
+    // =========================================================================
+
+    @Test
+    fun `revokeToken - unknown token is a no-op`() {
+        svc.revokeToken("nonexistent-token")
+        // No exception — per RFC 7009 always returns success
+    }
+
+    @Test
+    fun `revokeToken - revokes session by access token`() {
+        val accessToken = "access-to-revoke"
+        val session = sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        svc.revokeToken(accessToken)
+
+        val revoked = sessions.findById(session.id!!)
+        assertNotNull(revoked)
+        assertNotNull(revoked.revokedAt, "Session should be revoked")
+        assertTrue(auditLog.hasEvent(AuditEventType.TOKEN_REVOKED))
+    }
+
+    @Test
+    fun `revokeToken - revokes session by refresh token`() {
+        val refreshToken = "refresh-to-revoke"
+        val session = sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256("some-access"),
+                refreshTokenHash = OAuthService.sha256(refreshToken),
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+                refreshExpiresAt = Instant.now().plusSeconds(86400),
+            ),
+        )
+
+        svc.revokeToken(refreshToken)
+
+        val revoked = sessions.findById(session.id!!)
+        assertNotNull(revoked)
+        assertNotNull(revoked.revokedAt, "Session should be revoked via refresh token")
+    }
+
+    // =========================================================================
+    // getUserInfo
+    // =========================================================================
+
+    @Test
+    fun `getUserInfo - returns null for unknown token`() {
+        assertNull(svc.getUserInfo("unknown-token"))
+    }
+
+    @Test
+    fun `getUserInfo - returns null for M2M session (no userId)`() {
+        val accessToken = "m2m-access"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = null,
+                clientId = confidentialClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        assertNull(svc.getUserInfo(accessToken))
+    }
+
+    @Test
+    fun `getUserInfo - returns null for disabled user`() {
+        val disabledUser = testUser.copy(id = 20, username = "bob", email = "bob@example.com", enabled = false)
+        users.add(disabledUser)
+        val accessToken = "disabled-user-access"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 20,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        assertNull(svc.getUserInfo(accessToken))
+    }
+
+    @Test
+    fun `getUserInfo - returns user claims for valid token`() {
+        val accessToken = "valid-userinfo-token"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid profile",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        val info = svc.getUserInfo(accessToken)
+        assertNotNull(info)
+        assertEquals("10", info.sub)
+        assertEquals("alice", info.username)
+        assertEquals("alice@example.com", info.email)
+        assertTrue(info.emailVerified.not(), "testUser has emailVerified=false by default")
+        assertEquals("Alice", info.name)
+    }
+
+    // =========================================================================
+    // endSession
+    // =========================================================================
+
+    @Test
+    fun `endSession - unknown token is a no-op`() {
+        svc.endSession(accessToken = "no-such-token")
+        // No exception
+    }
+
+    @Test
+    fun `endSession - revokes single session`() {
+        val accessToken = "session-to-end"
+        val session = sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        // Create a second session that should NOT be revoked
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256("other-access"),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        svc.endSession(accessToken = accessToken)
+
+        assertNotNull(sessions.findById(session.id!!)?.revokedAt, "Target session should be revoked")
+        assertEquals(1, sessions.findActiveByUser(1, 10).size, "Other session should remain active")
+        assertTrue(auditLog.hasEvent(AuditEventType.SESSION_REVOKED))
+    }
+
+    @Test
+    fun `endSession - revokeAll revokes all user sessions`() {
+        val accessToken = "session-global-logout"
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = publicClient.id,
+                accessTokenHash = OAuthService.sha256("other-access-2"),
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+
+        svc.endSession(accessToken = accessToken, revokeAll = true)
+
+        assertEquals(0, sessions.findActiveByUser(1, 10).size, "All sessions should be revoked for global logout")
+    }
+
+    // =========================================================================
+    // getJwks
+    // =========================================================================
+
+    @Test
+    fun `getJwks - delegates to tokenPort and returns empty by default`() {
+        val jwks = svc.getJwks(tenantId = 1)
+        assertTrue(jwks.isEmpty())
+    }
+
+    @Test
+    fun `getJwks - returns configured JWKS from tokenPort`() {
+        tokens.jwksToReturn = listOf(mapOf("kty" to "RSA", "kid" to "key-1", "use" to "sig"))
+        val jwks = svc.getJwks(tenantId = 1)
+        assertEquals(1, jwks.size)
+        assertEquals("RSA", jwks[0]["kty"])
+        assertEquals("key-1", jwks[0]["kid"])
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
@@ -1,0 +1,499 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.Group
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [RoleGroupService].
+ *
+ * Covers: role CRUD, composite roles (cycle detection), user-role assignment,
+ * group CRUD, group-role assignment, user-group membership.
+ */
+class RoleGroupServiceTest {
+    private val roles = FakeRoleRepository()
+    private val groups = FakeGroupRepository()
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val apps = FakeApplicationRepository()
+    private val auditLog = FakeAuditLogPort()
+    private val hasher = FakePasswordHasher()
+
+    private val svc =
+        RoleGroupService(
+            roleRepository = roles,
+            groupRepository = groups,
+            tenantRepository = tenants,
+            userRepository = users,
+            applicationRepository = apps,
+            auditLog = auditLog,
+        )
+
+    private val tenant =
+        Tenant(id = 1, slug = "acme", displayName = "Acme Corp", issuerUrl = null)
+
+    private val testApp =
+        Application(
+            id = 100, tenantId = 1, clientId = "my-app", name = "My App",
+            description = null, accessType = AccessType.CONFIDENTIAL, enabled = true,
+        )
+
+    private val alice
+        get() = User(
+            id = 10, tenantId = 1, username = "alice", email = "alice@example.com",
+            fullName = "Alice", passwordHash = hasher.hash("pass"),
+        )
+
+    private val bob
+        get() = User(
+            id = 11, tenantId = 1, username = "bob", email = "bob@example.com",
+            fullName = "Bob", passwordHash = hasher.hash("pass"),
+        )
+
+    @BeforeTest
+    fun setup() {
+        roles.clear()
+        groups.clear()
+        tenants.clear()
+        users.clear()
+        apps.clear()
+        auditLog.clear()
+        tenants.add(tenant)
+        apps.add(testApp)
+        users.add(alice)
+        users.add(bob)
+    }
+
+    // =========================================================================
+    // createRole
+    // =========================================================================
+
+    @Test
+    fun `createRole - blank name`() {
+        val result = svc.createRole(tenantId = 1, name = "  ", description = null, scope = RoleScope.TENANT, clientId = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createRole - invalid name characters`() {
+        val result = svc.createRole(tenantId = 1, name = "bad role!", description = null, scope = RoleScope.TENANT, clientId = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createRole - client scope without clientId`() {
+        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createRole - tenant scope with clientId`() {
+        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = 100)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createRole - client scope with unknown app`() {
+        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = 999)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `createRole - duplicate name`() {
+        svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
+        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `createRole - same name different scopes is allowed`() {
+        svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
+        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = 100)
+        assertIs<AdminResult.Success<Role>>(result)
+    }
+
+    @Test
+    fun `createRole - success tenant scoped`() {
+        val result = svc.createRole(tenantId = 1, name = "admin", description = "Admin role", scope = RoleScope.TENANT, clientId = null)
+        assertIs<AdminResult.Success<Role>>(result)
+        assertEquals("admin", result.value.name)
+        assertEquals(RoleScope.TENANT, result.value.scope)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_CREATED))
+    }
+
+    @Test
+    fun `createRole - success client scoped`() {
+        val result = svc.createRole(tenantId = 1, name = "editor", description = null, scope = RoleScope.CLIENT, clientId = 100)
+        assertIs<AdminResult.Success<Role>>(result)
+        assertEquals(100, result.value.clientId)
+    }
+
+    // =========================================================================
+    // updateRole
+    // =========================================================================
+
+    @Test
+    fun `updateRole - not found`() {
+        val result = svc.updateRole(roleId = 999, tenantId = 1, name = "X", description = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateRole - tenant mismatch`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.updateRole(roleId = role.id!!, tenantId = 99, name = "X", description = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateRole - name conflict`() {
+        svc.createRole(1, "admin", null, RoleScope.TENANT, null)
+        val editor = (svc.createRole(1, "editor", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.updateRole(roleId = editor.id!!, tenantId = 1, name = "admin", description = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `updateRole - success`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.updateRole(roleId = role.id!!, tenantId = 1, name = "super-admin", description = "Elevated")
+        assertIs<AdminResult.Success<Role>>(result)
+        assertEquals("super-admin", result.value.name)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_UPDATED))
+    }
+
+    // =========================================================================
+    // deleteRole
+    // =========================================================================
+
+    @Test
+    fun `deleteRole - not found`() {
+        val result = svc.deleteRole(roleId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `deleteRole - success`() {
+        val role = (svc.createRole(1, "temp", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.deleteRole(role.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_DELETED))
+    }
+
+    // =========================================================================
+    // listRoles / listClientRoles
+    // =========================================================================
+
+    @Test
+    fun `listRoles - returns all roles for tenant`() {
+        svc.createRole(1, "admin", null, RoleScope.TENANT, null)
+        svc.createRole(1, "editor", null, RoleScope.CLIENT, 100)
+        assertEquals(2, svc.listRoles(1).size)
+        assertEquals(0, svc.listRoles(99).size)
+    }
+
+    @Test
+    fun `listClientRoles - returns only client-scoped roles`() {
+        svc.createRole(1, "admin", null, RoleScope.TENANT, null)
+        svc.createRole(1, "editor", null, RoleScope.CLIENT, 100)
+        assertEquals(1, svc.listClientRoles(1, 100).size)
+    }
+
+    // =========================================================================
+    // Composite roles (addChildRole / removeChildRole)
+    // =========================================================================
+
+    @Test
+    fun `addChildRole - parent not found`() {
+        val child = (svc.createRole(1, "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.addChildRole(parentRoleId = 999, childRoleId = child.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `addChildRole - child not found`() {
+        val parent = (svc.createRole(1, "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.addChildRole(parentRoleId = parent.id!!, childRoleId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `addChildRole - self reference`() {
+        val role = (svc.createRole(1, "self", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.addChildRole(parentRoleId = role.id!!, childRoleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `addChildRole - cycle detection`() {
+        val a = (svc.createRole(1, "role-a", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val b = (svc.createRole(1, "role-b", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val c = (svc.createRole(1, "role-c", null, RoleScope.TENANT, null) as AdminResult.Success).value
+
+        // a -> b -> c, then try c -> a (would create cycle)
+        svc.addChildRole(a.id!!, b.id!!, 1)
+        svc.addChildRole(b.id!!, c.id!!, 1)
+        val result = svc.addChildRole(c.id!!, a.id!!, 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertTrue(result.error.message.contains("circular"))
+    }
+
+    @Test
+    fun `addChildRole - success`() {
+        val parent = (svc.createRole(1, "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val child = (svc.createRole(1, "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.addChildRole(parent.id!!, child.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+    }
+
+    @Test
+    fun `removeChildRole - success`() {
+        val parent = (svc.createRole(1, "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val child = (svc.createRole(1, "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        svc.addChildRole(parent.id!!, child.id!!, 1)
+        val result = svc.removeChildRole(parent.id!!, child.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+    }
+
+    // =========================================================================
+    // User ↔ Role assignment
+    // =========================================================================
+
+    @Test
+    fun `assignRoleToUser - user not found`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.assignRoleToUser(userId = 999, roleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `assignRoleToUser - role not found`() {
+        val result = svc.assignRoleToUser(userId = 10, roleId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `assignRoleToUser - tenant mismatch`() {
+        val otherTenant = tenants.add(Tenant(id = 50, slug = "other", displayName = "Other", issuerUrl = null))
+        val role = roles.add(Role(tenantId = otherTenant.id, name = "admin", scope = RoleScope.TENANT))
+        val result = svc.assignRoleToUser(userId = 10, roleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `assignRoleToUser - success`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.assignRoleToUser(userId = 10, roleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(1, svc.getRolesForUser(10).size)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_ASSIGNED))
+    }
+
+    @Test
+    fun `unassignRoleFromUser - success`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        svc.assignRoleToUser(userId = 10, roleId = role.id!!, tenantId = 1)
+        val result = svc.unassignRoleFromUser(userId = 10, roleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(0, svc.getRolesForUser(10).size)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_UNASSIGNED))
+    }
+
+    @Test
+    fun `getEffectiveRolesForUser - includes composite children`() {
+        val parent = (svc.createRole(1, "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val child = (svc.createRole(1, "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        svc.addChildRole(parent.id!!, child.id!!, 1)
+        svc.assignRoleToUser(10, parent.id!!, 1)
+        val effective = svc.getEffectiveRolesForUser(10, 1)
+        assertEquals(2, effective.size, "Should include parent + child")
+        assertTrue(effective.any { it.name == "parent" })
+        assertTrue(effective.any { it.name == "child" })
+    }
+
+    // =========================================================================
+    // createGroup
+    // =========================================================================
+
+    @Test
+    fun `createGroup - blank name`() {
+        val result = svc.createGroup(tenantId = 1, name = "  ", description = null, parentGroupId = null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createGroup - invalid parent`() {
+        val result = svc.createGroup(tenantId = 1, name = "child", description = null, parentGroupId = 999)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `createGroup - duplicate name at same level`() {
+        svc.createGroup(1, "engineering", null, null)
+        val result = svc.createGroup(1, "engineering", null, null)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `createGroup - same name under different parents is allowed`() {
+        val parent1 = (svc.createGroup(1, "team-a", null, null) as AdminResult.Success).value
+        val parent2 = (svc.createGroup(1, "team-b", null, null) as AdminResult.Success).value
+        svc.createGroup(1, "devs", null, parent1.id)
+        val result = svc.createGroup(1, "devs", null, parent2.id)
+        assertIs<AdminResult.Success<Group>>(result)
+    }
+
+    @Test
+    fun `createGroup - success`() {
+        val result = svc.createGroup(1, "engineering", "Engineering team", null)
+        assertIs<AdminResult.Success<Group>>(result)
+        assertEquals("engineering", result.value.name)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_CREATED))
+    }
+
+    // =========================================================================
+    // updateGroup
+    // =========================================================================
+
+    @Test
+    fun `updateGroup - not found`() {
+        val result = svc.updateGroup(groupId = 999, tenantId = 1, name = "X", description = null)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `updateGroup - success`() {
+        val group = (svc.createGroup(1, "old-name", null, null) as AdminResult.Success).value
+        val result = svc.updateGroup(group.id!!, 1, "new-name", "Updated")
+        assertIs<AdminResult.Success<Group>>(result)
+        assertEquals("new-name", result.value.name)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_UPDATED))
+    }
+
+    // =========================================================================
+    // deleteGroup
+    // =========================================================================
+
+    @Test
+    fun `deleteGroup - not found`() {
+        val result = svc.deleteGroup(groupId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `deleteGroup - success`() {
+        val group = (svc.createGroup(1, "temp", null, null) as AdminResult.Success).value
+        val result = svc.deleteGroup(group.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_DELETED))
+    }
+
+    // =========================================================================
+    // Group ↔ Role assignment
+    // =========================================================================
+
+    @Test
+    fun `assignRoleToGroup - group not found`() {
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.assignRoleToGroup(groupId = 999, roleId = role.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `assignRoleToGroup - role not found`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        val result = svc.assignRoleToGroup(groupId = group.id!!, roleId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `assignRoleToGroup - success`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        val result = svc.assignRoleToGroup(group.id!!, role.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_ROLE_ASSIGNED))
+    }
+
+    @Test
+    fun `unassignRoleFromGroup - success`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        val role = (svc.createRole(1, "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
+        svc.assignRoleToGroup(group.id!!, role.id!!, 1)
+        val result = svc.unassignRoleFromGroup(group.id!!, role.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+    }
+
+    // =========================================================================
+    // User ↔ Group membership
+    // =========================================================================
+
+    @Test
+    fun `addUserToGroup - user not found`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        val result = svc.addUserToGroup(userId = 999, groupId = group.id!!, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `addUserToGroup - group not found`() {
+        val result = svc.addUserToGroup(userId = 10, groupId = 999, tenantId = 1)
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `addUserToGroup - success`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        val result = svc.addUserToGroup(10, group.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(1, svc.getGroupsForUser(10).size)
+        assertEquals(1, svc.getUserIdsInGroup(group.id!!).size)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_MEMBER_ADDED))
+    }
+
+    @Test
+    fun `removeUserFromGroup - success`() {
+        val group = (svc.createGroup(1, "eng", null, null) as AdminResult.Success).value
+        svc.addUserToGroup(10, group.id!!, 1)
+        val result = svc.removeUserFromGroup(10, group.id!!, 1)
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(0, svc.getGroupsForUser(10).size)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_MEMBER_REMOVED))
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
@@ -51,21 +51,36 @@ class RoleGroupServiceTest {
 
     private val testApp =
         Application(
-            id = 100, tenantId = 1, clientId = "my-app", name = "My App",
-            description = null, accessType = AccessType.CONFIDENTIAL, enabled = true,
+            id = 100,
+            tenantId = 1,
+            clientId = "my-app",
+            name = "My App",
+            description = null,
+            accessType = AccessType.CONFIDENTIAL,
+            enabled = true,
         )
 
     private val alice
-        get() = User(
-            id = 10, tenantId = 1, username = "alice", email = "alice@example.com",
-            fullName = "Alice", passwordHash = hasher.hash("pass"),
-        )
+        get() =
+            User(
+                id = 10,
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                fullName = "Alice",
+                passwordHash = hasher.hash("pass"),
+            )
 
     private val bob
-        get() = User(
-            id = 11, tenantId = 1, username = "bob", email = "bob@example.com",
-            fullName = "Bob", passwordHash = hasher.hash("pass"),
-        )
+        get() =
+            User(
+                id = 11,
+                tenantId = 1,
+                username = "bob",
+                email = "bob@example.com",
+                fullName = "Bob",
+                passwordHash = hasher.hash("pass"),
+            )
 
     @BeforeTest
     fun setup() {
@@ -87,35 +102,70 @@ class RoleGroupServiceTest {
 
     @Test
     fun `createRole - blank name`() {
-        val result = svc.createRole(tenantId = 1, name = "  ", description = null, scope = RoleScope.TENANT, clientId = null)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "  ",
+                description = null,
+                scope = RoleScope.TENANT,
+                clientId = null,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createRole - invalid name characters`() {
-        val result = svc.createRole(tenantId = 1, name = "bad role!", description = null, scope = RoleScope.TENANT, clientId = null)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "bad role!",
+                description = null,
+                scope = RoleScope.TENANT,
+                clientId = null,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createRole - client scope without clientId`() {
-        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = null)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = null,
+                scope = RoleScope.CLIENT,
+                clientId = null,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createRole - tenant scope with clientId`() {
-        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = 100)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = null,
+                scope = RoleScope.TENANT,
+                clientId = 100,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
 
     @Test
     fun `createRole - client scope with unknown app`() {
-        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = 999)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = null,
+                scope = RoleScope.CLIENT,
+                clientId = 999,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.NotFound>(result.error)
     }
@@ -123,7 +173,14 @@ class RoleGroupServiceTest {
     @Test
     fun `createRole - duplicate name`() {
         svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
-        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = null,
+                scope = RoleScope.TENANT,
+                clientId = null,
+            )
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Conflict>(result.error)
     }
@@ -131,13 +188,27 @@ class RoleGroupServiceTest {
     @Test
     fun `createRole - same name different scopes is allowed`() {
         svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.TENANT, clientId = null)
-        val result = svc.createRole(tenantId = 1, name = "admin", description = null, scope = RoleScope.CLIENT, clientId = 100)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = null,
+                scope = RoleScope.CLIENT,
+                clientId = 100,
+            )
         assertIs<AdminResult.Success<Role>>(result)
     }
 
     @Test
     fun `createRole - success tenant scoped`() {
-        val result = svc.createRole(tenantId = 1, name = "admin", description = "Admin role", scope = RoleScope.TENANT, clientId = null)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "admin",
+                description = "Admin role",
+                scope = RoleScope.TENANT,
+                clientId = null,
+            )
         assertIs<AdminResult.Success<Role>>(result)
         assertEquals("admin", result.value.name)
         assertEquals(RoleScope.TENANT, result.value.scope)
@@ -146,7 +217,14 @@ class RoleGroupServiceTest {
 
     @Test
     fun `createRole - success client scoped`() {
-        val result = svc.createRole(tenantId = 1, name = "editor", description = null, scope = RoleScope.CLIENT, clientId = 100)
+        val result =
+            svc.createRole(
+                tenantId = 1,
+                name = "editor",
+                description = null,
+                scope = RoleScope.CLIENT,
+                clientId = 100,
+            )
         assertIs<AdminResult.Success<Role>>(result)
         assertEquals(100, result.value.clientId)
     }

--- a/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
@@ -1,0 +1,430 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.User
+import com.kauth.domain.port.SocialUserProfile
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeIdentityProviderRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeSocialAccountRepository
+import com.kauth.fakes.FakeSocialProviderPort
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [SocialLoginService].
+ *
+ * Covers: buildRedirectUrl, handleCallback, completeSocialRegistration.
+ * All provider HTTP calls replaced by FakeSocialProviderPort.
+ */
+class SocialLoginServiceTest {
+    private val idpRepo = FakeIdentityProviderRepository()
+    private val socialAccounts = FakeSocialAccountRepository()
+    private val users = FakeUserRepository()
+    private val tenants = FakeTenantRepository()
+    private val sessions = FakeSessionRepository()
+    private val tokens = FakeTokenPort()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val googleAdapter = FakeSocialProviderPort(SocialProvider.GOOGLE)
+    private val githubAdapter = FakeSocialProviderPort(SocialProvider.GITHUB)
+
+    private val svc =
+        SocialLoginService(
+            identityProviderRepository = idpRepo,
+            socialAccountRepository = socialAccounts,
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            tokenPort = tokens,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            providerAdapters = mapOf(
+                SocialProvider.GOOGLE to googleAdapter,
+                SocialProvider.GITHUB to githubAdapter,
+            ),
+        )
+
+    private val tenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            registrationEnabled = true,
+        )
+
+    private val googleIdp =
+        IdentityProvider(
+            tenantId = 1,
+            provider = SocialProvider.GOOGLE,
+            clientId = "google-client-id",
+            clientSecret = "google-secret",
+            enabled = true,
+        )
+
+    private val alice
+        get() =
+            User(
+                id = 10,
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                fullName = "Alice Test",
+                passwordHash = hasher.hash("pass"),
+                emailVerified = true,
+                enabled = true,
+            )
+
+    private val disabledUser
+        get() =
+            User(
+                id = 11,
+                tenantId = 1,
+                username = "disabled",
+                email = "disabled@example.com",
+                fullName = "Disabled",
+                passwordHash = hasher.hash("pass"),
+                enabled = false,
+            )
+
+    private val googleProfile =
+        SocialUserProfile(
+            providerUserId = "google-uid-123",
+            email = "alice@example.com",
+            name = "Alice Google",
+            emailVerified = true,
+            avatarUrl = "https://avatar.example.com/alice.jpg",
+        )
+
+    @BeforeTest
+    fun setup() {
+        idpRepo.clear()
+        socialAccounts.clear()
+        users.clear()
+        tenants.clear()
+        sessions.clear()
+        tokens.reset()
+        auditLog.clear()
+        googleAdapter.clear()
+        githubAdapter.clear()
+        tenants.add(tenant)
+        idpRepo.add(googleIdp)
+        users.add(alice)
+        users.add(disabledUser)
+        googleAdapter.profileToReturn = googleProfile
+    }
+
+    // =========================================================================
+    // buildRedirectUrl
+    // =========================================================================
+
+    @Test
+    fun `buildRedirectUrl - tenant not found`() {
+        val result = svc.buildRedirectUrl("unknown", SocialProvider.GOOGLE, "state123", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.TenantNotFound, result.error)
+    }
+
+    @Test
+    fun `buildRedirectUrl - provider not configured for tenant`() {
+        val result = svc.buildRedirectUrl("acme", SocialProvider.GITHUB, "state123", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.ProviderNotConfigured, result.error)
+    }
+
+    @Test
+    fun `buildRedirectUrl - disabled provider`() {
+        idpRepo.add(
+            IdentityProvider(
+                tenantId = 1,
+                provider = SocialProvider.GITHUB,
+                clientId = "gh-id",
+                clientSecret = "gh-secret",
+                enabled = false,
+            ),
+        )
+        val result = svc.buildRedirectUrl("acme", SocialProvider.GITHUB, "state123", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.ProviderNotConfigured, result.error)
+    }
+
+    @Test
+    fun `buildRedirectUrl - success returns authorization URL`() {
+        val result = svc.buildRedirectUrl("acme", SocialProvider.GOOGLE, "state123", "http://localhost")
+        assertIs<SocialLoginResult.Success<String>>(result)
+        assertTrue(result.value.contains("client_id=google-client-id"))
+        assertTrue(result.value.contains("state=state123"))
+        assertTrue(result.value.contains("/t/acme/auth/social/google/callback"))
+    }
+
+    // =========================================================================
+    // handleCallback
+    // =========================================================================
+
+    @Test
+    fun `handleCallback - tenant not found`() {
+        val result = svc.handleCallback("unknown", SocialProvider.GOOGLE, "code", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.TenantNotFound, result.error)
+    }
+
+    @Test
+    fun `handleCallback - provider not configured`() {
+        val result = svc.handleCallback("acme", SocialProvider.GITHUB, "code", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.ProviderNotConfigured, result.error)
+    }
+
+    @Test
+    fun `handleCallback - provider exchange fails`() {
+        googleAdapter.shouldFail = true
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "bad-code", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertIs<SocialLoginError.ProviderError>(result.error)
+    }
+
+    @Test
+    fun `handleCallback - provider returns no email`() {
+        googleAdapter.profileToReturn = googleProfile.copy(email = null)
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.EmailNotProvided, result.error)
+    }
+
+    @Test
+    fun `handleCallback - existing user via email match auto-links and issues tokens`() {
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost", "1.2.3.4")
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals("alice", result.value.user.username)
+        assertNotNull(result.value.tokens.access_token)
+        assertEquals(1, socialAccounts.all().size, "Social account should be auto-linked")
+        assertEquals(1, sessions.all().size)
+        assertTrue(auditLog.hasEvent(AuditEventType.LOGIN_SUCCESS))
+    }
+
+    @Test
+    fun `handleCallback - existing user via social account link`() {
+        socialAccounts.save(
+            com.kauth.domain.model.SocialAccount(
+                userId = 10,
+                tenantId = 1,
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "google-uid-123",
+                providerEmail = "alice@example.com",
+                providerName = "Alice",
+            ),
+        )
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost")
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals("alice", result.value.user.username)
+    }
+
+    @Test
+    fun `handleCallback - disabled user returns UserDisabled`() {
+        googleAdapter.profileToReturn = googleProfile.copy(email = "disabled@example.com", providerUserId = "google-disabled")
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost")
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.UserDisabled, result.error)
+        assertTrue(auditLog.hasEvent(AuditEventType.LOGIN_FAILED))
+    }
+
+    @Test
+    fun `handleCallback - no existing user returns NeedsRegistration`() {
+        googleAdapter.profileToReturn =
+            SocialUserProfile(
+                providerUserId = "new-google-uid",
+                email = "newuser@example.com",
+                name = "New User",
+                emailVerified = true,
+            )
+        val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost")
+        assertIs<SocialLoginResult.NeedsRegistration>(result)
+        assertEquals("newuser@example.com", result.data.email)
+        assertEquals("new-google-uid", result.data.providerUserId)
+        assertEquals(SocialProvider.GOOGLE, result.data.provider)
+    }
+
+    // =========================================================================
+    // completeSocialRegistration
+    // =========================================================================
+
+    @Test
+    fun `completeSocialRegistration - tenant not found`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "unknown",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "uid",
+            email = "new@example.com",
+            providerName = "New",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "newuser",
+        )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.TenantNotFound, result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - registration disabled`() {
+        tenants.clear()
+        tenants.add(tenant.copy(registrationEnabled = false))
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "uid",
+            email = "new@example.com",
+            providerName = "New",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "newuser",
+        )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.RegistrationDisabled, result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - username too short`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "uid",
+            email = "new@example.com",
+            providerName = "New",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "ab",
+        )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertIs<SocialLoginError.InvalidUsername>(result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - username with invalid characters`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "uid",
+            email = "new@example.com",
+            providerName = "New",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "bad user!",
+        )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertIs<SocialLoginError.InvalidUsername>(result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - race condition existing link reuses user`() {
+        socialAccounts.save(
+            com.kauth.domain.model.SocialAccount(
+                userId = 10,
+                tenantId = 1,
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "race-uid",
+                providerEmail = "alice@example.com",
+                providerName = "Alice",
+            ),
+        )
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "race-uid",
+            email = "alice@example.com",
+            providerName = "Alice",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "newname",
+        )
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals("alice", result.value.user.username, "Should reuse existing user, not create new")
+    }
+
+    @Test
+    fun `completeSocialRegistration - race condition email match auto-links`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "new-uid",
+            email = "alice@example.com",
+            providerName = "Alice",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "newname",
+        )
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals("alice", result.value.user.username, "Should auto-link to existing user by email")
+        assertEquals(1, socialAccounts.all().size)
+    }
+
+    @Test
+    fun `completeSocialRegistration - username conflict`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "brand-new-uid",
+            email = "brand-new@example.com",
+            providerName = "Brand New",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "alice", // already taken
+        )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertEquals(SocialLoginError.UsernameConflict, result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - success creates user and social link`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "new-uid-999",
+            email = "brand-new@example.com",
+            providerName = "Brand New User",
+            avatarUrl = "https://avatar.example.com/new.jpg",
+            emailVerified = true,
+            chosenUsername = "brandnew",
+            ipAddress = "1.2.3.4",
+            userAgent = "TestAgent",
+        )
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertTrue(result.value.isNewUser)
+        assertEquals("brandnew", result.value.user.username)
+        assertEquals("brand-new@example.com", result.value.user.email)
+        assertEquals(true, result.value.user.emailVerified, "Provider-verified email should be trusted")
+        assertNotNull(result.value.tokens.access_token)
+        val newSocialAccount = socialAccounts.all().find { it.providerUserId == "new-uid-999" }
+        assertNotNull(newSocialAccount, "Social account link should be created")
+        assertEquals("brandnew", users.findById(newSocialAccount.userId)?.username)
+        assertTrue(auditLog.hasEvent(AuditEventType.LOGIN_SUCCESS))
+        assertEquals(1, sessions.all().size)
+    }
+
+    @Test
+    fun `completeSocialRegistration - unverified email propagated`() {
+        val result = svc.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "unverified-uid",
+            email = "unverified@example.com",
+            providerName = "Unverified",
+            avatarUrl = null,
+            emailVerified = false,
+            chosenUsername = "unverified_user",
+        )
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals(false, result.value.user.emailVerified, "Unverified email should not be marked as verified")
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
@@ -50,10 +50,11 @@ class SocialLoginServiceTest {
             tokenPort = tokens,
             passwordHasher = hasher,
             auditLog = auditLog,
-            providerAdapters = mapOf(
-                SocialProvider.GOOGLE to googleAdapter,
-                SocialProvider.GITHUB to githubAdapter,
-            ),
+            providerAdapters =
+                mapOf(
+                    SocialProvider.GOOGLE to googleAdapter,
+                    SocialProvider.GITHUB to githubAdapter,
+                ),
         )
 
     private val tenant =
@@ -233,7 +234,8 @@ class SocialLoginServiceTest {
 
     @Test
     fun `handleCallback - disabled user returns UserDisabled`() {
-        googleAdapter.profileToReturn = googleProfile.copy(email = "disabled@example.com", providerUserId = "google-disabled")
+        googleAdapter.profileToReturn =
+            googleProfile.copy(email = "disabled@example.com", providerUserId = "google-disabled")
         val result = svc.handleCallback("acme", SocialProvider.GOOGLE, "code", "http://localhost")
         assertIs<SocialLoginResult.Failure>(result)
         assertEquals(SocialLoginError.UserDisabled, result.error)
@@ -262,16 +264,17 @@ class SocialLoginServiceTest {
 
     @Test
     fun `completeSocialRegistration - tenant not found`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "unknown",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "uid",
-            email = "new@example.com",
-            providerName = "New",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "newuser",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "unknown",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "uid",
+                email = "new@example.com",
+                providerName = "New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "newuser",
+            )
         assertIs<SocialLoginResult.Failure>(result)
         assertEquals(SocialLoginError.TenantNotFound, result.error)
     }
@@ -280,48 +283,51 @@ class SocialLoginServiceTest {
     fun `completeSocialRegistration - registration disabled`() {
         tenants.clear()
         tenants.add(tenant.copy(registrationEnabled = false))
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "uid",
-            email = "new@example.com",
-            providerName = "New",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "newuser",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "uid",
+                email = "new@example.com",
+                providerName = "New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "newuser",
+            )
         assertIs<SocialLoginResult.Failure>(result)
         assertEquals(SocialLoginError.RegistrationDisabled, result.error)
     }
 
     @Test
     fun `completeSocialRegistration - username too short`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "uid",
-            email = "new@example.com",
-            providerName = "New",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "ab",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "uid",
+                email = "new@example.com",
+                providerName = "New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "ab",
+            )
         assertIs<SocialLoginResult.Failure>(result)
         assertIs<SocialLoginError.InvalidUsername>(result.error)
     }
 
     @Test
     fun `completeSocialRegistration - username with invalid characters`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "uid",
-            email = "new@example.com",
-            providerName = "New",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "bad user!",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "uid",
+                email = "new@example.com",
+                providerName = "New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "bad user!",
+            )
         assertIs<SocialLoginResult.Failure>(result)
         assertIs<SocialLoginError.InvalidUsername>(result.error)
     }
@@ -338,32 +344,34 @@ class SocialLoginServiceTest {
                 providerName = "Alice",
             ),
         )
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "race-uid",
-            email = "alice@example.com",
-            providerName = "Alice",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "newname",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "race-uid",
+                email = "alice@example.com",
+                providerName = "Alice",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "newname",
+            )
         assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
         assertEquals("alice", result.value.user.username, "Should reuse existing user, not create new")
     }
 
     @Test
     fun `completeSocialRegistration - race condition email match auto-links`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "new-uid",
-            email = "alice@example.com",
-            providerName = "Alice",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "newname",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "new-uid",
+                email = "alice@example.com",
+                providerName = "Alice",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "newname",
+            )
         assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
         assertEquals("alice", result.value.user.username, "Should auto-link to existing user by email")
         assertEquals(1, socialAccounts.all().size)
@@ -371,34 +379,36 @@ class SocialLoginServiceTest {
 
     @Test
     fun `completeSocialRegistration - username conflict`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "brand-new-uid",
-            email = "brand-new@example.com",
-            providerName = "Brand New",
-            avatarUrl = null,
-            emailVerified = true,
-            chosenUsername = "alice", // already taken
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "brand-new-uid",
+                email = "brand-new@example.com",
+                providerName = "Brand New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "alice", // already taken
+            )
         assertIs<SocialLoginResult.Failure>(result)
         assertEquals(SocialLoginError.UsernameConflict, result.error)
     }
 
     @Test
     fun `completeSocialRegistration - success creates user and social link`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "new-uid-999",
-            email = "brand-new@example.com",
-            providerName = "Brand New User",
-            avatarUrl = "https://avatar.example.com/new.jpg",
-            emailVerified = true,
-            chosenUsername = "brandnew",
-            ipAddress = "1.2.3.4",
-            userAgent = "TestAgent",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "new-uid-999",
+                email = "brand-new@example.com",
+                providerName = "Brand New User",
+                avatarUrl = "https://avatar.example.com/new.jpg",
+                emailVerified = true,
+                chosenUsername = "brandnew",
+                ipAddress = "1.2.3.4",
+                userAgent = "TestAgent",
+            )
         assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
         assertTrue(result.value.isNewUser)
         assertEquals("brandnew", result.value.user.username)
@@ -414,16 +424,17 @@ class SocialLoginServiceTest {
 
     @Test
     fun `completeSocialRegistration - unverified email propagated`() {
-        val result = svc.completeSocialRegistration(
-            tenantSlug = "acme",
-            provider = SocialProvider.GOOGLE,
-            providerUserId = "unverified-uid",
-            email = "unverified@example.com",
-            providerName = "Unverified",
-            avatarUrl = null,
-            emailVerified = false,
-            chosenUsername = "unverified_user",
-        )
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "unverified-uid",
+                email = "unverified@example.com",
+                providerName = "Unverified",
+                avatarUrl = null,
+                emailVerified = false,
+                chosenUsername = "unverified_user",
+            )
         assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
         assertEquals(false, result.value.user.emailVerified, "Unverified email should not be marked as verified")
     }

--- a/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
@@ -172,7 +172,12 @@ class UserSelfServiceServiceTest {
                     passwordHash = hasher.hash("pass"),
                 ),
             )
-        val result = svc.initiateEmailVerification(userId = userInNoSmtp.id!!, tenantId = 2, baseUrl = "http://localhost")
+        val result =
+            svc.initiateEmailVerification(
+                userId = userInNoSmtp.id!!,
+                tenantId = 2,
+                baseUrl = "http://localhost",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.SmtpNotConfigured>(result.error)
     }
@@ -528,7 +533,13 @@ class UserSelfServiceServiceTest {
     @Test
     fun `updateProfile - email change resets emailVerified`() {
         // Start with verified user
-        val result = svc.updateProfile(userId = 11, tenantId = 1, email = "newemail@example.com", fullName = "Verified Alice")
+        val result =
+            svc.updateProfile(
+                userId = 11,
+                tenantId = 1,
+                email = "newemail@example.com",
+                fullName = "Verified Alice",
+            )
         assertIs<SelfServiceResult.Success<User>>(result)
         assertEquals(false, result.value.emailVerified, "Email change should reset verification")
         assertEquals("newemail@example.com", result.value.email)
@@ -554,28 +565,56 @@ class UserSelfServiceServiceTest {
 
     @Test
     fun `changePassword - tenant not found`() {
-        val result = svc.changePassword(userId = 10, tenantId = 999, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 999,
+                currentPassword = "current-pass",
+                newPassword = "new-pass-123",
+                confirmPassword = "new-pass-123",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.NotFound>(result.error)
     }
 
     @Test
     fun `changePassword - user not found`() {
-        val result = svc.changePassword(userId = 999, tenantId = 1, currentPassword = "x", newPassword = "y", confirmPassword = "y")
+        val result =
+            svc.changePassword(
+                userId = 999,
+                tenantId = 1,
+                currentPassword = "x",
+                newPassword = "y",
+                confirmPassword = "y",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.NotFound>(result.error)
     }
 
     @Test
     fun `changePassword - tenant mismatch`() {
-        val result = svc.changePassword(userId = 10, tenantId = 2, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 2,
+                currentPassword = "current-pass",
+                newPassword = "new-pass-123",
+                confirmPassword = "new-pass-123",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Unauthorized>(result.error)
     }
 
     @Test
     fun `changePassword - wrong current password`() {
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "wrong", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "wrong",
+                newPassword = "new-pass-123",
+                confirmPassword = "new-pass-123",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
         assertTrue(result.error.message.contains("incorrect"))
@@ -583,14 +622,28 @@ class UserSelfServiceServiceTest {
 
     @Test
     fun `changePassword - blank new password`() {
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "  ", confirmPassword = "  ")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "  ",
+                confirmPassword = "  ",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
     }
 
     @Test
     fun `changePassword - passwords do not match`() {
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "different")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "new-pass-123",
+                confirmPassword = "different",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
     }
@@ -598,7 +651,14 @@ class UserSelfServiceServiceTest {
     @Test
     fun `changePassword - policy violation`() {
         passwordPolicy.validationError = "Must include special char"
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "newpassword", confirmPassword = "newpassword")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "newpassword",
+                confirmPassword = "newpassword",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
     }
@@ -606,7 +666,14 @@ class UserSelfServiceServiceTest {
     @Test
     fun `changePassword - password in history`() {
         passwordPolicy.recordPasswordHistory(10, 1, hasher.hash("reused-pass"))
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "reused-pass", confirmPassword = "reused-pass")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "reused-pass",
+                confirmPassword = "reused-pass",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
         assertTrue(result.error.message.contains("recently"))
@@ -614,7 +681,14 @@ class UserSelfServiceServiceTest {
 
     @Test
     fun `changePassword - no policy port falls back to minLength`() {
-        val result = svcNoPolicyPort.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "short", confirmPassword = "short")
+        val result =
+            svcNoPolicyPort.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "short",
+                confirmPassword = "short",
+            )
         assertIs<SelfServiceResult.Failure>(result)
         assertIs<SelfServiceError.Validation>(result.error)
         assertTrue(result.error.message.contains("at least"))
@@ -633,7 +707,14 @@ class UserSelfServiceServiceTest {
                 expiresAt = Instant.now().plusSeconds(3600),
             ),
         )
-        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "brand-new-pass", confirmPassword = "brand-new-pass")
+        val result =
+            svc.changePassword(
+                userId = 10,
+                tenantId = 1,
+                currentPassword = "current-pass",
+                newPassword = "brand-new-pass",
+                confirmPassword = "brand-new-pass",
+            )
         assertIs<SelfServiceResult.Success<Unit>>(result)
         assertEquals("hashed:brand-new-pass", users.findById(10)!!.passwordHash)
         assertTrue(sessions.findActiveByUser(1, 10).isEmpty(), "All sessions should be revoked")
@@ -647,13 +728,37 @@ class UserSelfServiceServiceTest {
     @Test
     fun `getActiveSessions - returns active sessions for user`() {
         sessions.save(
-            Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "h1",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
         )
         sessions.save(
-            Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h2", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "h2",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
         )
         sessions.save(
-            Session(tenantId = 1, userId = 11, clientId = null, accessTokenHash = "h3", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            Session(
+                tenantId = 1,
+                userId = 11,
+                clientId = null,
+                accessTokenHash = "h3",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
         )
         val result = svc.getActiveSessions(userId = 10, tenantId = 1)
         assertEquals(2, result.size)
@@ -674,7 +779,15 @@ class UserSelfServiceServiceTest {
     fun `revokeSession - cannot revoke another users session`() {
         val session =
             sessions.save(
-                Session(tenantId = 1, userId = 11, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+                Session(
+                    tenantId = 1,
+                    userId = 11,
+                    clientId = null,
+                    accessTokenHash = "h1",
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
             )
         val result = svc.revokeSession(userId = 10, tenantId = 1, sessionId = session.id!!)
         assertIs<SelfServiceResult.Failure>(result)
@@ -685,7 +798,15 @@ class UserSelfServiceServiceTest {
     fun `revokeSession - cannot revoke session from different tenant`() {
         val session =
             sessions.save(
-                Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    accessTokenHash = "h1",
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
             )
         val result = svc.revokeSession(userId = 10, tenantId = 2, sessionId = session.id!!)
         assertIs<SelfServiceResult.Failure>(result)
@@ -696,7 +817,15 @@ class UserSelfServiceServiceTest {
     fun `revokeSession - success revokes and records audit`() {
         val session =
             sessions.save(
-                Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+                Session(
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    accessTokenHash = "h1",
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
             )
         val result = svc.revokeSession(userId = 10, tenantId = 1, sessionId = session.id!!)
         assertIs<SelfServiceResult.Success<Unit>>(result)

--- a/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
@@ -1,0 +1,718 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.EmailVerificationToken
+import com.kauth.domain.model.PasswordResetToken
+import com.kauth.domain.model.Session
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordPolicyPort
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import java.security.MessageDigest
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [UserSelfServiceService].
+ *
+ * Covers: email verification, forgot password, profile update, password change, session management.
+ * All I/O replaced by in-memory fakes.
+ */
+class UserSelfServiceServiceTest {
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val sessions = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val evTokenRepo = FakeEmailVerificationTokenRepository()
+    private val prTokenRepo = FakePasswordResetTokenRepository()
+    private val emailPort = FakeEmailPort()
+    private val passwordPolicy = FakePasswordPolicyPort()
+
+    private val svc =
+        UserSelfServiceService(
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = evTokenRepo,
+            prTokenRepo = prTokenRepo,
+            emailPort = emailPort,
+            passwordPolicy = passwordPolicy,
+        )
+
+    // Service instance WITHOUT password policy (fallback to minLength check)
+    private val svcNoPolicyPort =
+        UserSelfServiceService(
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = evTokenRepo,
+            prTokenRepo = prTokenRepo,
+            emailPort = emailPort,
+            passwordPolicy = null,
+        )
+
+    private val smtpTenant =
+        Tenant(
+            id = 1,
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+            smtpHost = "smtp.example.com",
+            smtpFromAddress = "no-reply@acme.com",
+            smtpEnabled = true,
+            passwordPolicyMinLength = 8,
+            passwordPolicyHistoryCount = 3,
+        )
+
+    private val noSmtpTenant =
+        Tenant(
+            id = 2,
+            slug = "no-smtp",
+            displayName = "No SMTP",
+            issuerUrl = null,
+        )
+
+    private val alice
+        get() =
+            User(
+                id = 10,
+                tenantId = 1,
+                username = "alice",
+                email = "alice@example.com",
+                fullName = "Alice Test",
+                passwordHash = hasher.hash("current-pass"),
+                emailVerified = false,
+            )
+
+    private val verifiedAlice
+        get() =
+            User(
+                id = 11,
+                tenantId = 1,
+                username = "verified-alice",
+                email = "verified@example.com",
+                fullName = "Verified Alice",
+                passwordHash = hasher.hash("current-pass"),
+                emailVerified = true,
+            )
+
+    private val disabledUser
+        get() =
+            User(
+                id = 12,
+                tenantId = 1,
+                username = "disabled",
+                email = "disabled@example.com",
+                fullName = "Disabled User",
+                passwordHash = hasher.hash("pass"),
+                enabled = false,
+            )
+
+    @BeforeTest
+    fun setup() {
+        tenants.clear()
+        users.clear()
+        sessions.clear()
+        auditLog.clear()
+        evTokenRepo.clear()
+        prTokenRepo.clear()
+        emailPort.clear()
+        passwordPolicy.clear()
+        tenants.add(smtpTenant)
+        tenants.add(noSmtpTenant)
+        users.add(alice)
+        users.add(verifiedAlice)
+        users.add(disabledUser)
+    }
+
+    // =========================================================================
+    // initiateEmailVerification
+    // =========================================================================
+
+    @Test
+    fun `initiateEmailVerification - tenant not found`() {
+        val result = svc.initiateEmailVerification(userId = 10, tenantId = 999, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `initiateEmailVerification - user not found`() {
+        val result = svc.initiateEmailVerification(userId = 999, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `initiateEmailVerification - smtp not configured`() {
+        val result = svc.initiateEmailVerification(userId = 10, tenantId = 2, baseUrl = "http://localhost")
+        // alice is tenantId=1 but we're asking about tenantId=2 (no-smtp) — user won't be found,
+        // but the tenant check happens first. Let's use a user in tenant 2.
+        val userInNoSmtp =
+            users.add(
+                User(
+                    tenantId = 2,
+                    username = "bob",
+                    email = "bob@example.com",
+                    fullName = "Bob",
+                    passwordHash = hasher.hash("pass"),
+                ),
+            )
+        val r = svc.initiateEmailVerification(userId = userInNoSmtp.id!!, tenantId = 2, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Failure>(r)
+        assertIs<SelfServiceError.SmtpNotConfigured>(r.error)
+    }
+
+    @Test
+    fun `initiateEmailVerification - already verified returns success noop`() {
+        val result = svc.initiateEmailVerification(userId = 11, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(emailPort.sent.isEmpty(), "No email should be sent for already-verified user")
+    }
+
+    @Test
+    fun `initiateEmailVerification - sends verification email and creates token`() {
+        val result = svc.initiateEmailVerification(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertEquals(1, emailPort.sent.size)
+        assertEquals("verification", emailPort.sent[0].type)
+        assertEquals("alice@example.com", emailPort.sent[0].to)
+        assertTrue(emailPort.sent[0].url.contains("/t/acme/verify-email?token="))
+        assertEquals(1, evTokenRepo.all().size)
+        assertTrue(auditLog.hasEvent(AuditEventType.EMAIL_VERIFICATION_SENT))
+    }
+
+    @Test
+    fun `initiateEmailVerification - deletes unused tokens before creating new one`() {
+        svc.initiateEmailVerification(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        assertEquals(1, evTokenRepo.all().size)
+        svc.initiateEmailVerification(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        // Old unused token should be deleted, new one created
+        assertEquals(1, evTokenRepo.all().size)
+    }
+
+    @Test
+    fun `initiateEmailVerification - smtp failure returns EmailDeliveryFailed`() {
+        emailPort.shouldFail = true
+        val result = svc.initiateEmailVerification(userId = 10, tenantId = 1, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.EmailDeliveryFailed>(result.error)
+    }
+
+    // =========================================================================
+    // confirmEmailVerification
+    // =========================================================================
+
+    @Test
+    fun `confirmEmailVerification - invalid token hash`() {
+        val result = svc.confirmEmailVerification("nonexistent-raw-token")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenInvalid>(result.error)
+    }
+
+    @Test
+    fun `confirmEmailVerification - expired token`() {
+        val hash = sha256("raw-token")
+        evTokenRepo.create(
+            EmailVerificationToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().minusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmEmailVerification("raw-token")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenExpired>(result.error)
+    }
+
+    @Test
+    fun `confirmEmailVerification - already used token`() {
+        val hash = sha256("raw-token")
+        evTokenRepo.create(
+            EmailVerificationToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(86400),
+                usedAt = Instant.now().minusSeconds(100),
+            ),
+        )
+        val result = svc.confirmEmailVerification("raw-token")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenExpired>(result.error)
+    }
+
+    @Test
+    fun `confirmEmailVerification - success marks user verified and token used`() {
+        val hash = sha256("raw-token")
+        evTokenRepo.create(
+            EmailVerificationToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(86400),
+            ),
+        )
+        val result = svc.confirmEmailVerification("raw-token")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(users.findById(10)!!.emailVerified, "User should be marked as email-verified")
+        assertNotNull(evTokenRepo.all().first().usedAt, "Token should be marked as used")
+        assertTrue(auditLog.hasEvent(AuditEventType.EMAIL_VERIFIED))
+    }
+
+    // =========================================================================
+    // initiateForgotPassword
+    // =========================================================================
+
+    @Test
+    fun `initiateForgotPassword - unknown tenant returns success silently`() {
+        val result = svc.initiateForgotPassword("alice@example.com", "unknown-slug", "http://localhost", null)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(emailPort.sent.isEmpty(), "No email for unknown tenant")
+    }
+
+    @Test
+    fun `initiateForgotPassword - smtp not configured returns success silently`() {
+        val result = svc.initiateForgotPassword("alice@example.com", "no-smtp", "http://localhost", null)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(emailPort.sent.isEmpty())
+    }
+
+    @Test
+    fun `initiateForgotPassword - unknown email returns success to prevent enumeration`() {
+        val result = svc.initiateForgotPassword("nobody@example.com", "acme", "http://localhost", null)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(emailPort.sent.isEmpty(), "No email for unknown address")
+    }
+
+    @Test
+    fun `initiateForgotPassword - disabled user returns success silently`() {
+        val result = svc.initiateForgotPassword("disabled@example.com", "acme", "http://localhost", null)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(emailPort.sent.isEmpty(), "No email for disabled user")
+    }
+
+    @Test
+    fun `initiateForgotPassword - success sends reset email`() {
+        val result = svc.initiateForgotPassword("alice@example.com", "acme", "http://localhost", "1.2.3.4")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertEquals(1, emailPort.sent.size)
+        assertEquals("password_reset", emailPort.sent[0].type)
+        assertTrue(emailPort.sent[0].url.contains("/t/acme/reset-password?token="))
+        assertEquals(1, prTokenRepo.all().size)
+        assertTrue(auditLog.hasEvent(AuditEventType.PASSWORD_RESET_REQUESTED))
+    }
+
+    @Test
+    fun `initiateForgotPassword - smtp failure still returns success`() {
+        emailPort.shouldFail = true
+        val result = svc.initiateForgotPassword("alice@example.com", "acme", "http://localhost", null)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+    }
+
+    // =========================================================================
+    // confirmPasswordReset
+    // =========================================================================
+
+    @Test
+    fun `confirmPasswordReset - invalid token`() {
+        val result = svc.confirmPasswordReset("bad-token", "newpass123", "newpass123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenInvalid>(result.error)
+    }
+
+    @Test
+    fun `confirmPasswordReset - expired token`() {
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().minusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "newpass123", "newpass123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenExpired>(result.error)
+    }
+
+    @Test
+    fun `confirmPasswordReset - already used token`() {
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+                usedAt = Instant.now().minusSeconds(60),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "newpass123", "newpass123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.TokenExpired>(result.error)
+    }
+
+    @Test
+    fun `confirmPasswordReset - blank password`() {
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "  ", "  ")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `confirmPasswordReset - passwords do not match`() {
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "newpass123", "different123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("match"))
+    }
+
+    @Test
+    fun `confirmPasswordReset - password policy violation`() {
+        passwordPolicy.validationError = "Too weak"
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "weak", "weak")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertEquals("Too weak", result.error.message)
+    }
+
+    @Test
+    fun `confirmPasswordReset - password in history`() {
+        passwordPolicy.recordPasswordHistory(10, 1, hasher.hash("old-pass"))
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "old-pass", "old-pass")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("recently"))
+    }
+
+    @Test
+    fun `confirmPasswordReset - success updates password and revokes sessions`() {
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "hash1",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.confirmPasswordReset("raw-reset", "new-secure-password", "new-secure-password")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertEquals("hashed:new-secure-password", users.findById(10)!!.passwordHash)
+        assertTrue(sessions.findActiveByUser(1, 10).isEmpty(), "All sessions should be revoked")
+        assertNotNull(prTokenRepo.all().first().usedAt)
+        assertTrue(auditLog.hasEvent(AuditEventType.PASSWORD_RESET_COMPLETED))
+    }
+
+    @Test
+    fun `confirmPasswordReset - no policy port falls back to minLength check`() {
+        val hash = sha256("raw-reset")
+        prTokenRepo.create(
+            PasswordResetToken(
+                userId = 10,
+                tenantId = 1,
+                tokenHash = hash,
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svcNoPolicyPort.confirmPasswordReset("raw-reset", "short", "short")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("at least"))
+    }
+
+    // =========================================================================
+    // updateProfile
+    // =========================================================================
+
+    @Test
+    fun `updateProfile - user not found`() {
+        val result = svc.updateProfile(userId = 999, tenantId = 1, email = "x@x.com", fullName = "X")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateProfile - tenant mismatch`() {
+        val result = svc.updateProfile(userId = 10, tenantId = 99, email = "x@x.com", fullName = "X")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Unauthorized>(result.error)
+    }
+
+    @Test
+    fun `updateProfile - invalid email`() {
+        val result = svc.updateProfile(userId = 10, tenantId = 1, email = "not-an-email", fullName = "Alice")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateProfile - blank full name`() {
+        val result = svc.updateProfile(userId = 10, tenantId = 1, email = "alice@example.com", fullName = "  ")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateProfile - duplicate email`() {
+        val result = svc.updateProfile(userId = 10, tenantId = 1, email = "verified@example.com", fullName = "Alice")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("already in use"))
+    }
+
+    @Test
+    fun `updateProfile - email change resets emailVerified`() {
+        // Start with verified user
+        val result = svc.updateProfile(userId = 11, tenantId = 1, email = "newemail@example.com", fullName = "Verified Alice")
+        assertIs<SelfServiceResult.Success<User>>(result)
+        assertEquals(false, result.value.emailVerified, "Email change should reset verification")
+        assertEquals("newemail@example.com", result.value.email)
+    }
+
+    @Test
+    fun `updateProfile - same email does not reset emailVerified`() {
+        val result = svc.updateProfile(userId = 11, tenantId = 1, email = "verified@example.com", fullName = "New Name")
+        assertIs<SelfServiceResult.Success<User>>(result)
+        assertEquals(true, result.value.emailVerified, "Same email should keep verification")
+        assertEquals("New Name", result.value.fullName)
+    }
+
+    @Test
+    fun `updateProfile - success records audit event`() {
+        svc.updateProfile(userId = 10, tenantId = 1, email = "alice@example.com", fullName = "Alice Updated")
+        assertTrue(auditLog.hasEvent(AuditEventType.USER_PROFILE_UPDATED))
+    }
+
+    // =========================================================================
+    // changePassword
+    // =========================================================================
+
+    @Test
+    fun `changePassword - tenant not found`() {
+        val result = svc.changePassword(userId = 10, tenantId = 999, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `changePassword - user not found`() {
+        val result = svc.changePassword(userId = 999, tenantId = 1, currentPassword = "x", newPassword = "y", confirmPassword = "y")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `changePassword - tenant mismatch`() {
+        val result = svc.changePassword(userId = 10, tenantId = 2, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Unauthorized>(result.error)
+    }
+
+    @Test
+    fun `changePassword - wrong current password`() {
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "wrong", newPassword = "new-pass-123", confirmPassword = "new-pass-123")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("incorrect"))
+    }
+
+    @Test
+    fun `changePassword - blank new password`() {
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "  ", confirmPassword = "  ")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `changePassword - passwords do not match`() {
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "new-pass-123", confirmPassword = "different")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `changePassword - policy violation`() {
+        passwordPolicy.validationError = "Must include special char"
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "newpassword", confirmPassword = "newpassword")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+    }
+
+    @Test
+    fun `changePassword - password in history`() {
+        passwordPolicy.recordPasswordHistory(10, 1, hasher.hash("reused-pass"))
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "reused-pass", confirmPassword = "reused-pass")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("recently"))
+    }
+
+    @Test
+    fun `changePassword - no policy port falls back to minLength`() {
+        val result = svcNoPolicyPort.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "short", confirmPassword = "short")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Validation>(result.error)
+        assertTrue(result.error.message.contains("at least"))
+    }
+
+    @Test
+    fun `changePassword - success updates password and revokes sessions`() {
+        sessions.save(
+            Session(
+                tenantId = 1,
+                userId = 10,
+                clientId = null,
+                accessTokenHash = "hash1",
+                refreshTokenHash = null,
+                scopes = "openid",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        val result = svc.changePassword(userId = 10, tenantId = 1, currentPassword = "current-pass", newPassword = "brand-new-pass", confirmPassword = "brand-new-pass")
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertEquals("hashed:brand-new-pass", users.findById(10)!!.passwordHash)
+        assertTrue(sessions.findActiveByUser(1, 10).isEmpty(), "All sessions should be revoked")
+        assertTrue(auditLog.hasEvent(AuditEventType.USER_PASSWORD_CHANGED))
+    }
+
+    // =========================================================================
+    // getActiveSessions
+    // =========================================================================
+
+    @Test
+    fun `getActiveSessions - returns active sessions for user`() {
+        sessions.save(
+            Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+        )
+        sessions.save(
+            Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h2", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+        )
+        sessions.save(
+            Session(tenantId = 1, userId = 11, clientId = null, accessTokenHash = "h3", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+        )
+        val result = svc.getActiveSessions(userId = 10, tenantId = 1)
+        assertEquals(2, result.size)
+    }
+
+    // =========================================================================
+    // revokeSession
+    // =========================================================================
+
+    @Test
+    fun `revokeSession - session not found`() {
+        val result = svc.revokeSession(userId = 10, tenantId = 1, sessionId = 999)
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `revokeSession - cannot revoke another users session`() {
+        val session =
+            sessions.save(
+                Session(tenantId = 1, userId = 11, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            )
+        val result = svc.revokeSession(userId = 10, tenantId = 1, sessionId = session.id!!)
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Unauthorized>(result.error)
+    }
+
+    @Test
+    fun `revokeSession - cannot revoke session from different tenant`() {
+        val session =
+            sessions.save(
+                Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            )
+        val result = svc.revokeSession(userId = 10, tenantId = 2, sessionId = session.id!!)
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.Unauthorized>(result.error)
+    }
+
+    @Test
+    fun `revokeSession - success revokes and records audit`() {
+        val session =
+            sessions.save(
+                Session(tenantId = 1, userId = 10, clientId = null, accessTokenHash = "h1", refreshTokenHash = null, scopes = "openid", expiresAt = Instant.now().plusSeconds(3600)),
+            )
+        val result = svc.revokeSession(userId = 10, tenantId = 1, sessionId = session.id!!)
+        assertIs<SelfServiceResult.Success<Unit>>(result)
+        assertTrue(sessions.findActiveByUser(1, 10).isEmpty())
+        assertTrue(auditLog.hasEvent(AuditEventType.USER_SESSION_REVOKED_SELF))
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun sha256(input: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserSelfServiceServiceTest.kt
@@ -162,9 +162,6 @@ class UserSelfServiceServiceTest {
 
     @Test
     fun `initiateEmailVerification - smtp not configured`() {
-        val result = svc.initiateEmailVerification(userId = 10, tenantId = 2, baseUrl = "http://localhost")
-        // alice is tenantId=1 but we're asking about tenantId=2 (no-smtp) — user won't be found,
-        // but the tenant check happens first. Let's use a user in tenant 2.
         val userInNoSmtp =
             users.add(
                 User(
@@ -175,9 +172,9 @@ class UserSelfServiceServiceTest {
                     passwordHash = hasher.hash("pass"),
                 ),
             )
-        val r = svc.initiateEmailVerification(userId = userInNoSmtp.id!!, tenantId = 2, baseUrl = "http://localhost")
-        assertIs<SelfServiceResult.Failure>(r)
-        assertIs<SelfServiceError.SmtpNotConfigured>(r.error)
+        val result = svc.initiateEmailVerification(userId = userInNoSmtp.id!!, tenantId = 2, baseUrl = "http://localhost")
+        assertIs<SelfServiceResult.Failure>(result)
+        assertIs<SelfServiceError.SmtpNotConfigured>(result.error)
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
@@ -1,7 +1,5 @@
 package com.kauth.domain.service
 
-import com.kauth.domain.model.WebhookDeliveryStatus
-import com.kauth.domain.model.WebhookEndpoint
 import com.kauth.domain.model.WebhookEvent
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
@@ -26,10 +24,11 @@ class WebhookServiceTest {
     private val endpoints = FakeWebhookEndpointRepository()
     private val deliveries = FakeWebhookDeliveryRepository()
 
-    private val svc = WebhookService(
-        endpointRepository = endpoints,
-        deliveryRepository = deliveries,
-    )
+    private val svc =
+        WebhookService(
+            endpointRepository = endpoints,
+            deliveryRepository = deliveries,
+        )
 
     @BeforeTest
     fun setup() {
@@ -50,7 +49,12 @@ class WebhookServiceTest {
 
     @Test
     fun `createEndpoint - URL without http scheme`() {
-        val result = svc.createEndpoint(tenantId = 1, url = "ftp://example.com/hook", events = setOf(WebhookEvent.USER_CREATED))
+        val result =
+            svc.createEndpoint(
+                tenantId = 1,
+                url = "ftp://example.com/hook",
+                events = setOf(WebhookEvent.USER_CREATED),
+            )
         assertIs<WebhookResult.Failure>(result)
         assertTrue(result.error.contains("http"), "Error should mention http requirement")
     }
@@ -72,12 +76,13 @@ class WebhookServiceTest {
 
     @Test
     fun `createEndpoint - success returns endpoint and plaintext secret`() {
-        val result = svc.createEndpoint(
-            tenantId = 1,
-            url = "https://example.com/hook",
-            events = setOf(WebhookEvent.USER_CREATED, WebhookEvent.USER_DELETED),
-            description = "Test hook",
-        )
+        val result =
+            svc.createEndpoint(
+                tenantId = 1,
+                url = "https://example.com/hook",
+                events = setOf(WebhookEvent.USER_CREATED, WebhookEvent.USER_DELETED),
+                description = "Test hook",
+            )
         assertIs<WebhookResult.Success>(result)
         val ep = result.endpoint
         assertNotNull(ep.id)
@@ -91,7 +96,12 @@ class WebhookServiceTest {
 
     @Test
     fun `createEndpoint - http URL is accepted`() {
-        val result = svc.createEndpoint(tenantId = 1, url = "http://localhost:8080/hook", events = setOf(WebhookEvent.LOGIN_SUCCESS))
+        val result =
+            svc.createEndpoint(
+                tenantId = 1,
+                url = "http://localhost:8080/hook",
+                events = setOf(WebhookEvent.LOGIN_SUCCESS),
+            )
         assertIs<WebhookResult.Success>(result)
     }
 
@@ -116,7 +126,14 @@ class WebhookServiceTest {
 
     @Test
     fun `deleteEndpoint - removes endpoint for correct tenant`() {
-        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val created =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://a.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
         assertEquals(1, svc.listEndpoints(1).size)
 
         svc.deleteEndpoint(created.id!!, tenantId = 1)
@@ -125,7 +142,14 @@ class WebhookServiceTest {
 
     @Test
     fun `deleteEndpoint - wrong tenant does not delete`() {
-        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val created =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://a.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
 
         svc.deleteEndpoint(created.id!!, tenantId = 99)
         assertEquals(1, svc.listEndpoints(1).size, "Endpoint should not be deleted for wrong tenant")
@@ -137,7 +161,14 @@ class WebhookServiceTest {
 
     @Test
     fun `toggleEndpoint - disables and re-enables endpoint`() {
-        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val created =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://a.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
         assertTrue(created.enabled)
 
         svc.toggleEndpoint(created.id!!, tenantId = 1, enabled = false)
@@ -181,7 +212,14 @@ class WebhookServiceTest {
 
     @Test
     fun `dispatch - does not create deliveries for disabled endpoints`() {
-        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val created =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://a.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
         svc.toggleEndpoint(created.id!!, tenantId = 1, enabled = false)
 
         svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = emptyMap())
@@ -211,8 +249,22 @@ class WebhookServiceTest {
 
     @Test
     fun `deliveriesForEndpoint - scoped to specific endpoint`() {
-        val ep1 = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
-        val ep2 = (svc.createEndpoint(1, "https://b.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val ep1 =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://a.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
+        val ep2 =
+            (
+                svc.createEndpoint(
+                    1,
+                    "https://b.com/hook",
+                    setOf(WebhookEvent.USER_CREATED),
+                ) as WebhookResult.Success
+            ).endpoint
 
         svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = mapOf("id" to 1))
 

--- a/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
@@ -1,0 +1,227 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.WebhookDeliveryStatus
+import com.kauth.domain.model.WebhookEndpoint
+import com.kauth.domain.model.WebhookEvent
+import com.kauth.fakes.FakeWebhookDeliveryRepository
+import com.kauth.fakes.FakeWebhookEndpointRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [WebhookService].
+ *
+ * Covers: endpoint CRUD, validation, dispatch delivery record creation,
+ * and delivery query operations.
+ *
+ * Note: the async HTTP delivery machinery (coroutine-based retries, actual
+ * HTTP calls) is intentionally not tested here — those are integration concerns.
+ * These tests validate the synchronous domain logic.
+ */
+class WebhookServiceTest {
+    private val endpoints = FakeWebhookEndpointRepository()
+    private val deliveries = FakeWebhookDeliveryRepository()
+
+    private val svc = WebhookService(
+        endpointRepository = endpoints,
+        deliveryRepository = deliveries,
+    )
+
+    @BeforeTest
+    fun setup() {
+        endpoints.clear()
+        deliveries.clear()
+    }
+
+    // =========================================================================
+    // createEndpoint — validation
+    // =========================================================================
+
+    @Test
+    fun `createEndpoint - blank URL`() {
+        val result = svc.createEndpoint(tenantId = 1, url = "  ", events = setOf(WebhookEvent.USER_CREATED))
+        assertIs<WebhookResult.Failure>(result)
+        assertTrue(result.error.contains("blank"), "Error should mention blank URL")
+    }
+
+    @Test
+    fun `createEndpoint - URL without http scheme`() {
+        val result = svc.createEndpoint(tenantId = 1, url = "ftp://example.com/hook", events = setOf(WebhookEvent.USER_CREATED))
+        assertIs<WebhookResult.Failure>(result)
+        assertTrue(result.error.contains("http"), "Error should mention http requirement")
+    }
+
+    @Test
+    fun `createEndpoint - URL exceeds 2048 characters`() {
+        val longUrl = "https://example.com/" + "a".repeat(2040)
+        val result = svc.createEndpoint(tenantId = 1, url = longUrl, events = setOf(WebhookEvent.USER_CREATED))
+        assertIs<WebhookResult.Failure>(result)
+        assertTrue(result.error.contains("2048"), "Error should mention length limit")
+    }
+
+    @Test
+    fun `createEndpoint - unknown event type`() {
+        val result = svc.createEndpoint(tenantId = 1, url = "https://example.com/hook", events = setOf("bogus.event"))
+        assertIs<WebhookResult.Failure>(result)
+        assertTrue(result.error.contains("bogus.event"), "Error should mention the unknown event")
+    }
+
+    @Test
+    fun `createEndpoint - success returns endpoint and plaintext secret`() {
+        val result = svc.createEndpoint(
+            tenantId = 1,
+            url = "https://example.com/hook",
+            events = setOf(WebhookEvent.USER_CREATED, WebhookEvent.USER_DELETED),
+            description = "Test hook",
+        )
+        assertIs<WebhookResult.Success>(result)
+        val ep = result.endpoint
+        assertNotNull(ep.id)
+        assertEquals(1, ep.tenantId)
+        assertEquals("https://example.com/hook", ep.url)
+        assertEquals(setOf(WebhookEvent.USER_CREATED, WebhookEvent.USER_DELETED), ep.events)
+        assertEquals("Test hook", ep.description)
+        assertTrue(ep.enabled)
+        assertTrue(result.plaintextSecret.isNotBlank(), "Secret must be non-blank")
+    }
+
+    @Test
+    fun `createEndpoint - http URL is accepted`() {
+        val result = svc.createEndpoint(tenantId = 1, url = "http://localhost:8080/hook", events = setOf(WebhookEvent.LOGIN_SUCCESS))
+        assertIs<WebhookResult.Success>(result)
+    }
+
+    // =========================================================================
+    // listEndpoints
+    // =========================================================================
+
+    @Test
+    fun `listEndpoints - returns only endpoints for the given tenant`() {
+        svc.createEndpoint(tenantId = 1, url = "https://a.com/hook", events = setOf(WebhookEvent.USER_CREATED))
+        svc.createEndpoint(tenantId = 1, url = "https://b.com/hook", events = setOf(WebhookEvent.USER_UPDATED))
+        svc.createEndpoint(tenantId = 2, url = "https://c.com/hook", events = setOf(WebhookEvent.USER_CREATED))
+
+        assertEquals(2, svc.listEndpoints(1).size)
+        assertEquals(1, svc.listEndpoints(2).size)
+        assertEquals(0, svc.listEndpoints(99).size)
+    }
+
+    // =========================================================================
+    // deleteEndpoint
+    // =========================================================================
+
+    @Test
+    fun `deleteEndpoint - removes endpoint for correct tenant`() {
+        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        assertEquals(1, svc.listEndpoints(1).size)
+
+        svc.deleteEndpoint(created.id!!, tenantId = 1)
+        assertEquals(0, svc.listEndpoints(1).size)
+    }
+
+    @Test
+    fun `deleteEndpoint - wrong tenant does not delete`() {
+        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+
+        svc.deleteEndpoint(created.id!!, tenantId = 99)
+        assertEquals(1, svc.listEndpoints(1).size, "Endpoint should not be deleted for wrong tenant")
+    }
+
+    // =========================================================================
+    // toggleEndpoint
+    // =========================================================================
+
+    @Test
+    fun `toggleEndpoint - disables and re-enables endpoint`() {
+        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        assertTrue(created.enabled)
+
+        svc.toggleEndpoint(created.id!!, tenantId = 1, enabled = false)
+        val disabled = svc.listEndpoints(1).first()
+        assertEquals(false, disabled.enabled)
+
+        svc.toggleEndpoint(created.id!!, tenantId = 1, enabled = true)
+        val reenabled = svc.listEndpoints(1).first()
+        assertEquals(true, reenabled.enabled)
+    }
+
+    // =========================================================================
+    // dispatch — delivery record creation
+    // =========================================================================
+
+    @Test
+    fun `dispatch - creates delivery records for matching enabled endpoints`() {
+        svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED))
+        svc.createEndpoint(1, "https://b.com/hook", setOf(WebhookEvent.USER_CREATED, WebhookEvent.USER_DELETED))
+
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = mapOf("userId" to 42))
+
+        // Give coroutines a moment — but delivery records are created synchronously before launch
+        val allDeliveries = deliveries.all()
+        assertEquals(2, allDeliveries.size, "Should create one delivery per matching endpoint")
+        allDeliveries.forEach { d ->
+            assertEquals(WebhookEvent.USER_CREATED, d.eventType)
+            assertTrue(d.payload.contains("user.created"))
+            assertNotNull(d.id)
+        }
+    }
+
+    @Test
+    fun `dispatch - does not create deliveries for unsubscribed event`() {
+        svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED))
+
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.LOGIN_SUCCESS, payloadData = emptyMap())
+
+        assertEquals(0, deliveries.all().size)
+    }
+
+    @Test
+    fun `dispatch - does not create deliveries for disabled endpoints`() {
+        val created = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        svc.toggleEndpoint(created.id!!, tenantId = 1, enabled = false)
+
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = emptyMap())
+
+        assertEquals(0, deliveries.all().size)
+    }
+
+    @Test
+    fun `dispatch - no endpoints for tenant is a no-op`() {
+        svc.dispatch(tenantId = 99, eventType = WebhookEvent.USER_CREATED, payloadData = emptyMap())
+        assertEquals(0, deliveries.all().size)
+    }
+
+    // =========================================================================
+    // recentDeliveries / deliveriesForEndpoint
+    // =========================================================================
+
+    @Test
+    fun `recentDeliveries - returns deliveries for tenant`() {
+        svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED))
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = mapOf("id" to 1))
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = mapOf("id" to 2))
+
+        val recent = svc.recentDeliveries(tenantId = 1, limit = 10)
+        assertEquals(2, recent.size)
+    }
+
+    @Test
+    fun `deliveriesForEndpoint - scoped to specific endpoint`() {
+        val ep1 = (svc.createEndpoint(1, "https://a.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+        val ep2 = (svc.createEndpoint(1, "https://b.com/hook", setOf(WebhookEvent.USER_CREATED)) as WebhookResult.Success).endpoint
+
+        svc.dispatch(tenantId = 1, eventType = WebhookEvent.USER_CREATED, payloadData = mapOf("id" to 1))
+
+        val ep1Deliveries = svc.deliveriesForEndpoint(ep1.id!!, limit = 10)
+        val ep2Deliveries = svc.deliveriesForEndpoint(ep2.id!!, limit = 10)
+
+        assertEquals(1, ep1Deliveries.size)
+        assertEquals(1, ep2Deliveries.size)
+        assertEquals(ep1.id, ep1Deliveries.first().endpointId)
+        assertEquals(ep2.id, ep2Deliveries.first().endpointId)
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
@@ -1,0 +1,51 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.ApiKey
+import com.kauth.domain.port.ApiKeyRepository
+import java.time.Instant
+
+/**
+ * In-memory ApiKeyRepository for unit tests.
+ */
+class FakeApiKeyRepository : ApiKeyRepository {
+    private val store = mutableMapOf<Int, ApiKey>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<ApiKey> = store.values.toList()
+
+    override fun save(apiKey: ApiKey): ApiKey {
+        val k = if (apiKey.id == null) apiKey.copy(id = nextId++) else apiKey
+        store[k.id!!] = k
+        return k
+    }
+
+    override fun findByHash(hash: String): ApiKey? =
+        store.values.find { it.keyHash == hash }
+
+    override fun findByTenantId(tenantId: Int): List<ApiKey> =
+        store.values.filter { it.tenantId == tenantId }.sortedByDescending { it.createdAt }
+
+    override fun findById(id: Int, tenantId: Int): ApiKey? =
+        store[id]?.takeIf { it.tenantId == tenantId }
+
+    override fun revoke(id: Int, tenantId: Int) {
+        store[id]?.takeIf { it.tenantId == tenantId }?.let {
+            store[id] = it.copy(enabled = false)
+        }
+    }
+
+    override fun touchLastUsed(id: Int, at: Instant) {
+        store[id]?.let { store[id] = it.copy(lastUsedAt = at) }
+    }
+
+    override fun delete(id: Int, tenantId: Int) {
+        if (store[id]?.tenantId == tenantId) {
+            store.remove(id)
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
@@ -24,26 +24,36 @@ class FakeApiKeyRepository : ApiKeyRepository {
         return k
     }
 
-    override fun findByHash(hash: String): ApiKey? =
-        store.values.find { it.keyHash == hash }
+    override fun findByHash(hash: String): ApiKey? = store.values.find { it.keyHash == hash }
 
     override fun findByTenantId(tenantId: Int): List<ApiKey> =
         store.values.filter { it.tenantId == tenantId }.sortedByDescending { it.createdAt }
 
-    override fun findById(id: Int, tenantId: Int): ApiKey? =
-        store[id]?.takeIf { it.tenantId == tenantId }
+    override fun findById(
+        id: Int,
+        tenantId: Int,
+    ): ApiKey? = store[id]?.takeIf { it.tenantId == tenantId }
 
-    override fun revoke(id: Int, tenantId: Int) {
+    override fun revoke(
+        id: Int,
+        tenantId: Int,
+    ) {
         store[id]?.takeIf { it.tenantId == tenantId }?.let {
             store[id] = it.copy(enabled = false)
         }
     }
 
-    override fun touchLastUsed(id: Int, at: Instant) {
+    override fun touchLastUsed(
+        id: Int,
+        at: Instant,
+    ) {
         store[id]?.let { store[id] = it.copy(lastUsedAt = at) }
     }
 
-    override fun delete(id: Int, tenantId: Int) {
+    override fun delete(
+        id: Int,
+        tenantId: Int,
+    ) {
         if (store[id]?.tenantId == tenantId) {
             store.remove(id)
         }

--- a/src/test/kotlin/com/kauth/fakes/FakeAuditLogRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeAuditLogRepository.kt
@@ -1,0 +1,48 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.AuditEvent
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.port.AuditLogRepository
+
+/**
+ * In-memory AuditLogRepository for integration tests.
+ * Implements the read-side port (findByTenant, countByTenant).
+ */
+class FakeAuditLogRepository : AuditLogRepository {
+    private val store = mutableListOf<AuditEvent>()
+
+    fun add(event: AuditEvent) {
+        store.add(event)
+    }
+
+    fun clear() {
+        store.clear()
+    }
+
+    override fun findByTenant(
+        tenantId: Int,
+        eventType: AuditEventType?,
+        userId: Int?,
+        limit: Int,
+        offset: Int,
+    ): List<AuditEvent> =
+        store
+            .filter { it.tenantId == tenantId }
+            .let { list -> if (eventType != null) list.filter { it.eventType == eventType } else list }
+            .let { list -> if (userId != null) list.filter { it.userId == userId } else list }
+            .sortedByDescending { it.createdAt }
+            .drop(offset)
+            .take(limit)
+
+    override fun countByTenant(
+        tenantId: Int,
+        eventType: AuditEventType?,
+        userId: Int?,
+    ): Long =
+        store
+            .filter { it.tenantId == tenantId }
+            .let { list -> if (eventType != null) list.filter { it.eventType == eventType } else list }
+            .let { list -> if (userId != null) list.filter { it.userId == userId } else list }
+            .size
+            .toLong()
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeEmailPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeEmailPort.kt
@@ -1,0 +1,51 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.port.EmailPort
+
+/**
+ * In-memory EmailPort for unit tests.
+ * Captures sent emails so tests can assert on delivery.
+ * Can be configured to throw to simulate SMTP failures.
+ */
+class FakeEmailPort : EmailPort {
+    data class SentEmail(
+        val to: String,
+        val toName: String,
+        val url: String,
+        val workspaceName: String,
+        val type: String,
+    )
+
+    private val _sent = mutableListOf<SentEmail>()
+    val sent: List<SentEmail> get() = _sent.toList()
+
+    var shouldFail: Boolean = false
+
+    fun clear() {
+        _sent.clear()
+        shouldFail = false
+    }
+
+    override fun sendVerificationEmail(
+        to: String,
+        toName: String,
+        verifyUrl: String,
+        workspaceName: String,
+        tenant: Tenant,
+    ) {
+        if (shouldFail) throw RuntimeException("SMTP delivery failed")
+        _sent.add(SentEmail(to, toName, verifyUrl, workspaceName, "verification"))
+    }
+
+    override fun sendPasswordResetEmail(
+        to: String,
+        toName: String,
+        resetUrl: String,
+        workspaceName: String,
+        tenant: Tenant,
+    ) {
+        if (shouldFail) throw RuntimeException("SMTP delivery failed")
+        _sent.add(SentEmail(to, toName, resetUrl, workspaceName, "password_reset"))
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeEmailVerificationTokenRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeEmailVerificationTokenRepository.kt
@@ -1,0 +1,37 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.EmailVerificationToken
+import com.kauth.domain.port.EmailVerificationTokenRepository
+import java.time.Instant
+
+/**
+ * In-memory EmailVerificationTokenRepository for unit tests.
+ */
+class FakeEmailVerificationTokenRepository : EmailVerificationTokenRepository {
+    private val store = mutableMapOf<Int, EmailVerificationToken>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<EmailVerificationToken> = store.values.toList()
+
+    override fun create(token: EmailVerificationToken): EmailVerificationToken {
+        val t = token.copy(id = nextId++)
+        store[t.id!!] = t
+        return t
+    }
+
+    override fun findByTokenHash(hash: String): EmailVerificationToken? =
+        store.values.find { it.tokenHash == hash }
+
+    override fun markUsed(tokenId: Int, usedAt: Instant) {
+        store[tokenId]?.let { store[tokenId] = it.copy(usedAt = usedAt) }
+    }
+
+    override fun deleteUnusedByUser(userId: Int) {
+        store.entries.removeIf { it.value.userId == userId && it.value.usedAt == null }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeEmailVerificationTokenRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeEmailVerificationTokenRepository.kt
@@ -24,10 +24,12 @@ class FakeEmailVerificationTokenRepository : EmailVerificationTokenRepository {
         return t
     }
 
-    override fun findByTokenHash(hash: String): EmailVerificationToken? =
-        store.values.find { it.tokenHash == hash }
+    override fun findByTokenHash(hash: String): EmailVerificationToken? = store.values.find { it.tokenHash == hash }
 
-    override fun markUsed(tokenId: Int, usedAt: Instant) {
+    override fun markUsed(
+        tokenId: Int,
+        usedAt: Instant,
+    ) {
         store[tokenId]?.let { store[tokenId] = it.copy(usedAt = usedAt) }
     }
 

--- a/src/test/kotlin/com/kauth/fakes/FakeGroupRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeGroupRepository.kt
@@ -1,0 +1,99 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.Group
+import com.kauth.domain.port.GroupRepository
+
+/**
+ * In-memory GroupRepository for unit tests.
+ * Supports hierarchy, role assignments, and user membership.
+ */
+class FakeGroupRepository : GroupRepository {
+    private val store = mutableMapOf<Int, Group>()
+    private var nextId = 1
+
+    // groupId -> set of roleIds
+    private val groupRoles = mutableMapOf<Int, MutableSet<Int>>()
+
+    // groupId -> set of userIds
+    private val groupMembers = mutableMapOf<Int, MutableSet<Int>>()
+
+    fun add(group: Group): Group {
+        val g = if (group.id == null) group.copy(id = nextId++) else group
+        store[g.id!!] = g
+        return g
+    }
+
+    fun clear() {
+        store.clear()
+        groupRoles.clear()
+        groupMembers.clear()
+        nextId = 1
+    }
+
+    override fun findById(id: Int): Group? = store[id]
+
+    override fun findByTenantId(tenantId: Int): List<Group> =
+        store.values.filter { it.tenantId == tenantId }
+
+    override fun findByName(tenantId: Int, name: String, parentGroupId: Int?): Group? =
+        store.values.find {
+            it.tenantId == tenantId && it.name == name && it.parentGroupId == parentGroupId
+        }
+
+    override fun findChildren(groupId: Int): List<Group> =
+        store.values.filter { it.parentGroupId == groupId }
+
+    override fun save(group: Group): Group {
+        val g = if (group.id == null) group.copy(id = nextId++) else group
+        store[g.id!!] = g
+        return g
+    }
+
+    override fun update(group: Group): Group {
+        store[group.id!!] = group
+        return group
+    }
+
+    override fun delete(groupId: Int) {
+        store.remove(groupId)
+        groupRoles.remove(groupId)
+        groupMembers.remove(groupId)
+    }
+
+    override fun assignRoleToGroup(groupId: Int, roleId: Int) {
+        groupRoles.getOrPut(groupId) { mutableSetOf() }.add(roleId)
+    }
+
+    override fun unassignRoleFromGroup(groupId: Int, roleId: Int) {
+        groupRoles[groupId]?.remove(roleId)
+    }
+
+    override fun findRoleIdsForGroup(groupId: Int): List<Int> =
+        groupRoles[groupId]?.toList() ?: emptyList()
+
+    override fun addUserToGroup(userId: Int, groupId: Int) {
+        groupMembers.getOrPut(groupId) { mutableSetOf() }.add(userId)
+    }
+
+    override fun removeUserFromGroup(userId: Int, groupId: Int) {
+        groupMembers[groupId]?.remove(userId)
+    }
+
+    override fun findGroupsForUser(userId: Int): List<Group> =
+        groupMembers.filter { it.value.contains(userId) }
+            .keys
+            .mapNotNull { store[it] }
+
+    override fun findUserIdsInGroup(groupId: Int): List<Int> =
+        groupMembers[groupId]?.toList() ?: emptyList()
+
+    override fun findAncestorGroupIds(groupId: Int): List<Int> {
+        val ancestors = mutableListOf<Int>()
+        var current = store[groupId]?.parentGroupId
+        while (current != null) {
+            ancestors.add(current)
+            current = store[current]?.parentGroupId
+        }
+        return ancestors
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeGroupRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeGroupRepository.kt
@@ -32,16 +32,18 @@ class FakeGroupRepository : GroupRepository {
 
     override fun findById(id: Int): Group? = store[id]
 
-    override fun findByTenantId(tenantId: Int): List<Group> =
-        store.values.filter { it.tenantId == tenantId }
+    override fun findByTenantId(tenantId: Int): List<Group> = store.values.filter { it.tenantId == tenantId }
 
-    override fun findByName(tenantId: Int, name: String, parentGroupId: Int?): Group? =
+    override fun findByName(
+        tenantId: Int,
+        name: String,
+        parentGroupId: Int?,
+    ): Group? =
         store.values.find {
             it.tenantId == tenantId && it.name == name && it.parentGroupId == parentGroupId
         }
 
-    override fun findChildren(groupId: Int): List<Group> =
-        store.values.filter { it.parentGroupId == groupId }
+    override fun findChildren(groupId: Int): List<Group> = store.values.filter { it.parentGroupId == groupId }
 
     override fun save(group: Group): Group {
         val g = if (group.id == null) group.copy(id = nextId++) else group
@@ -60,32 +62,43 @@ class FakeGroupRepository : GroupRepository {
         groupMembers.remove(groupId)
     }
 
-    override fun assignRoleToGroup(groupId: Int, roleId: Int) {
+    override fun assignRoleToGroup(
+        groupId: Int,
+        roleId: Int,
+    ) {
         groupRoles.getOrPut(groupId) { mutableSetOf() }.add(roleId)
     }
 
-    override fun unassignRoleFromGroup(groupId: Int, roleId: Int) {
+    override fun unassignRoleFromGroup(
+        groupId: Int,
+        roleId: Int,
+    ) {
         groupRoles[groupId]?.remove(roleId)
     }
 
-    override fun findRoleIdsForGroup(groupId: Int): List<Int> =
-        groupRoles[groupId]?.toList() ?: emptyList()
+    override fun findRoleIdsForGroup(groupId: Int): List<Int> = groupRoles[groupId]?.toList() ?: emptyList()
 
-    override fun addUserToGroup(userId: Int, groupId: Int) {
+    override fun addUserToGroup(
+        userId: Int,
+        groupId: Int,
+    ) {
         groupMembers.getOrPut(groupId) { mutableSetOf() }.add(userId)
     }
 
-    override fun removeUserFromGroup(userId: Int, groupId: Int) {
+    override fun removeUserFromGroup(
+        userId: Int,
+        groupId: Int,
+    ) {
         groupMembers[groupId]?.remove(userId)
     }
 
     override fun findGroupsForUser(userId: Int): List<Group> =
-        groupMembers.filter { it.value.contains(userId) }
+        groupMembers
+            .filter { it.value.contains(userId) }
             .keys
             .mapNotNull { store[it] }
 
-    override fun findUserIdsInGroup(groupId: Int): List<Int> =
-        groupMembers[groupId]?.toList() ?: emptyList()
+    override fun findUserIdsInGroup(groupId: Int): List<Int> = groupMembers[groupId]?.toList() ?: emptyList()
 
     override fun findAncestorGroupIds(groupId: Int): List<Int> {
         val ancestors = mutableListOf<Int>()

--- a/src/test/kotlin/com/kauth/fakes/FakeIdentityProviderRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeIdentityProviderRepository.kt
@@ -28,8 +28,10 @@ class FakeIdentityProviderRepository : IdentityProviderRepository {
     override fun findAllByTenant(tenantId: Int): List<IdentityProvider> =
         store.values.filter { it.tenantId == tenantId }
 
-    override fun findByTenantAndProvider(tenantId: Int, provider: SocialProvider): IdentityProvider? =
-        store.values.find { it.tenantId == tenantId && it.provider == provider }
+    override fun findByTenantAndProvider(
+        tenantId: Int,
+        provider: SocialProvider,
+    ): IdentityProvider? = store.values.find { it.tenantId == tenantId && it.provider == provider }
 
     override fun save(provider: IdentityProvider): IdentityProvider {
         val p = if (provider.id == null) provider.copy(id = nextId++) else provider
@@ -42,7 +44,10 @@ class FakeIdentityProviderRepository : IdentityProviderRepository {
         return provider
     }
 
-    override fun delete(tenantId: Int, provider: SocialProvider) {
+    override fun delete(
+        tenantId: Int,
+        provider: SocialProvider,
+    ) {
         store.entries.removeIf { it.value.tenantId == tenantId && it.value.provider == provider }
     }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeIdentityProviderRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeIdentityProviderRepository.kt
@@ -1,0 +1,48 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.port.IdentityProviderRepository
+
+/**
+ * In-memory IdentityProviderRepository for unit tests.
+ */
+class FakeIdentityProviderRepository : IdentityProviderRepository {
+    private val store = mutableMapOf<Int, IdentityProvider>()
+    private var nextId = 1
+
+    fun add(provider: IdentityProvider): IdentityProvider {
+        val p = if (provider.id == null) provider.copy(id = nextId++) else provider
+        store[p.id!!] = p
+        return p
+    }
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    override fun findEnabledByTenant(tenantId: Int): List<IdentityProvider> =
+        store.values.filter { it.tenantId == tenantId && it.enabled }
+
+    override fun findAllByTenant(tenantId: Int): List<IdentityProvider> =
+        store.values.filter { it.tenantId == tenantId }
+
+    override fun findByTenantAndProvider(tenantId: Int, provider: SocialProvider): IdentityProvider? =
+        store.values.find { it.tenantId == tenantId && it.provider == provider }
+
+    override fun save(provider: IdentityProvider): IdentityProvider {
+        val p = if (provider.id == null) provider.copy(id = nextId++) else provider
+        store[p.id!!] = p
+        return p
+    }
+
+    override fun update(provider: IdentityProvider): IdentityProvider {
+        store[provider.id!!] = provider
+        return provider
+    }
+
+    override fun delete(tenantId: Int, provider: SocialProvider) {
+        store.entries.removeIf { it.value.tenantId == tenantId && it.value.provider == provider }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakePasswordPolicyPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakePasswordPolicyPort.kt
@@ -1,0 +1,39 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.port.PasswordPolicyPort
+
+/**
+ * In-memory PasswordPolicyPort for unit tests.
+ * Configurable validation result and history tracking.
+ */
+class FakePasswordPolicyPort : PasswordPolicyPort {
+    var validationError: String? = null
+    private val history = mutableListOf<Triple<Int, Int, String>>() // userId, tenantId, hash
+    private val blacklist = mutableSetOf<String>()
+
+    fun clear() {
+        validationError = null
+        history.clear()
+        blacklist.clear()
+    }
+
+    fun addToBlacklist(password: String) {
+        blacklist.add(password)
+    }
+
+    override fun validate(rawPassword: String, tenant: Tenant, userId: Int?): String? =
+        validationError
+
+    override fun recordPasswordHistory(userId: Int, tenantId: Int, passwordHash: String) {
+        history.add(Triple(userId, tenantId, passwordHash))
+    }
+
+    override fun isInHistory(userId: Int, tenantId: Int, rawPassword: String, historyCount: Int): Boolean =
+        history.filter { it.first == userId && it.second == tenantId }
+            .takeLast(historyCount)
+            .any { it.third == "hashed:$rawPassword" }
+
+    override fun isBlacklisted(rawPassword: String, tenantId: Int): Boolean =
+        rawPassword in blacklist
+}

--- a/src/test/kotlin/com/kauth/fakes/FakePasswordPolicyPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakePasswordPolicyPort.kt
@@ -22,18 +22,33 @@ class FakePasswordPolicyPort : PasswordPolicyPort {
         blacklist.add(password)
     }
 
-    override fun validate(rawPassword: String, tenant: Tenant, userId: Int?): String? =
-        validationError
+    override fun validate(
+        rawPassword: String,
+        tenant: Tenant,
+        userId: Int?,
+    ): String? = validationError
 
-    override fun recordPasswordHistory(userId: Int, tenantId: Int, passwordHash: String) {
+    override fun recordPasswordHistory(
+        userId: Int,
+        tenantId: Int,
+        passwordHash: String,
+    ) {
         history.add(Triple(userId, tenantId, passwordHash))
     }
 
-    override fun isInHistory(userId: Int, tenantId: Int, rawPassword: String, historyCount: Int): Boolean =
-        history.filter { it.first == userId && it.second == tenantId }
+    override fun isInHistory(
+        userId: Int,
+        tenantId: Int,
+        rawPassword: String,
+        historyCount: Int,
+    ): Boolean =
+        history
+            .filter { it.first == userId && it.second == tenantId }
             .takeLast(historyCount)
             .any { it.third == "hashed:$rawPassword" }
 
-    override fun isBlacklisted(rawPassword: String, tenantId: Int): Boolean =
-        rawPassword in blacklist
+    override fun isBlacklisted(
+        rawPassword: String,
+        tenantId: Int,
+    ): Boolean = rawPassword in blacklist
 }

--- a/src/test/kotlin/com/kauth/fakes/FakePasswordResetTokenRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakePasswordResetTokenRepository.kt
@@ -24,10 +24,12 @@ class FakePasswordResetTokenRepository : PasswordResetTokenRepository {
         return t
     }
 
-    override fun findByTokenHash(hash: String): PasswordResetToken? =
-        store.values.find { it.tokenHash == hash }
+    override fun findByTokenHash(hash: String): PasswordResetToken? = store.values.find { it.tokenHash == hash }
 
-    override fun markUsed(tokenId: Int, usedAt: Instant) {
+    override fun markUsed(
+        tokenId: Int,
+        usedAt: Instant,
+    ) {
         store[tokenId]?.let { store[tokenId] = it.copy(usedAt = usedAt) }
     }
 

--- a/src/test/kotlin/com/kauth/fakes/FakePasswordResetTokenRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakePasswordResetTokenRepository.kt
@@ -1,0 +1,37 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.PasswordResetToken
+import com.kauth.domain.port.PasswordResetTokenRepository
+import java.time.Instant
+
+/**
+ * In-memory PasswordResetTokenRepository for unit tests.
+ */
+class FakePasswordResetTokenRepository : PasswordResetTokenRepository {
+    private val store = mutableMapOf<Int, PasswordResetToken>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<PasswordResetToken> = store.values.toList()
+
+    override fun create(token: PasswordResetToken): PasswordResetToken {
+        val t = token.copy(id = nextId++)
+        store[t.id!!] = t
+        return t
+    }
+
+    override fun findByTokenHash(hash: String): PasswordResetToken? =
+        store.values.find { it.tokenHash == hash }
+
+    override fun markUsed(tokenId: Int, usedAt: Instant) {
+        store[tokenId]?.let { store[tokenId] = it.copy(usedAt = usedAt) }
+    }
+
+    override fun deleteByUser(userId: Int) {
+        store.entries.removeIf { it.value.userId == userId }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
@@ -1,0 +1,102 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
+import com.kauth.domain.port.RoleRepository
+
+/**
+ * In-memory RoleRepository for unit tests.
+ * Supports composite roles, user assignments, and effective role resolution.
+ */
+class FakeRoleRepository : RoleRepository {
+    private val store = mutableMapOf<Int, Role>()
+    private var nextId = 1
+
+    // parentRoleId -> set of childRoleIds
+    private val composites = mutableMapOf<Int, MutableSet<Int>>()
+
+    // userId -> set of roleIds
+    private val userRoles = mutableMapOf<Int, MutableSet<Int>>()
+
+    fun add(role: Role): Role {
+        val r = if (role.id == null) role.copy(id = nextId++) else role
+        store[r.id!!] = r
+        return r
+    }
+
+    fun clear() {
+        store.clear()
+        composites.clear()
+        userRoles.clear()
+        nextId = 1
+    }
+
+    override fun findById(id: Int): Role? = store[id]
+
+    override fun findByName(tenantId: Int, name: String, scope: RoleScope, clientId: Int?): Role? =
+        store.values.find {
+            it.tenantId == tenantId && it.name == name && it.scope == scope && it.clientId == clientId
+        }
+
+    override fun findByTenantId(tenantId: Int): List<Role> =
+        store.values.filter { it.tenantId == tenantId }
+
+    override fun findByClientId(tenantId: Int, clientId: Int): List<Role> =
+        store.values.filter { it.tenantId == tenantId && it.clientId == clientId }
+
+    override fun save(role: Role): Role {
+        val r = if (role.id == null) role.copy(id = nextId++) else role
+        store[r.id!!] = r
+        return r
+    }
+
+    override fun update(role: Role): Role {
+        store[role.id!!] = role
+        return role
+    }
+
+    override fun delete(roleId: Int) {
+        store.remove(roleId)
+        composites.remove(roleId)
+        composites.values.forEach { it.remove(roleId) }
+        userRoles.values.forEach { it.remove(roleId) }
+    }
+
+    override fun addChildRole(parentRoleId: Int, childRoleId: Int) {
+        composites.getOrPut(parentRoleId) { mutableSetOf() }.add(childRoleId)
+    }
+
+    override fun removeChildRole(parentRoleId: Int, childRoleId: Int) {
+        composites[parentRoleId]?.remove(childRoleId)
+    }
+
+    override fun findChildRoleIds(roleId: Int): List<Int> =
+        composites[roleId]?.toList() ?: emptyList()
+
+    override fun assignRoleToUser(userId: Int, roleId: Int) {
+        userRoles.getOrPut(userId) { mutableSetOf() }.add(roleId)
+    }
+
+    override fun unassignRoleFromUser(userId: Int, roleId: Int) {
+        userRoles[userId]?.remove(roleId)
+    }
+
+    override fun findRolesForUser(userId: Int): List<Role> =
+        userRoles[userId]?.mapNotNull { store[it] } ?: emptyList()
+
+    override fun findUserIdsForRole(roleId: Int): List<Int> =
+        userRoles.filter { it.value.contains(roleId) }.keys.toList()
+
+    override fun resolveEffectiveRoles(userId: Int, tenantId: Int): List<Role> {
+        val directRoleIds = userRoles[userId] ?: emptySet()
+        val allRoleIds = mutableSetOf<Int>()
+        val queue = ArrayDeque(directRoleIds.toList())
+        while (queue.isNotEmpty()) {
+            val id = queue.removeFirst()
+            if (allRoleIds.add(id)) {
+                queue.addAll(composites[id] ?: emptySet())
+            }
+        }
+        return allRoleIds.mapNotNull { store[it] }.filter { it.tenantId == tenantId }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
@@ -33,16 +33,22 @@ class FakeRoleRepository : RoleRepository {
 
     override fun findById(id: Int): Role? = store[id]
 
-    override fun findByName(tenantId: Int, name: String, scope: RoleScope, clientId: Int?): Role? =
+    override fun findByName(
+        tenantId: Int,
+        name: String,
+        scope: RoleScope,
+        clientId: Int?,
+    ): Role? =
         store.values.find {
             it.tenantId == tenantId && it.name == name && it.scope == scope && it.clientId == clientId
         }
 
-    override fun findByTenantId(tenantId: Int): List<Role> =
-        store.values.filter { it.tenantId == tenantId }
+    override fun findByTenantId(tenantId: Int): List<Role> = store.values.filter { it.tenantId == tenantId }
 
-    override fun findByClientId(tenantId: Int, clientId: Int): List<Role> =
-        store.values.filter { it.tenantId == tenantId && it.clientId == clientId }
+    override fun findByClientId(
+        tenantId: Int,
+        clientId: Int,
+    ): List<Role> = store.values.filter { it.tenantId == tenantId && it.clientId == clientId }
 
     override fun save(role: Role): Role {
         val r = if (role.id == null) role.copy(id = nextId++) else role
@@ -62,32 +68,45 @@ class FakeRoleRepository : RoleRepository {
         userRoles.values.forEach { it.remove(roleId) }
     }
 
-    override fun addChildRole(parentRoleId: Int, childRoleId: Int) {
+    override fun addChildRole(
+        parentRoleId: Int,
+        childRoleId: Int,
+    ) {
         composites.getOrPut(parentRoleId) { mutableSetOf() }.add(childRoleId)
     }
 
-    override fun removeChildRole(parentRoleId: Int, childRoleId: Int) {
+    override fun removeChildRole(
+        parentRoleId: Int,
+        childRoleId: Int,
+    ) {
         composites[parentRoleId]?.remove(childRoleId)
     }
 
-    override fun findChildRoleIds(roleId: Int): List<Int> =
-        composites[roleId]?.toList() ?: emptyList()
+    override fun findChildRoleIds(roleId: Int): List<Int> = composites[roleId]?.toList() ?: emptyList()
 
-    override fun assignRoleToUser(userId: Int, roleId: Int) {
+    override fun assignRoleToUser(
+        userId: Int,
+        roleId: Int,
+    ) {
         userRoles.getOrPut(userId) { mutableSetOf() }.add(roleId)
     }
 
-    override fun unassignRoleFromUser(userId: Int, roleId: Int) {
+    override fun unassignRoleFromUser(
+        userId: Int,
+        roleId: Int,
+    ) {
         userRoles[userId]?.remove(roleId)
     }
 
-    override fun findRolesForUser(userId: Int): List<Role> =
-        userRoles[userId]?.mapNotNull { store[it] } ?: emptyList()
+    override fun findRolesForUser(userId: Int): List<Role> = userRoles[userId]?.mapNotNull { store[it] } ?: emptyList()
 
     override fun findUserIdsForRole(roleId: Int): List<Int> =
         userRoles.filter { it.value.contains(roleId) }.keys.toList()
 
-    override fun resolveEffectiveRoles(userId: Int, tenantId: Int): List<Role> {
+    override fun resolveEffectiveRoles(
+        userId: Int,
+        tenantId: Int,
+    ): List<Role> {
         val directRoleIds = userRoles[userId] ?: emptySet()
         val allRoleIds = mutableSetOf<Int>()
         val queue = ArrayDeque(directRoleIds.toList())

--- a/src/test/kotlin/com/kauth/fakes/FakeSocialAccountRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeSocialAccountRepository.kt
@@ -1,0 +1,42 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.SocialAccount
+import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.port.SocialAccountRepository
+
+/**
+ * In-memory SocialAccountRepository for unit tests.
+ */
+class FakeSocialAccountRepository : SocialAccountRepository {
+    private val store = mutableMapOf<Int, SocialAccount>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<SocialAccount> = store.values.toList()
+
+    override fun findByProviderIdentity(
+        tenantId: Int,
+        provider: SocialProvider,
+        providerUserId: String,
+    ): SocialAccount? =
+        store.values.find {
+            it.tenantId == tenantId && it.provider == provider && it.providerUserId == providerUserId
+        }
+
+    override fun findByUserId(userId: Int): List<SocialAccount> =
+        store.values.filter { it.userId == userId }
+
+    override fun save(account: SocialAccount): SocialAccount {
+        val a = if (account.id == null) account.copy(id = nextId++) else account
+        store[a.id!!] = a
+        return a
+    }
+
+    override fun delete(userId: Int, provider: SocialProvider) {
+        store.entries.removeIf { it.value.userId == userId && it.value.provider == provider }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeSocialAccountRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeSocialAccountRepository.kt
@@ -27,8 +27,7 @@ class FakeSocialAccountRepository : SocialAccountRepository {
             it.tenantId == tenantId && it.provider == provider && it.providerUserId == providerUserId
         }
 
-    override fun findByUserId(userId: Int): List<SocialAccount> =
-        store.values.filter { it.userId == userId }
+    override fun findByUserId(userId: Int): List<SocialAccount> = store.values.filter { it.userId == userId }
 
     override fun save(account: SocialAccount): SocialAccount {
         val a = if (account.id == null) account.copy(id = nextId++) else account
@@ -36,7 +35,10 @@ class FakeSocialAccountRepository : SocialAccountRepository {
         return a
     }
 
-    override fun delete(userId: Int, provider: SocialProvider) {
+    override fun delete(
+        userId: Int,
+        provider: SocialProvider,
+    ) {
         store.entries.removeIf { it.value.userId == userId && it.value.provider == provider }
     }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeSocialProviderPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeSocialProviderPort.kt
@@ -1,0 +1,40 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.port.SocialProviderPort
+import com.kauth.domain.port.SocialUserProfile
+
+/**
+ * In-memory SocialProviderPort for unit tests.
+ * Returns a configurable profile or throws to simulate provider failures.
+ */
+class FakeSocialProviderPort(
+    override val provider: SocialProvider,
+) : SocialProviderPort {
+    var profileToReturn: SocialUserProfile? = null
+    var shouldFail: Boolean = false
+    var authorizationUrl: String = "https://provider.example.com/auth"
+
+    fun clear() {
+        profileToReturn = null
+        shouldFail = false
+        authorizationUrl = "https://provider.example.com/auth"
+    }
+
+    override fun exchangeCodeForProfile(
+        code: String,
+        redirectUri: String,
+        clientId: String,
+        clientSecret: String,
+    ): SocialUserProfile {
+        if (shouldFail) throw RuntimeException("Provider exchange failed")
+        return profileToReturn ?: throw RuntimeException("No profile configured in fake")
+    }
+
+    override fun buildAuthorizationUrl(
+        clientId: String,
+        redirectUri: String,
+        state: String,
+        scopes: List<String>,
+    ): String = "$authorizationUrl?client_id=$clientId&redirect_uri=$redirectUri&state=$state"
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
@@ -21,8 +21,13 @@ class FakeTokenPort : TokenPort {
     // session has a different refresh token hash.
     private var callCount = 0
 
+    var claimsToReturn: AccessTokenClaims? = null
+    var jwksToReturn: List<Map<String, Any>> = emptyList()
+
     fun reset() {
         callCount = 0
+        claimsToReturn = null
+        jwksToReturn = emptyList()
     }
 
     override fun issueUserTokens(
@@ -51,8 +56,7 @@ class FakeTokenPort : TokenPort {
         scopes: List<String>,
     ): String = "fake.m2m.${client.clientId}"
 
-    /** Not needed for domain service tests — return null. */
-    override fun decodeAccessToken(token: String): AccessTokenClaims? = null
+    override fun decodeAccessToken(token: String): AccessTokenClaims? = claimsToReturn
 
-    override fun getTenantJwks(tenantId: Int): List<Map<String, Any>> = emptyList()
+    override fun getTenantJwks(tenantId: Int): List<Map<String, Any>> = jwksToReturn
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeWebhookDeliveryRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeWebhookDeliveryRepository.kt
@@ -1,0 +1,47 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.WebhookDelivery
+import com.kauth.domain.model.WebhookDeliveryStatus
+import com.kauth.domain.port.WebhookDeliveryRepository
+
+class FakeWebhookDeliveryRepository : WebhookDeliveryRepository {
+    private val store = mutableMapOf<Int, WebhookDelivery>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<WebhookDelivery> = store.values.toList()
+
+    override fun save(delivery: WebhookDelivery): WebhookDelivery {
+        val d = delivery.copy(id = nextId++)
+        store[d.id!!] = d
+        return d
+    }
+
+    override fun update(delivery: WebhookDelivery) {
+        delivery.id?.let { store[it] = delivery }
+    }
+
+    override fun findByEndpointId(endpointId: Int, limit: Int): List<WebhookDelivery> =
+        store.values
+            .filter { it.endpointId == endpointId }
+            .sortedByDescending { it.createdAt }
+            .take(limit)
+
+    override fun findByTenantId(tenantId: Int, limit: Int): List<WebhookDelivery> {
+        // In production this joins on endpoint.tenantId — here we need the endpoint repo
+        // For simplicity, return all deliveries (tests scope by endpointId anyway)
+        return store.values.sortedByDescending { it.createdAt }.take(limit)
+    }
+
+    override fun findById(id: Int): WebhookDelivery? = store[id]
+
+    override fun findPending(limit: Int): List<WebhookDelivery> =
+        store.values
+            .filter { it.status == WebhookDeliveryStatus.PENDING }
+            .sortedBy { it.createdAt }
+            .take(limit)
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeWebhookDeliveryRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeWebhookDeliveryRepository.kt
@@ -25,13 +25,19 @@ class FakeWebhookDeliveryRepository : WebhookDeliveryRepository {
         delivery.id?.let { store[it] = delivery }
     }
 
-    override fun findByEndpointId(endpointId: Int, limit: Int): List<WebhookDelivery> =
+    override fun findByEndpointId(
+        endpointId: Int,
+        limit: Int,
+    ): List<WebhookDelivery> =
         store.values
             .filter { it.endpointId == endpointId }
             .sortedByDescending { it.createdAt }
             .take(limit)
 
-    override fun findByTenantId(tenantId: Int, limit: Int): List<WebhookDelivery> {
+    override fun findByTenantId(
+        tenantId: Int,
+        limit: Int,
+    ): List<WebhookDelivery> {
         // In production this joins on endpoint.tenantId — here we need the endpoint repo
         // For simplicity, return all deliveries (tests scope by endpointId anyway)
         return store.values.sortedByDescending { it.createdAt }.take(limit)

--- a/src/test/kotlin/com/kauth/fakes/FakeWebhookEndpointRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeWebhookEndpointRepository.kt
@@ -1,0 +1,53 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.WebhookEndpoint
+import com.kauth.domain.port.WebhookEndpointRepository
+
+class FakeWebhookEndpointRepository : WebhookEndpointRepository {
+    private val store = mutableMapOf<Int, WebhookEndpoint>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun add(endpoint: WebhookEndpoint): WebhookEndpoint {
+        val e = if (endpoint.id == null) endpoint.copy(id = nextId++) else endpoint
+        store[e.id!!] = e
+        return e
+    }
+
+    override fun save(endpoint: WebhookEndpoint): WebhookEndpoint {
+        val e = endpoint.copy(id = nextId++)
+        store[e.id!!] = e
+        return e
+    }
+
+    override fun findByTenantId(tenantId: Int): List<WebhookEndpoint> =
+        store.values.filter { it.tenantId == tenantId }.sortedByDescending { it.createdAt }
+
+    override fun findEnabledByTenantAndEvent(tenantId: Int, eventType: String): List<WebhookEndpoint> =
+        store.values.filter {
+            it.tenantId == tenantId && it.enabled && eventType in it.events
+        }
+
+    override fun findById(id: Int, tenantId: Int): WebhookEndpoint? =
+        store[id]?.takeIf { it.tenantId == tenantId }
+
+    override fun update(endpoint: WebhookEndpoint) {
+        endpoint.id?.let { store[it] = endpoint }
+    }
+
+    override fun delete(id: Int, tenantId: Int) {
+        val ep = store[id]
+        if (ep != null && ep.tenantId == tenantId) store.remove(id)
+    }
+
+    override fun setEnabled(id: Int, tenantId: Int, enabled: Boolean) {
+        val ep = store[id]
+        if (ep != null && ep.tenantId == tenantId) {
+            store[id] = ep.copy(enabled = enabled)
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeWebhookEndpointRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeWebhookEndpointRepository.kt
@@ -27,24 +27,36 @@ class FakeWebhookEndpointRepository : WebhookEndpointRepository {
     override fun findByTenantId(tenantId: Int): List<WebhookEndpoint> =
         store.values.filter { it.tenantId == tenantId }.sortedByDescending { it.createdAt }
 
-    override fun findEnabledByTenantAndEvent(tenantId: Int, eventType: String): List<WebhookEndpoint> =
+    override fun findEnabledByTenantAndEvent(
+        tenantId: Int,
+        eventType: String,
+    ): List<WebhookEndpoint> =
         store.values.filter {
             it.tenantId == tenantId && it.enabled && eventType in it.events
         }
 
-    override fun findById(id: Int, tenantId: Int): WebhookEndpoint? =
-        store[id]?.takeIf { it.tenantId == tenantId }
+    override fun findById(
+        id: Int,
+        tenantId: Int,
+    ): WebhookEndpoint? = store[id]?.takeIf { it.tenantId == tenantId }
 
     override fun update(endpoint: WebhookEndpoint) {
         endpoint.id?.let { store[it] = endpoint }
     }
 
-    override fun delete(id: Int, tenantId: Int) {
+    override fun delete(
+        id: Int,
+        tenantId: Int,
+    ) {
         val ep = store[id]
         if (ep != null && ep.tenantId == tenantId) store.remove(id)
     }
 
-    override fun setEnabled(id: Int, tenantId: Int, enabled: Boolean) {
+    override fun setEnabled(
+        id: Int,
+        tenantId: Int,
+        enabled: Boolean,
+    ) {
         val ep = store[id]
         if (ep != null && ep.tenantId == tenantId) {
             store[id] = ep.copy(enabled = enabled)

--- a/src/test/kotlin/com/kauth/infrastructure/EncryptionServiceTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/EncryptionServiceTest.kt
@@ -2,6 +2,8 @@ package com.kauth.infrastructure
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -99,5 +101,105 @@ class EncryptionServiceTest {
         val result = EncryptionService.decrypt(corrupted)
 
         assertNull(result, "decrypt must return null when ciphertext has been tampered with")
+    }
+
+    @Test
+    fun `encrypt produces different ciphertexts for the same plaintext (random IV)`() {
+        if (!EncryptionService.isAvailable) return
+
+        val plaintext = "same-value-twice"
+        val enc1 = EncryptionService.encrypt(plaintext)
+        val enc2 = EncryptionService.encrypt(plaintext)
+
+        assertNotEquals(enc1, enc2, "Each encryption should use a unique IV and produce different ciphertext")
+
+        assertEquals(plaintext, EncryptionService.decrypt(enc1))
+        assertEquals(plaintext, EncryptionService.decrypt(enc2))
+    }
+
+    @Test
+    fun `encrypt output has expected iv-dot-ciphertext format`() {
+        if (!EncryptionService.isAvailable) return
+
+        val encrypted = EncryptionService.encrypt("test")
+        val parts = encrypted.split(".")
+        assertEquals(2, parts.size, "Encrypted value must have exactly two dot-separated parts (iv.ciphertext)")
+        assertTrue(parts[0].isNotEmpty(), "IV part must not be empty")
+        assertTrue(parts[1].isNotEmpty(), "Ciphertext part must not be empty")
+    }
+
+    @Test
+    fun `decrypt returns null for empty string`() {
+        assertNull(EncryptionService.decrypt(""))
+    }
+
+    @Test
+    fun `decrypt returns null for string without dot separator`() {
+        assertNull(EncryptionService.decrypt("nodothere"))
+    }
+
+    @Test
+    fun `decrypt returns null for string with too many dots`() {
+        if (!EncryptionService.isAvailable) return
+
+        val encrypted = EncryptionService.encrypt("test")
+        val corrupted = "$encrypted.extra"
+        assertNull(EncryptionService.decrypt(corrupted), "Three-part string should fail decryption")
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional cookie signing edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `signCookie - handles empty value`() {
+        val signed = EncryptionService.signCookie("")
+        assertTrue(signed.startsWith("."), "Empty value should produce a cookie starting with dot")
+        val verified = EncryptionService.verifyCookie(signed)
+        assertEquals("", verified, "Round-trip should return empty string")
+    }
+
+    @Test
+    fun `signCookie - handles value containing dots`() {
+        val value = "part1.part2.part3"
+        val signed = EncryptionService.signCookie(value)
+        val verified = EncryptionService.verifyCookie(signed)
+        assertEquals(value, verified, "Values with dots should round-trip correctly (lastIndexOf split)")
+    }
+
+    @Test
+    fun `signCookie - handles unicode content`() {
+        val value = "user:42|café|日本語"
+        val signed = EncryptionService.signCookie(value)
+        val verified = EncryptionService.verifyCookie(signed)
+        assertEquals(value, verified, "Unicode content should round-trip correctly")
+    }
+
+    @Test
+    fun `verifyCookie - rejects completely empty string`() {
+        assertNull(EncryptionService.verifyCookie(""))
+    }
+
+    @Test
+    fun `verifyCookie - rejects signature from a different value swapped in`() {
+        val signed1 = EncryptionService.signCookie("user:1|tenant:a")
+        val signed2 = EncryptionService.signCookie("user:2|tenant:b")
+
+        // Take the value from signed1 and the signature from signed2
+        val lastDot1 = signed1.lastIndexOf('.')
+        val lastDot2 = signed2.lastIndexOf('.')
+        val frankenCookie = signed1.substring(0, lastDot1) + signed2.substring(lastDot2)
+
+        assertNull(
+            EncryptionService.verifyCookie(frankenCookie),
+            "Mismatched value+signature should be rejected",
+        )
+    }
+
+    @Test
+    fun `signCookie is deterministic - same value produces same signature`() {
+        val signed1 = EncryptionService.signCookie("deterministic-test")
+        val signed2 = EncryptionService.signCookie("deterministic-test")
+        assertEquals(signed1, signed2, "HMAC signing should be deterministic for the same key and value")
     }
 }

--- a/src/test/kotlin/com/kauth/infrastructure/EncryptionServiceTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/EncryptionServiceTest.kt
@@ -2,7 +2,6 @@ package com.kauth.infrastructure
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/src/test/kotlin/com/kauth/infrastructure/KeyGeneratorTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/KeyGeneratorTest.kt
@@ -1,0 +1,92 @@
+package com.kauth.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [KeyGenerator] — RSA key pair generation and PEM serialization.
+ *
+ * Tests cover: key pair generation, PEM format, round-trip encode/decode,
+ * key uniqueness, and key size validation.
+ */
+class KeyGeneratorTest {
+    // =========================================================================
+    // generateRsaKeyPair
+    // =========================================================================
+
+    @Test
+    fun `generateRsaKeyPair - returns KeyPairPem with correct keyId`() {
+        val kp = KeyGenerator.generateRsaKeyPair("test-key-1")
+        assertEquals("test-key-1", kp.keyId)
+    }
+
+    @Test
+    fun `generateRsaKeyPair - public key is valid PEM format`() {
+        val kp = KeyGenerator.generateRsaKeyPair("test-key-2")
+        assertTrue(kp.publicKeyPem.startsWith("-----BEGIN PUBLIC KEY-----"))
+        assertTrue(kp.publicKeyPem.endsWith("-----END PUBLIC KEY-----"))
+    }
+
+    @Test
+    fun `generateRsaKeyPair - private key is valid PEM format`() {
+        val kp = KeyGenerator.generateRsaKeyPair("test-key-3")
+        assertTrue(kp.privateKeyPem.startsWith("-----BEGIN PRIVATE KEY-----"))
+        assertTrue(kp.privateKeyPem.endsWith("-----END PRIVATE KEY-----"))
+    }
+
+    @Test
+    fun `generateRsaKeyPair - produces unique key pairs on each call`() {
+        val kp1 = KeyGenerator.generateRsaKeyPair("key-a")
+        val kp2 = KeyGenerator.generateRsaKeyPair("key-b")
+        assertNotEquals(kp1.publicKeyPem, kp2.publicKeyPem, "Different calls should produce different public keys")
+        assertNotEquals(kp1.privateKeyPem, kp2.privateKeyPem, "Different calls should produce different private keys")
+    }
+
+    // =========================================================================
+    // decodePublicKey / decodePrivateKey — round-trip
+    // =========================================================================
+
+    @Test
+    fun `decodePublicKey - round-trip from generated PEM produces valid RSA key`() {
+        val kp = KeyGenerator.generateRsaKeyPair("round-trip-pub")
+        val decoded = KeyGenerator.decodePublicKey(kp.publicKeyPem)
+        assertEquals("RSA", decoded.algorithm)
+        assertTrue(decoded.modulus.bitLength() >= 2048, "Key must be at least 2048-bit")
+    }
+
+    @Test
+    fun `decodePrivateKey - round-trip from generated PEM produces valid RSA key`() {
+        val kp = KeyGenerator.generateRsaKeyPair("round-trip-priv")
+        val decoded = KeyGenerator.decodePrivateKey(kp.privateKeyPem)
+        assertEquals("RSA", decoded.algorithm)
+        assertTrue(decoded.modulus.bitLength() >= 2048, "Key must be at least 2048-bit")
+    }
+
+    @Test
+    fun `public and private keys share the same modulus`() {
+        val kp = KeyGenerator.generateRsaKeyPair("modulus-check")
+        val pub = KeyGenerator.decodePublicKey(kp.publicKeyPem)
+        val priv = KeyGenerator.decodePrivateKey(kp.privateKeyPem)
+        assertEquals(pub.modulus, priv.modulus, "Public and private keys must share the same modulus")
+    }
+
+    @Test
+    fun `generated key pair can sign and verify data`() {
+        val kp = KeyGenerator.generateRsaKeyPair("sign-verify")
+        val priv = KeyGenerator.decodePrivateKey(kp.privateKeyPem)
+        val pub = KeyGenerator.decodePublicKey(kp.publicKeyPem)
+
+        val data = "test payload".toByteArray()
+        val sig = java.security.Signature.getInstance("SHA256withRSA")
+        sig.initSign(priv)
+        sig.update(data)
+        val signature = sig.sign()
+
+        val verifier = java.security.Signature.getInstance("SHA256withRSA")
+        verifier.initVerify(pub)
+        verifier.update(data)
+        assertTrue(verifier.verify(signature), "Signature produced by private key must verify with public key")
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/RateLimiterTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/RateLimiterTest.kt
@@ -1,0 +1,135 @@
+package com.kauth.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [RateLimiter] — in-memory sliding-window rate limiter.
+ *
+ * These tests exercise the core contract: allow up to [maxRequests] within
+ * [windowSeconds], then reject. Also tests key isolation, remaining count,
+ * and reset behavior.
+ */
+class RateLimiterTest {
+    // =========================================================================
+    // isAllowed — basic flow
+    // =========================================================================
+
+    @Test
+    fun `isAllowed - permits requests up to the limit`() {
+        val limiter = RateLimiter(maxRequests = 3, windowSeconds = 60)
+
+        assertTrue(limiter.isAllowed("key1"), "1st request should be allowed")
+        assertTrue(limiter.isAllowed("key1"), "2nd request should be allowed")
+        assertTrue(limiter.isAllowed("key1"), "3rd request should be allowed")
+    }
+
+    @Test
+    fun `isAllowed - rejects requests beyond the limit`() {
+        val limiter = RateLimiter(maxRequests = 3, windowSeconds = 60)
+
+        repeat(3) { limiter.isAllowed("key1") }
+        assertFalse(limiter.isAllowed("key1"), "4th request should be rate-limited")
+        assertFalse(limiter.isAllowed("key1"), "5th request should also be rate-limited")
+    }
+
+    @Test
+    fun `isAllowed - limit of 1 blocks immediately after first request`() {
+        val limiter = RateLimiter(maxRequests = 1, windowSeconds = 60)
+
+        assertTrue(limiter.isAllowed("key1"))
+        assertFalse(limiter.isAllowed("key1"))
+    }
+
+    // =========================================================================
+    // Key isolation
+    // =========================================================================
+
+    @Test
+    fun `isAllowed - different keys have independent limits`() {
+        val limiter = RateLimiter(maxRequests = 2, windowSeconds = 60)
+
+        assertTrue(limiter.isAllowed("user:1"))
+        assertTrue(limiter.isAllowed("user:1"))
+        assertFalse(limiter.isAllowed("user:1"), "user:1 should be exhausted")
+
+        assertTrue(limiter.isAllowed("user:2"), "user:2 should have its own quota")
+        assertTrue(limiter.isAllowed("user:2"))
+    }
+
+    // =========================================================================
+    // remaining
+    // =========================================================================
+
+    @Test
+    fun `remaining - returns maxRequests for unknown key`() {
+        val limiter = RateLimiter(maxRequests = 5, windowSeconds = 60)
+        assertEquals(5, limiter.remaining("never-seen"))
+    }
+
+    @Test
+    fun `remaining - decrements with each allowed request`() {
+        val limiter = RateLimiter(maxRequests = 3, windowSeconds = 60)
+
+        assertEquals(3, limiter.remaining("key1"))
+        limiter.isAllowed("key1")
+        assertEquals(2, limiter.remaining("key1"))
+        limiter.isAllowed("key1")
+        assertEquals(1, limiter.remaining("key1"))
+        limiter.isAllowed("key1")
+        assertEquals(0, limiter.remaining("key1"))
+    }
+
+    @Test
+    fun `remaining - never goes below zero`() {
+        val limiter = RateLimiter(maxRequests = 1, windowSeconds = 60)
+        limiter.isAllowed("key1")
+        limiter.isAllowed("key1") // rejected but shouldn't go negative
+        assertEquals(0, limiter.remaining("key1"))
+    }
+
+    // =========================================================================
+    // reset
+    // =========================================================================
+
+    @Test
+    fun `reset - restores full quota for the key`() {
+        val limiter = RateLimiter(maxRequests = 2, windowSeconds = 60)
+
+        limiter.isAllowed("key1")
+        limiter.isAllowed("key1")
+        assertFalse(limiter.isAllowed("key1"), "Should be rate-limited before reset")
+
+        limiter.reset("key1")
+
+        assertTrue(limiter.isAllowed("key1"), "Should be allowed after reset")
+        assertEquals(1, limiter.remaining("key1"))
+    }
+
+    @Test
+    fun `reset - does not affect other keys`() {
+        val limiter = RateLimiter(maxRequests = 2, windowSeconds = 60)
+
+        limiter.isAllowed("key1")
+        limiter.isAllowed("key2")
+        limiter.isAllowed("key2")
+
+        limiter.reset("key1")
+
+        assertFalse(limiter.isAllowed("key2"), "key2 should still be rate-limited")
+        assertEquals(2, limiter.remaining("key1"), "key1 should be fully reset")
+    }
+
+    // =========================================================================
+    // Constructor properties
+    // =========================================================================
+
+    @Test
+    fun `constructor properties are accessible`() {
+        val limiter = RateLimiter(maxRequests = 10, windowSeconds = 120)
+        assertEquals(10, limiter.maxRequests)
+        assertEquals(120L, limiter.windowSeconds)
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/TotpUtilTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/TotpUtilTest.kt
@@ -1,0 +1,186 @@
+package com.kauth.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [TotpUtil] — RFC 6238 TOTP implementation.
+ *
+ * Tests cover: secret generation, Base32 encode/decode, URI formatting,
+ * TOTP code generation/verification, and clock skew tolerance.
+ */
+class TotpUtilTest {
+    // =========================================================================
+    // generateSecret
+    // =========================================================================
+
+    @Test
+    fun `generateSecret - returns a non-blank Base32 string`() {
+        val secret = TotpUtil.generateSecret()
+        assertTrue(secret.isNotBlank())
+        assertTrue(secret.all { it in "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567" }, "Secret must be valid Base32")
+    }
+
+    @Test
+    fun `generateSecret - produces unique secrets on each call`() {
+        val secrets = (1..10).map { TotpUtil.generateSecret() }.toSet()
+        assertEquals(10, secrets.size, "10 calls should produce 10 unique secrets")
+    }
+
+    @Test
+    fun `generateSecret - decodes back to 20 bytes (160-bit HMAC-SHA1 key)`() {
+        val secret = TotpUtil.generateSecret()
+        val decoded = TotpUtil.base32Decode(secret)
+        assertEquals(20, decoded.size, "Secret must decode to 20 bytes for HMAC-SHA1")
+    }
+
+    // =========================================================================
+    // base32Encode / base32Decode
+    // =========================================================================
+
+    @Test
+    fun `base32 round-trip preserves arbitrary byte arrays`() {
+        val original = byteArrayOf(0, 1, 2, 127, -128, -1, 42, 99)
+        val encoded = TotpUtil.base32Encode(original)
+        val decoded = TotpUtil.base32Decode(encoded)
+        assertTrue(original.contentEquals(decoded), "Base32 round-trip must preserve byte content")
+    }
+
+    @Test
+    fun `base32Encode - known value matches expected output`() {
+        // "Hello" in ASCII = [72, 101, 108, 108, 111]
+        // Base32("Hello") = "JBSWY3DP" (per RFC 4648 test vectors, no padding)
+        val encoded = TotpUtil.base32Encode("Hello".toByteArray(Charsets.US_ASCII))
+        assertEquals("JBSWY3DP", encoded)
+    }
+
+    @Test
+    fun `base32Decode - handles lowercase input`() {
+        val upper = TotpUtil.base32Decode("JBSWY3DP")
+        val lower = TotpUtil.base32Decode("jbswy3dp")
+        assertTrue(upper.contentEquals(lower), "Base32 decode should be case-insensitive")
+    }
+
+    @Test
+    fun `base32Decode - strips padding characters`() {
+        val withPadding = TotpUtil.base32Decode("JBSWY3DP======")
+        val without = TotpUtil.base32Decode("JBSWY3DP")
+        assertTrue(withPadding.contentEquals(without), "Padding should be stripped and ignored")
+    }
+
+    @Test
+    fun `base32Decode - empty string returns empty array`() {
+        val decoded = TotpUtil.base32Decode("")
+        assertEquals(0, decoded.size)
+    }
+
+    // =========================================================================
+    // generateUri
+    // =========================================================================
+
+    @Test
+    fun `generateUri - contains required components`() {
+        val secret = "JBSWY3DPEHPK3PXP"
+        val uri = TotpUtil.generateUri(secret = secret, accountName = "alice@example.com", issuer = "Acme Corp")
+
+        assertTrue(uri.startsWith("otpauth://totp/"), "Must use otpauth scheme")
+        assertTrue(uri.contains("secret=$secret"), "Must include the secret")
+        assertTrue(uri.contains("issuer=Acme"), "Must include the issuer")
+        assertTrue(uri.contains("algorithm=SHA1"), "Must specify SHA1")
+        assertTrue(uri.contains("digits=6"), "Must specify 6 digits")
+        assertTrue(uri.contains("period=30"), "Must specify 30s period")
+    }
+
+    @Test
+    fun `generateUri - URL-encodes special characters in issuer and account`() {
+        val uri = TotpUtil.generateUri(
+            secret = "ABCDEF",
+            accountName = "user@example.com",
+            issuer = "My Company & Co",
+        )
+        assertTrue(uri.contains("My+Company"), "Spaces and special chars should be URL-encoded")
+        assertTrue(uri.contains("user%40example.com"), "@ should be URL-encoded")
+    }
+
+    // =========================================================================
+    // generateCode
+    // =========================================================================
+
+    @Test
+    fun `generateCode - returns a 6-digit string`() {
+        val secret = TotpUtil.generateSecret()
+        val code = TotpUtil.generateCode(secret)
+        assertEquals(6, code.length)
+        assertTrue(code.all { it.isDigit() }, "Code must be all digits")
+    }
+
+    @Test
+    fun `generateCode - same secret and time produce the same code`() {
+        val secret = TotpUtil.generateSecret()
+        val fixedTime = 1700000000000L
+        val code1 = TotpUtil.generateCode(secret, fixedTime)
+        val code2 = TotpUtil.generateCode(secret, fixedTime)
+        assertEquals(code1, code2, "Same inputs must produce the same TOTP code")
+    }
+
+    @Test
+    fun `generateCode - different time steps produce different codes`() {
+        val secret = TotpUtil.generateSecret()
+        val code1 = TotpUtil.generateCode(secret, 1700000000000L)
+        val code2 = TotpUtil.generateCode(secret, 1700000060000L) // 60s later = different step
+        assertNotEquals(code1, code2, "Different time steps should produce different codes")
+    }
+
+    // =========================================================================
+    // verify
+    // =========================================================================
+
+    @Test
+    fun `verify - accepts a valid code for the current time step`() {
+        val secret = TotpUtil.generateSecret()
+        val fixedTime = 1700000000000L
+        val code = TotpUtil.generateCode(secret, fixedTime)
+        assertTrue(TotpUtil.verify(secret, code, fixedTime))
+    }
+
+    @Test
+    fun `verify - accepts code from adjacent time steps (clock skew tolerance)`() {
+        val secret = TotpUtil.generateSecret()
+        val fixedTime = 1700000000000L
+        val codePrevStep = TotpUtil.generateCode(secret, fixedTime - 30_000L) // previous step
+        val codeNextStep = TotpUtil.generateCode(secret, fixedTime + 30_000L) // next step
+
+        assertTrue(TotpUtil.verify(secret, codePrevStep, fixedTime), "Should accept code from -1 time step")
+        assertTrue(TotpUtil.verify(secret, codeNextStep, fixedTime), "Should accept code from +1 time step")
+    }
+
+    @Test
+    fun `verify - rejects code from 2 steps away`() {
+        val secret = TotpUtil.generateSecret()
+        val fixedTime = 1700000000000L
+        val codeFarFuture = TotpUtil.generateCode(secret, fixedTime + 90_000L) // +3 steps
+        assertFalse(TotpUtil.verify(secret, codeFarFuture, fixedTime), "Should reject code from distant time step")
+    }
+
+    @Test
+    fun `verify - rejects non-numeric code`() {
+        val secret = TotpUtil.generateSecret()
+        assertFalse(TotpUtil.verify(secret, "abcdef"))
+    }
+
+    @Test
+    fun `verify - rejects code with wrong length`() {
+        val secret = TotpUtil.generateSecret()
+        assertFalse(TotpUtil.verify(secret, "12345"), "5-digit code should be rejected")
+        assertFalse(TotpUtil.verify(secret, "1234567"), "7-digit code should be rejected")
+    }
+
+    @Test
+    fun `verify - rejects empty code`() {
+        val secret = TotpUtil.generateSecret()
+        assertFalse(TotpUtil.verify(secret, ""))
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/TotpUtilTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/TotpUtilTest.kt
@@ -96,11 +96,12 @@ class TotpUtilTest {
 
     @Test
     fun `generateUri - URL-encodes special characters in issuer and account`() {
-        val uri = TotpUtil.generateUri(
-            secret = "ABCDEF",
-            accountName = "user@example.com",
-            issuer = "My Company & Co",
-        )
+        val uri =
+            TotpUtil.generateUri(
+                secret = "ABCDEF",
+                accountName = "user@example.com",
+                issuer = "My Company & Co",
+            )
         assertTrue(uri.contains("My+Company"), "Spaces and special chars should be URL-encoded")
         assertTrue(uri.contains("user%40example.com"), "@ should be URL-encoded")
     }


### PR DESCRIPTION
## What does this PR do?

This pull request introduces several improvements to testing practices and API response serialization, as well as updates to project documentation. The most significant changes include a comprehensive rewrite of the testing philosophy in `CONTRIBUTING.md`, the addition of new integration tests for health checks and admin API key management, and the replacement of `mapOf` with `buildJsonObject` for JSON responses to ensure serialization compatibility. Obsolete documentation has also been removed, and project status documents have been updated.

**Testing practices and coverage:**

* Rewrote the "Running Tests" section in `CONTRIBUTING.md` to a detailed "Testing Philosophy and Conventions" guide, covering the use of in-memory fakes, test layering, integration test patterns, known serialization issues, and test file organization.
* Added `src/test/kotlin/com/kauth/adapter/web/HealthRoutesTest.kt` with integration tests for health and readiness endpoints, including config checks and database readiness scenarios.
* Added `src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt` with integration tests for admin API key management routes, including key creation, revocation, and deletion.
* Removed the obsolete `TESTS_ROADMAP.md` file and redirected readers to the new testing section in `CONTRIBUTING.md`.

**API response serialization:**

* Replaced all uses of `mapOf` with `buildJsonObject` for JSON responses in `AuthRoutes.kt` to avoid kotlinx.serialization issues with polymorphic `Any` types, ensuring compatibility and correctness of API responses. [[1]](diffhunk://#diff-3cf23e1cdecde951712fe9a42cf670263852adb7f851e0ff5ce7b0b67ee32763L1406-R1425) [[2]](diffhunk://#diff-3cf23e1cdecde951712fe9a42cf670263852adb7f851e0ff5ce7b0b67ee32763L1432-R1441) [[3]](diffhunk://#diff-3cf23e1cdecde951712fe9a42cf670263852adb7f851e0ff5ce7b0b67ee32763L1454-R1472)

**Documentation updates:**

* Updated `docs/ROADMAP.md` and `docs/IMPLEMENTATION_STATUS.md` to reflect the latest project version (1.0.3) and current status, indicating that all planned phases (0–5) have shipped. [[1]](diffhunk://#diff-0d96796e2b2a475d618f28659f8bca752e1513e54ae8741220ec7b800d3777c2L3-R4) [[2]](diffhunk://#diff-f25fc4312adb72468e0cc2f3cd6297b096ddb26160de5aa3a0085551cf00532fL3-R4)
* Fixed the repository URL in the clone instructions in `CONTRIBUTING.md`.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
