### PR TITLE
fix/encryption-port-extraction

### DIFF
--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresIdentityProviderRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresIdentityProviderRepository.kt
@@ -2,8 +2,8 @@ package com.kauth.adapter.persistence
 
 import com.kauth.domain.model.IdentityProvider
 import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.port.EncryptionPort
 import com.kauth.domain.port.IdentityProviderRepository
-import com.kauth.infrastructure.EncryptionService
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -19,7 +19,7 @@ import java.time.ZoneOffset
  * is intentional: social login cannot be configured without encryption being available.
  */
 class PostgresIdentityProviderRepository(
-    private val encryptionService: EncryptionService,
+    private val encryptionService: EncryptionPort,
 ) : IdentityProviderRepository {
     override fun findEnabledByTenant(tenantId: Int): List<IdentityProvider> =
         transaction {

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresMfaRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresMfaRepository.kt
@@ -3,8 +3,8 @@ package com.kauth.adapter.persistence
 import com.kauth.domain.model.MfaEnrollment
 import com.kauth.domain.model.MfaMethod
 import com.kauth.domain.model.MfaRecoveryCode
+import com.kauth.domain.port.EncryptionPort
 import com.kauth.domain.port.MfaRepository
-import com.kauth.infrastructure.EncryptionService
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -19,7 +19,7 @@ import java.time.ZoneOffset
  * application warns about this at startup (see Application.kt).
  */
 class PostgresMfaRepository(
-    private val encryptionService: EncryptionService,
+    private val encryptionService: EncryptionPort,
 ) : MfaRepository {
     // -----------------------------------------------------------------------
     // Enrollments

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
@@ -2,8 +2,8 @@ package com.kauth.adapter.persistence
 
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.port.EncryptionPort
 import com.kauth.domain.port.TenantRepository
-import com.kauth.infrastructure.EncryptionService
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
@@ -17,12 +17,12 @@ import org.jetbrains.exposed.sql.update
  * A simple in-process cache keyed by slug would be a worthwhile optimisation
  * once traffic warrants it — the port interface makes that swap transparent.
  *
- * SMTP password is encrypted/decrypted transparently using [EncryptionService].
- * If [EncryptionService] is unavailable (KAUTH_SECRET_KEY not set), the password field
+ * SMTP password is encrypted/decrypted transparently using [EncryptionPort].
+ * If encryption is unavailable (KAUTH_SECRET_KEY not set), the password field
  * is stored as null and SMTP config will not function.
  */
 class PostgresTenantRepository(
-    private val encryptionService: EncryptionService,
+    private val encryptionService: EncryptionPort,
 ) : TenantRepository {
     override fun findBySlug(slug: String): Tenant? =
         transaction {

--- a/src/main/kotlin/com/kauth/domain/port/EncryptionPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/EncryptionPort.kt
@@ -1,0 +1,9 @@
+package com.kauth.domain.port
+
+interface EncryptionPort {
+    val isAvailable: Boolean
+
+    fun encrypt(plaintext: String): String
+
+    fun decrypt(encrypted: String): String?
+}

--- a/src/main/kotlin/com/kauth/infrastructure/EncryptionService.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/EncryptionService.kt
@@ -27,13 +27,12 @@ import javax.crypto.spec.SecretKeySpec
  * Cookie signing format: "{value}.{base64url(hmac)}"
  * Verification strips the signature, recomputes it, and compares in constant time.
  *
- * NOTE: A future follow-up will extract an EncryptionPort interface in the
- * domain layer so persistence adapters depend on an abstraction rather than
- * this concrete class. See KOTLIN_ADVANTAGE_ROADMAP.md for details.
+ * Persistence adapters depend on [com.kauth.domain.port.EncryptionPort] (encrypt/decrypt/isAvailable).
+ * Web adapters depend on the concrete class for cookie signing (signCookie/verifyCookie).
  */
 class EncryptionService(
     rawSecretKey: String?,
-) {
+) : com.kauth.domain.port.EncryptionPort {
     private val secretKey: SecretKeySpec? =
         if (rawSecretKey.isNullOrBlank()) {
             null
@@ -57,14 +56,14 @@ class EncryptionService(
             ByteArray(32).also { SecureRandom().nextBytes(it) }
         }
 
-    val isAvailable: Boolean get() = secretKey != null
+    override val isAvailable: Boolean get() = secretKey != null
 
     /**
      * Encrypts [plaintext] using AES-256-GCM.
      * Returns a base64-encoded "iv.ciphertext" string suitable for DB storage.
      * Throws [IllegalStateException] if no secret key was provided.
      */
-    fun encrypt(plaintext: String): String {
+    override fun encrypt(plaintext: String): String {
         val key =
             secretKey ?: error(
                 "KAUTH_SECRET_KEY env var is not set. Cannot encrypt SMTP password.",
@@ -83,7 +82,7 @@ class EncryptionService(
      * Decrypts an encrypted value produced by [encrypt].
      * Returns null if decryption fails (wrong key, tampered data, or missing secret key).
      */
-    fun decrypt(encrypted: String): String? {
+    override fun decrypt(encrypted: String): String? {
         val key = secretKey ?: return null
         return try {
             val parts = encrypted.split(".")


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new `EncryptionPort` interface in the domain layer and updates the persistence adapters to depend on this abstraction rather than the concrete `EncryptionService` implementation. This change improves the architecture by decoupling domain logic from infrastructure details and aligns the codebase with clean architecture principles. The most important changes are grouped below:

### Domain Layer Abstraction

* Added a new `EncryptionPort` interface in `com.kauth.domain.port`, defining the contract for encryption operations (`isAvailable`, `encrypt`, `decrypt`).

### Adapter Refactoring

* Updated constructors of `PostgresIdentityProviderRepository`, `PostgresMfaRepository`, and `PostgresTenantRepository` to depend on `EncryptionPort` instead of `EncryptionService`. Imports and documentation were updated accordingly. [[1]](diffhunk://#diff-ef4c19bec69262efd3e5f6cee610dcc07fb2062a236608c9269239f654279a24R5-L6) [[2]](diffhunk://#diff-ef4c19bec69262efd3e5f6cee610dcc07fb2062a236608c9269239f654279a24L22-R22) [[3]](diffhunk://#diff-fa36584c4900c0850e33130257247beb8f8a92cd623b4d995d4188a10001419bR6-L7) [[4]](diffhunk://#diff-fa36584c4900c0850e33130257247beb8f8a92cd623b4d995d4188a10001419bL22-R22) [[5]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R5-L6) [[6]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357L20-R25)

### Infrastructure Implementation

* Modified `EncryptionService` to implement the new `EncryptionPort` interface, marking relevant methods and properties with `override`. Documentation was updated to clarify the separation between domain and web adapter dependencies. [[1]](diffhunk://#diff-df3f15b4da40cd4223f693da9a298438f17355bda0a78635852b7840aa262f6eL30-R35) [[2]](diffhunk://#diff-df3f15b4da40cd4223f693da9a298438f17355bda0a78635852b7840aa262f6eL60-R66) [[3]](diffhunk://#diff-df3f15b4da40cd4223f693da9a298438f17355bda0a78635852b7840aa262f6eL86-R85)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
