### PR TITLE
chore/E2E-smoke-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 .DEFAULT_GOAL := help
-.PHONY: help css css-admin css-auth lint lint-fix test build jar version up up-fresh down nuke logs health
+.PHONY: help css css-admin css-auth lint lint-fix test e2e build jar version up up-fresh down nuke logs health
 
 # ── CSS ───────────────────────────────────────────────────────────────────────
 
@@ -32,6 +32,12 @@ lint-fix: ## Auto-fix lint issues with ktlintFormat
 
 test: ## Run the test suite
 	./gradlew test
+
+e2e: ## Run E2E browser smoke tests (Playwright, headless)
+	./gradlew e2eTest
+
+e2e-headed: ## Run E2E tests with visible browser (debugging)
+	./gradlew e2eTest -Dplaywright.headless=false
 
 build: ## Full build — CSS + lint + tests + fat JAR (CI-equivalent)
 	./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,37 @@ tasks.test {
     useJUnitPlatform()
 }
 
+// ── E2E smoke tests (Playwright) ─────────────────────────────────────────
+sourceSets {
+    create("e2eTest") {
+        kotlin.srcDir("src/e2eTest/kotlin")
+        resources.srcDir("src/e2eTest/resources")
+        compileClasspath += sourceSets["main"].output + sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output + sourceSets["test"].output
+    }
+}
+
+val e2eTestImplementation by configurations.getting {
+    extendsFrom(configurations.testImplementation.get())
+}
+val e2eTestRuntimeOnly by configurations.getting {
+    extendsFrom(configurations.testRuntimeOnly.get())
+}
+
+dependencies {
+    e2eTestImplementation("com.microsoft.playwright:playwright:1.44.0")
+}
+
+tasks.register<Test>("e2eTest") {
+    description = "Runs E2E browser smoke tests (Playwright)"
+    group = "verification"
+    testClassesDirs = sourceSets["e2eTest"].output.classesDirs
+    classpath = sourceSets["e2eTest"].runtimeClasspath
+    useJUnitPlatform()
+    maxParallelForks = 1
+    systemProperty("playwright.headless", System.getProperty("playwright.headless", "true"))
+}
+
 // ── CSS compilation ───────────────────────────────────────────────────────
 val lightningCssBin = "frontend/node_modules/.bin/lightningcss"
 

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminApiKeyE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminApiKeyE2ETest.kt
@@ -1,0 +1,104 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.ApiKey
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdminApiKeyE2ETest : E2ETestBase() {
+    private val workspace =
+        Tenant(
+            id = TenantId(2),
+            slug = "apikey-ws",
+            displayName = "API Key Workspace",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
+
+    @BeforeEach
+    fun seedWorkspace() {
+        tenantRepo.add(workspace)
+    }
+
+    @Test
+    fun `create api key shows raw key on success`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/apikey-ws/settings/api-keys/new")
+
+        page.fill("input[name=name]", "CI Pipeline Key")
+        page.locator("input[name=scopes][value='${ApiScope.USERS_READ}']").check()
+        page.locator("button[type=submit][form=create-api-key-form]").click()
+
+        waitForUrlPattern("**/settings/api-keys**")
+        val content = page.content()
+        assertTrue(
+            content.contains("kauth_"),
+            "After creation, page must display the raw API key (starts with kauth_)",
+        )
+    }
+
+    @Test
+    fun `api key list page does not leak value class toString`() {
+        apiKeyRepo.save(
+            ApiKey(
+                tenantId = TenantId(2),
+                name = "Test Key",
+                keyPrefix = "kauth_apikey_",
+                keyHash = "fake-hash-1",
+                scopes = listOf(ApiScope.USERS_READ, ApiScope.ROLES_READ),
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/apikey-ws/settings/api-keys")
+
+        val content = page.content()
+        assertFalse(
+            content.contains("TenantId(value="),
+            "API keys page must not render TenantId value class toString",
+        )
+        assertTrue(
+            content.contains("Test Key"),
+            "API keys page must display the seeded key name",
+        )
+    }
+
+    @Test
+    fun `revoke and delete form actions use plain int keyId`() {
+        apiKeyRepo.save(
+            ApiKey(
+                tenantId = TenantId(2),
+                name = "Revocable Key",
+                keyPrefix = "kauth_apikey_",
+                keyHash = "fake-hash-2",
+                scopes = listOf(ApiScope.USERS_READ),
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/apikey-ws/settings/api-keys")
+
+        val forms = page.querySelectorAll("form[action*='/api-keys/']")
+        forms.forEach { form ->
+            val action = form.getAttribute("action") ?: ""
+            if (action.contains("/revoke") || action.contains("/delete")) {
+                assertFalse(
+                    action.contains("ApiKey(") || action.contains("TenantId("),
+                    "Form action must use plain int ID, got: $action",
+                )
+                val idSegment = action.substringAfter("/api-keys/").substringBefore("/")
+                assertTrue(
+                    idSegment.toIntOrNull() != null,
+                    "keyId in form action must be a plain integer, got: $idSegment",
+                )
+            }
+        }
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminApplicationE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminApplicationE2ETest.kt
@@ -1,0 +1,125 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.TenantId
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+import kotlin.test.assertTrue
+
+class AdminApplicationE2ETest : E2ETestBase() {
+    @Test
+    fun `create application redirects to app detail with clientId in URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/applications/new")
+        page.fill("input[name=clientId]", "test-app")
+        page.fill("input[name=name]", "Test Application")
+        page.locator("button[type=submit][form=create-app-form]").click()
+
+        page.waitForURL(
+            Pattern.compile(".*/applications/test-app"),
+            Page
+                .WaitForURLOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                .setTimeout(5000.0),
+        )
+        val url = page.url()
+        assertTrue(
+            url.endsWith("/applications/test-app"),
+            "URL must end with clientId string, got: $url",
+        )
+    }
+
+    @Test
+    fun `application detail page does not leak value class toString`() {
+        appRepo.add(
+            Application(
+                id = ApplicationId(10),
+                tenantId = TenantId(1),
+                clientId = "my-spa",
+                name = "My SPA",
+                description = "Single page app",
+                accessType = AccessType.PUBLIC,
+                enabled = true,
+                redirectUris = listOf("http://localhost:3000/callback"),
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/applications/my-spa")
+
+        val content = page.content()
+        assertTrue(
+            !content.contains("ApplicationId(value="),
+            "Page must not render ApplicationId value class toString",
+        )
+        assertTrue(
+            !content.contains("TenantId(value="),
+            "Page must not render TenantId value class toString",
+        )
+    }
+
+    @Test
+    fun `application detail hidden inputs contain plain values`() {
+        appRepo.add(
+            Application(
+                id = ApplicationId(10),
+                tenantId = TenantId(1),
+                clientId = "my-api",
+                name = "My API",
+                description = null,
+                accessType = AccessType.CONFIDENTIAL,
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/applications/my-api")
+
+        val hiddenInputs = page.querySelectorAll("input[type=hidden]")
+        hiddenInputs.forEach { input ->
+            val value = input.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    !value.contains("Id(value="),
+                    "Hidden input value must not contain value class toString, got: $value",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `toggle application form action uses string clientId not numeric ID`() {
+        appRepo.add(
+            Application(
+                id = ApplicationId(10),
+                tenantId = TenantId(1),
+                clientId = "toggle-app",
+                name = "Toggle App",
+                description = null,
+                accessType = AccessType.PUBLIC,
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/applications/toggle-app")
+
+        val toggleForm = page.querySelector("form[action*='/toggle']")
+        if (toggleForm != null) {
+            val action = toggleForm.getAttribute("action")
+            assertTrue(
+                action.contains("/applications/toggle-app/toggle"),
+                "Toggle action must use string clientId, got: $action",
+            )
+            assertTrue(
+                !action.contains("ApplicationId("),
+                "Toggle action must not contain ApplicationId toString, got: $action",
+            )
+        }
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
@@ -1,0 +1,142 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.Group
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
+import com.kauth.domain.model.TenantId
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class AdminRbacE2ETest : E2ETestBase() {
+    @Test
+    fun `create role redirects with numeric role ID in URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/roles/create")
+        page.fill("input[name=name]", "test-role")
+        page.fill("input[name=description]", "E2E test role")
+        page.locator("button[type=submit][form=create-role-form]").click()
+
+        waitForUrlPattern("**/roles")
+        val url = page.url()
+        assertTrue(
+            !url.contains("RoleId("),
+            "URL must not contain RoleId value class toString, got: $url",
+        )
+    }
+
+    @Test
+    fun `role detail page renders IDs as plain numbers`() {
+        val saved =
+            roleRepo.add(
+                Role(tenantId = TenantId(1), name = "viewer", description = "View only", scope = RoleScope.TENANT),
+            )
+        val roleId = saved.id
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/roles/${roleId?.value}")
+
+        val content = page.content()
+        assertTrue(
+            !content.contains("RoleId(value="),
+            "Page must not render RoleId value class toString",
+        )
+        assertTrue(
+            !content.contains("UserId(value="),
+            "Page must not render UserId value class toString",
+        )
+        assertTrue(
+            !content.contains("ApplicationId(value="),
+            "Page must not render ApplicationId value class toString",
+        )
+
+        // Check form hidden inputs contain numeric values
+        val hiddenInputs = page.querySelectorAll("input[type=hidden]")
+        hiddenInputs.forEach { input ->
+            val value = input.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    !value.contains("Id(value="),
+                    "Hidden input value must be numeric, got: $value",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `create group redirects with numeric group ID in URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/groups/create")
+        page.fill("input[name=name]", "test-group")
+        page.fill("input[name=description]", "E2E test group")
+        page.locator("button[type=submit][form=create-group-form]").click()
+
+        waitForUrlPattern("**/groups")
+        val url = page.url()
+        assertTrue(
+            !url.contains("GroupId("),
+            "URL must not contain GroupId value class toString, got: $url",
+        )
+    }
+
+    @Test
+    fun `group detail page renders IDs as plain numbers`() {
+        val saved =
+            groupRepo.add(
+                Group(tenantId = TenantId(1), name = "devs", description = "Dev team"),
+            )
+        val groupId = saved.id
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/groups/${groupId?.value}")
+
+        val content = page.content()
+        assertTrue(
+            !content.contains("GroupId(value="),
+            "Page must not render GroupId value class toString",
+        )
+        assertTrue(
+            !content.contains("UserId(value="),
+            "Page must not render UserId value class toString",
+        )
+        assertTrue(
+            !content.contains("RoleId(value="),
+            "Page must not render RoleId value class toString",
+        )
+
+        val hiddenInputs = page.querySelectorAll("input[type=hidden]")
+        hiddenInputs.forEach { input ->
+            val value = input.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    !value.contains("Id(value="),
+                    "Hidden input value must be numeric, got: $value",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `session list page does not show value class toString`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/sessions")
+        val content = page.content()
+
+        assertTrue(!content.contains("UserId(value="), "Must not show UserId toString")
+        assertTrue(!content.contains("ApplicationId(value="), "Must not show ApplicationId toString")
+        assertTrue(!content.contains("SessionId(value="), "Must not show SessionId toString")
+    }
+
+    @Test
+    fun `audit log page does not show value class toString`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/audit")
+        val content = page.content()
+
+        assertTrue(!content.contains("UserId(value="), "Must not show UserId toString")
+        assertTrue(!content.contains("ApplicationId(value="), "Must not show ApplicationId toString")
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
@@ -4,7 +4,10 @@ import com.kauth.domain.model.Group
 import com.kauth.domain.model.Role
 import com.kauth.domain.model.RoleScope
 import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AdminRbacE2ETest : E2ETestBase() {
@@ -139,5 +142,179 @@ class AdminRbacE2ETest : E2ETestBase() {
         assertTrue(content.contains("Audit") || content.contains("Log"), "Must reach the audit log page")
         assertTrue(!content.contains("UserId(value="), "Must not show UserId toString")
         assertTrue(!content.contains("ApplicationId(value="), "Must not show ApplicationId toString")
+    }
+
+    @Test
+    fun `role detail child role forms use plain int IDs`() {
+        val parentRole =
+            roleRepo.add(
+                Role(
+                    tenantId = TenantId(1),
+                    name = "manager",
+                    description = "Manager role",
+                    scope = RoleScope.TENANT,
+                ),
+            )
+        val childRole =
+            roleRepo.add(
+                Role(
+                    tenantId = TenantId(1),
+                    name = "viewer",
+                    description = "View only",
+                    scope = RoleScope.TENANT,
+                ),
+            )
+        // Update parent to include child in childRoleIds so the view renders it
+        roleRepo.update(parentRole.copy(childRoleIds = listOf(childRole.id!!)))
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/roles/${parentRole.id?.value}")
+
+        val content = page.content()
+        assertFalse(content.contains("RoleId(value="), "Must not render RoleId value class toString")
+
+        // Check remove-child form hidden input
+        val childInputs = page.querySelectorAll("input[type=hidden][name=childRoleId]")
+        childInputs.forEach { input ->
+            val value = input.getAttribute("value") ?: ""
+            assertTrue(
+                value.toIntOrNull() != null,
+                "childRoleId hidden input must be a plain integer, got: $value",
+            )
+        }
+
+        // Check add-child select options
+        val childOptions = page.querySelectorAll("select[name=childRoleId] option")
+        childOptions.forEach { opt ->
+            val value = opt.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    value.toIntOrNull() != null,
+                    "childRoleId select option must be a plain integer, got: $value",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `role detail assign-user form uses plain int userId`() {
+        val role =
+            roleRepo.add(
+                Role(
+                    tenantId = TenantId(1),
+                    name = "editor",
+                    description = "Editor role",
+                    scope = RoleScope.TENANT,
+                ),
+            )
+        userRepo.add(
+            User(
+                id = UserId(10),
+                tenantId = TenantId(1),
+                username = "testuser",
+                email = "test@example.com",
+                fullName = "Test User",
+                passwordHash = hasher.hash("password"),
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/roles/${role.id?.value}")
+
+        // Check assign-user form action
+        val assignForm = page.querySelector("form[action*='/assign-user']")
+        if (assignForm != null) {
+            val action = assignForm.getAttribute("action")
+            assertFalse(
+                action.contains("RoleId("),
+                "assign-user form action must not contain RoleId toString, got: $action",
+            )
+        }
+
+        // Check userId select options
+        val userOptions = page.querySelectorAll("select[name=userId] option")
+        userOptions.forEach { opt ->
+            val value = opt.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    value.toIntOrNull() != null,
+                    "userId select option must be a plain integer, got: $value",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `group detail assign-role and add-member forms use plain int IDs`() {
+        val role =
+            roleRepo.add(
+                Role(
+                    tenantId = TenantId(1),
+                    name = "dev-role",
+                    description = "Developer role",
+                    scope = RoleScope.TENANT,
+                ),
+            )
+        val group =
+            groupRepo.add(
+                Group(
+                    tenantId = TenantId(1),
+                    name = "developers",
+                    description = "Dev team",
+                    roleIds = listOf(role.id!!),
+                ),
+            )
+        userRepo.add(
+            User(
+                id = UserId(20),
+                tenantId = TenantId(1),
+                username = "dev-user",
+                email = "dev@example.com",
+                fullName = "Dev User",
+                passwordHash = hasher.hash("password"),
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master/groups/${group.id?.value}")
+
+        val content = page.content()
+        assertFalse(content.contains("GroupId(value="), "Must not render GroupId value class toString")
+        assertFalse(content.contains("RoleId(value="), "Must not render RoleId value class toString")
+        assertFalse(content.contains("UserId(value="), "Must not render UserId value class toString")
+
+        // Check unassign-role hidden inputs
+        val roleInputs = page.querySelectorAll("input[type=hidden][name=roleId]")
+        roleInputs.forEach { input ->
+            val value = input.getAttribute("value") ?: ""
+            assertTrue(
+                value.toIntOrNull() != null,
+                "roleId hidden input must be a plain integer, got: $value",
+            )
+        }
+
+        // Check add-member userId select options
+        val memberOptions = page.querySelectorAll("select[name=userId] option")
+        memberOptions.forEach { opt ->
+            val value = opt.getAttribute("value") ?: ""
+            if (value.isNotBlank()) {
+                assertTrue(
+                    value.toIntOrNull() != null,
+                    "userId select option must be a plain integer, got: $value",
+                )
+            }
+        }
+
+        // Check form actions use plain ints
+        val groupForms = page.querySelectorAll("form[action*='/groups/']")
+        groupForms.forEach { form ->
+            val action = form.getAttribute("action") ?: ""
+            assertFalse(
+                action.contains("GroupId(") || action.contains("RoleId(") || action.contains("UserId("),
+                "Group form action must not contain value class toString, got: $action",
+            )
+        }
     }
 }

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt
@@ -133,9 +133,10 @@ class AdminRbacE2ETest : E2ETestBase() {
     fun `audit log page does not show value class toString`() {
         loginAsAdmin()
 
-        navigateSafe("$baseUrl/admin/workspaces/master/audit")
+        navigateSafe("$baseUrl/admin/workspaces/master/logs")
         val content = page.content()
 
+        assertTrue(content.contains("Audit") || content.contains("Log"), "Must reach the audit log page")
         assertTrue(!content.contains("UserId(value="), "Must not show UserId toString")
         assertTrue(!content.contains("ApplicationId(value="), "Must not show ApplicationId toString")
     }

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminSettingsE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminSettingsE2ETest.kt
@@ -1,0 +1,94 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdminSettingsE2ETest : E2ETestBase() {
+    private val workspace =
+        Tenant(
+            id = TenantId(2),
+            slug = "settings-ws",
+            displayName = "Settings Workspace",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
+
+    @BeforeEach
+    fun seedWorkspace() {
+        tenantRepo.add(workspace)
+    }
+
+    @Test
+    fun `general settings page does not leak value class toString`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/settings-ws/settings")
+
+        val content = page.content()
+        assertFalse(
+            content.contains("TenantId(value="),
+            "Settings page must not render TenantId value class toString",
+        )
+        assertTrue(
+            content.contains("Settings Workspace") || content.contains("settings-ws"),
+            "Settings page must render workspace name or slug",
+        )
+    }
+
+    @Test
+    fun `settings save redirects with saved param`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/settings-ws/settings")
+
+        page.fill("input[name=displayName]", "Updated Workspace")
+        page.locator("button[type=submit][form=general-form]").click()
+
+        page.waitForURL(
+            Pattern.compile(".*/settings\\?saved=true"),
+            Page
+                .WaitForURLOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                .setTimeout(5000.0),
+        )
+        assertTrue(page.url().contains("saved=true"), "Redirect must include saved=true param")
+    }
+
+    @Test
+    fun `smtp settings page does not leak value class toString`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/settings-ws/settings/smtp")
+
+        val content = page.content()
+        assertFalse(
+            content.contains("TenantId(value="),
+            "SMTP page must not render TenantId value class toString",
+        )
+        assertTrue(
+            content.contains("SMTP") || content.contains("smtp") || content.contains("Email"),
+            "SMTP page must contain SMTP-related content",
+        )
+    }
+
+    @Test
+    fun `security policy page does not leak value class toString`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/settings-ws/settings/security")
+
+        val content = page.content()
+        assertFalse(
+            content.contains("TenantId(value="),
+            "Security page must not render TenantId value class toString",
+        )
+        assertTrue(
+            content.contains("Security") || content.contains("Password") || content.contains("password"),
+            "Security page must contain security-related content",
+        )
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminUserE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminUserE2ETest.kt
@@ -1,0 +1,125 @@
+package com.kauth.e2e
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+import kotlin.test.assertTrue
+
+class AdminUserE2ETest : E2ETestBase() {
+    @Test
+    fun `create user redirects to user detail page with numeric ID in URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/users/new")
+        page.fill("input[name=username]", "newuser")
+        page.fill("input[name=email]", "new@test.dev")
+        page.fill("input[name=fullName]", "New User")
+        page.fill("input[name=password]", "SecurePass123!")
+        page.locator("button:has-text('Create User')").click()
+
+        page.waitForURL(
+            Pattern.compile(".*/users/\\d+"),
+            Page
+                .WaitForURLOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                .setTimeout(5000.0),
+        )
+        val url = page.url()
+        assertTrue(
+            url.matches(Regex(".*/users/\\d+.*")),
+            "URL must contain numeric user ID, got: $url",
+        )
+        assertTrue(page.content().contains("newuser"))
+    }
+
+    @Test
+    fun `edit user profile redirects back with saved param`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/users/1")
+        page.waitForSelector("a[href*='edit'], button:has-text('Edit'), .btn:has-text('Edit')")
+
+        // Navigate to edit (either via HTMX fragment or full page)
+        val editLink = page.querySelector("a[href*='edit-fragment'], a[href*='/edit']")
+        if (editLink != null) {
+            editLink.click()
+            page.waitForTimeout(500.0)
+        }
+
+        // Fill and submit the edit form
+        val emailField = page.querySelector("input[name=email]")
+        if (emailField != null) {
+            emailField.fill("updated@test.dev")
+            page.click("button[type=submit]")
+            page.waitForTimeout(1000.0)
+
+            val url = page.url()
+            val content = page.content()
+            // Should either redirect with ?saved=true or show success via HTMX
+            assertTrue(
+                url.contains("saved=true") || content.contains("Profile saved") || content.contains("updated@test.dev"),
+                "Edit should succeed — URL: $url",
+            )
+        }
+    }
+
+    @Test
+    fun `toggle user enabled redirects to user detail with numeric URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/users/1")
+
+        val toggleForm = page.querySelector("form[action*='/toggle']")
+        if (toggleForm != null) {
+            val action = toggleForm.getAttribute("action")
+            // Action must use numeric user ID
+            assertTrue(
+                action.matches(Regex(".*/users/\\d+/toggle")),
+                "Toggle form action must use numeric ID, got: $action",
+            )
+            toggleForm.querySelector("button[type=submit]")?.click()
+            waitForUrlPattern("**/users/**")
+
+            val url = page.url()
+            assertTrue(
+                url.matches(Regex(".*/users/\\d+.*")),
+                "Redirect URL must contain numeric user ID, got: $url",
+            )
+        }
+    }
+
+    @Test
+    fun `revoke sessions redirects to user detail with numeric URL`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/users/1")
+
+        val revokeForm = page.querySelector("form[action*='/revoke-sessions']")
+        if (revokeForm != null) {
+            val action = revokeForm.getAttribute("action")
+            assertTrue(
+                action.matches(Regex(".*/users/\\d+/revoke-sessions")),
+                "Revoke form action must use numeric ID, got: $action",
+            )
+        }
+    }
+
+    @Test
+    fun `user list page renders user IDs as plain numbers`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/master/users")
+        val content = page.content()
+
+        // Must not contain value class toString artifacts
+        assertTrue(
+            !content.contains("UserId(value="),
+            "Page must not render UserId value class toString",
+        )
+        assertTrue(
+            !content.contains("TenantId(value="),
+            "Page must not render TenantId value class toString",
+        )
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminWebhookE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminWebhookE2ETest.kt
@@ -1,0 +1,106 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.WebhookEndpoint
+import com.kauth.domain.model.WebhookEvent
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdminWebhookE2ETest : E2ETestBase() {
+    private val workspace =
+        Tenant(
+            id = TenantId(2),
+            slug = "webhook-ws",
+            displayName = "Webhook Workspace",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+        )
+
+    @BeforeEach
+    fun seedWorkspace() {
+        tenantRepo.add(workspace)
+    }
+
+    @Test
+    fun `create webhook shows secret on success`() {
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/webhook-ws/settings/webhooks/new")
+
+        page.fill("input[name=url]", "https://example.com/hook")
+        page.locator("input[name=events][value='${WebhookEvent.USER_CREATED}']").check()
+        page.locator("button[type=submit][form=create-webhook-form]").click()
+
+        waitForUrlPattern("**/settings/webhooks**")
+        val content = page.content()
+        assertTrue(
+            content.contains("example.com") || content.contains("secret") || content.contains("Secret"),
+            "After creation, page must display the webhook endpoint or signing secret",
+        )
+    }
+
+    @Test
+    fun `webhook list page does not leak value class toString`() {
+        webhookEndpointRepo.add(
+            WebhookEndpoint(
+                id = 10,
+                tenantId = TenantId(2),
+                url = "https://hooks.example.com/receiver",
+                secret = "fake-secret-abc",
+                events = setOf(WebhookEvent.USER_CREATED, WebhookEvent.LOGIN_SUCCESS),
+                description = "Test Endpoint",
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/webhook-ws/settings/webhooks")
+
+        val content = page.content()
+        assertFalse(
+            content.contains("TenantId(value="),
+            "Webhooks page must not render TenantId value class toString",
+        )
+        assertTrue(
+            content.contains("hooks.example.com") || content.contains("Test Endpoint"),
+            "Webhooks page must display the seeded endpoint",
+        )
+    }
+
+    @Test
+    fun `toggle and delete form actions use plain int endpointId`() {
+        webhookEndpointRepo.add(
+            WebhookEndpoint(
+                id = 10,
+                tenantId = TenantId(2),
+                url = "https://hooks.example.com/receiver",
+                secret = "fake-secret-abc",
+                events = setOf(WebhookEvent.USER_CREATED),
+                description = "Toggle Test",
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/webhook-ws/settings/webhooks")
+
+        val forms = page.querySelectorAll("form[action*='/webhooks/']")
+        forms.forEach { form ->
+            val action = form.getAttribute("action") ?: ""
+            if (action.contains("/toggle") || action.contains("/delete")) {
+                assertFalse(
+                    action.contains("WebhookEndpoint(") || action.contains("TenantId("),
+                    "Form action must not contain value class toString, got: $action",
+                )
+                val idSegment = action.substringAfter("/webhooks/").substringBefore("/")
+                assertTrue(
+                    idSegment.toIntOrNull() != null,
+                    "endpointId in form action must be a plain integer, got: $idSegment",
+                )
+            }
+        }
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/AdminWorkspaceE2ETest.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/AdminWorkspaceE2ETest.kt
@@ -1,0 +1,138 @@
+package com.kauth.e2e
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.options.WaitUntilState
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+import kotlin.test.assertTrue
+
+class AdminWorkspaceE2ETest : E2ETestBase() {
+    @Test
+    fun `create workspace redirects to workspace detail`() {
+        loginAsAdmin()
+
+        navigateSafe("$baseUrl/admin/workspaces/new")
+        page.fill("input[name=slug]", "acme-corp")
+        page.fill("input[name=displayName]", "Acme Corp")
+        page.locator("button[type=submit][form=create-workspace-form]").click()
+
+        page.waitForURL(
+            Pattern.compile(".*/workspaces/acme-corp"),
+            Page
+                .WaitForURLOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                .setTimeout(5000.0),
+        )
+        val url = page.url()
+        assertTrue(
+            url.endsWith("/workspaces/acme-corp"),
+            "URL must end with workspace slug, got: $url",
+        )
+        assertTrue(
+            !url.contains("TenantId("),
+            "URL must not contain TenantId toString, got: $url",
+        )
+    }
+
+    @Test
+    fun `workspace list page does not leak value class toString`() {
+        tenantRepo.add(
+            Tenant(
+                id = TenantId(2),
+                slug = "demo-ws",
+                displayName = "Demo Workspace",
+                issuerUrl = null,
+                theme = TenantTheme.DEFAULT,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces")
+
+        val content = page.content()
+        assertTrue(
+            !content.contains("TenantId(value="),
+            "Page must not render TenantId value class toString",
+        )
+    }
+
+    @Test
+    fun `workspace detail with apps does not leak ApplicationId`() {
+        appRepo.add(
+            Application(
+                id = ApplicationId(5),
+                tenantId = TenantId(1),
+                clientId = "web-client",
+                name = "Web Client",
+                description = null,
+                accessType = AccessType.PUBLIC,
+                enabled = true,
+            ),
+        )
+        appRepo.add(
+            Application(
+                id = ApplicationId(6),
+                tenantId = TenantId(1),
+                clientId = "api-server",
+                name = "API Server",
+                description = null,
+                accessType = AccessType.CONFIDENTIAL,
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master")
+
+        val content = page.content()
+        assertTrue(
+            !content.contains("ApplicationId(value="),
+            "Page must not render ApplicationId value class toString",
+        )
+        assertTrue(
+            !content.contains("TenantId(value="),
+            "Page must not render TenantId value class toString",
+        )
+        assertTrue(content.contains("web-client"), "Should show app clientId")
+        assertTrue(content.contains("api-server"), "Should show app clientId")
+    }
+
+    @Test
+    fun `workspace detail app links use string clientId not numeric ID`() {
+        appRepo.add(
+            Application(
+                id = ApplicationId(5),
+                tenantId = TenantId(1),
+                clientId = "my-frontend",
+                name = "My Frontend",
+                description = null,
+                accessType = AccessType.PUBLIC,
+                enabled = true,
+            ),
+        )
+
+        loginAsAdmin()
+        navigateSafe("$baseUrl/admin/workspaces/master")
+
+        val appLinks = page.querySelectorAll("a[href*='/applications/']")
+        appLinks.forEach { link ->
+            val href = link.getAttribute("href") ?: ""
+            if (href.contains("/applications/") && !href.endsWith("/new")) {
+                assertTrue(
+                    !href.matches(Regex(".*/applications/\\d+$")),
+                    "App link must use string clientId not numeric ID, got: $href",
+                )
+                assertTrue(
+                    !href.contains("ApplicationId("),
+                    "App link must not contain ApplicationId toString, got: $href",
+                )
+            }
+        }
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
@@ -1,0 +1,267 @@
+package com.kauth.e2e
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.adapter.web.admin.AdminSession
+import com.kauth.adapter.web.admin.adminRoutes
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.KeyProvisioningService
+import com.microsoft.playwright.Browser
+import com.microsoft.playwright.BrowserContext
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.Playwright
+import com.microsoft.playwright.options.WaitUntilState
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.URL
+
+abstract class E2ETestBase {
+    companion object {
+        lateinit var server: NettyApplicationEngine
+        lateinit var playwright: Playwright
+        lateinit var browser: Browser
+        var port: Int = 0
+        val baseUrl get() = "http://localhost:$port"
+
+        val tenantRepo = FakeTenantRepository()
+        val userRepo = FakeUserRepository()
+        val appRepo = FakeApplicationRepository()
+        val sessionRepo = FakeSessionRepository()
+        val roleRepo = FakeRoleRepository()
+        val groupRepo = FakeGroupRepository()
+        val auditLogRepo = FakeAuditLogRepository()
+        val auditLogPort = FakeAuditLogPort()
+        val hasher = FakePasswordHasher()
+        val tokenPort = FakeTokenPort()
+        val encryptionService = EncryptionService("e2e-test-secret-key-32chars!!")
+        val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+
+        val masterTenant =
+            Tenant(
+                id = TenantId(1),
+                slug = "master",
+                displayName = "Master",
+                issuerUrl = null,
+                theme = TenantTheme.DEFAULT,
+            )
+
+        val adminUser =
+            User(
+                id = UserId(1),
+                tenantId = TenantId(1),
+                username = "admin",
+                email = "admin@kotauth.dev",
+                fullName = "Admin User",
+                passwordHash = hasher.hash("admin-pass"),
+                enabled = true,
+            )
+
+        private fun buildAuthService() =
+            AuthService(
+                userRepository = userRepo,
+                tenantRepository = tenantRepo,
+                tokenPort = tokenPort,
+                passwordHasher = hasher,
+                auditLog = auditLogPort,
+                sessionRepository = sessionRepo,
+            )
+
+        private fun buildSelfService() =
+            UserSelfServiceService(
+                userRepository = userRepo,
+                tenantRepository = tenantRepo,
+                sessionRepository = sessionRepo,
+                passwordHasher = hasher,
+                auditLog = auditLogPort,
+                evTokenRepo = FakeEmailVerificationTokenRepository(),
+                prTokenRepo = FakePasswordResetTokenRepository(),
+                emailPort = FakeEmailPort(),
+            )
+
+        private fun buildAdminService() =
+            AdminService(
+                tenantRepository = tenantRepo,
+                userRepository = userRepo,
+                applicationRepository = appRepo,
+                passwordHasher = hasher,
+                auditLog = auditLogPort,
+                sessionRepository = sessionRepo,
+                selfServiceService = buildSelfService(),
+            )
+
+        private fun buildRoleGroupService() =
+            RoleGroupService(
+                roleRepository = roleRepo,
+                groupRepository = groupRepo,
+                tenantRepository = tenantRepo,
+                userRepository = userRepo,
+                applicationRepository = appRepo,
+                auditLog = auditLogPort,
+            )
+
+        private fun findFreePort(): Int = ServerSocket(0).use { it.localPort }
+
+        @JvmStatic
+        @BeforeAll
+        fun startServer() {
+            port = findFreePort()
+
+            server =
+                embeddedServer(Netty, port = port) {
+                    install(ContentNegotiation) { json() }
+                    install(Sessions) {
+                        cookie<AdminSession>("KOTAUTH_ADMIN")
+                    }
+                    install(StatusPages) {
+                        exception<Throwable> { call, cause ->
+                            cause.printStackTrace()
+                            call.respondText(
+                                "E2E Server Error: ${cause.message}",
+                                status = HttpStatusCode.InternalServerError,
+                            )
+                        }
+                    }
+                    routing {
+                        adminRoutes(
+                            authService = buildAuthService(),
+                            adminService = buildAdminService(),
+                            roleGroupService = buildRoleGroupService(),
+                            appInfo = AppInfo(),
+                            tenantRepository = tenantRepo,
+                            applicationRepository = appRepo,
+                            userRepository = userRepo,
+                            sessionRepository = sessionRepo,
+                            auditLogRepository = auditLogRepo,
+                            keyProvisioningService = keyProvisioningService,
+                            encryptionService = encryptionService,
+                        )
+                    }
+                }
+            server.start(wait = false)
+            waitForServer()
+
+            playwright = Playwright.create()
+            val headless = System.getProperty("playwright.headless", "true").toBoolean()
+            browser =
+                playwright.chromium().launch(
+                    com.microsoft.playwright.BrowserType
+                        .LaunchOptions()
+                        .setHeadless(headless),
+                )
+        }
+
+        private fun waitForServer(
+            timeoutMs: Long = 10_000,
+            intervalMs: Long = 200,
+        ) {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    val conn = URL("$baseUrl/admin/login").openConnection() as HttpURLConnection
+                    conn.connectTimeout = 500
+                    conn.readTimeout = 500
+                    conn.requestMethod = "GET"
+                    if (conn.responseCode in 200..499) return
+                } catch (_: Exception) {
+                    // server not ready yet
+                }
+                Thread.sleep(intervalMs)
+            }
+            error("Server did not become ready within ${timeoutMs}ms")
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopServer() {
+            browser.close()
+            playwright.close()
+            server.stop(500, 1000)
+        }
+    }
+
+    protected lateinit var context: BrowserContext
+    protected lateinit var page: Page
+
+    @BeforeEach
+    fun setupBrowser() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        sessionRepo.clear()
+        roleRepo.clear()
+        groupRepo.clear()
+        auditLogPort.clear()
+        tokenPort.reset()
+
+        tenantRepo.add(masterTenant)
+        userRepo.add(adminUser)
+
+        context = browser.newContext()
+        page = context.newPage()
+    }
+
+    @AfterEach
+    fun teardownBrowser() {
+        context.close()
+    }
+
+    protected fun navigateSafe(url: String) {
+        page.navigate(url, Page.NavigateOptions().setWaitUntil(WaitUntilState.DOMCONTENTLOADED))
+    }
+
+    protected fun waitForUrlPattern(glob: String) {
+        page.waitForURL(
+            glob,
+            Page
+                .WaitForURLOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                .setTimeout(5000.0),
+        )
+    }
+
+    protected fun loginAsAdmin() {
+        navigateSafe("$baseUrl/admin/login")
+        page.fill("input[name=username]", "admin")
+        page.fill("input[name=password]", "admin-pass")
+        page.click("button[type=submit]")
+        waitForUrlPattern("**/admin/**")
+    }
+}

--- a/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
@@ -9,9 +9,12 @@ import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.ApiKeyService
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.RoleGroupService
 import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.domain.service.WebhookService
+import com.kauth.fakes.FakeApiKeyRepository
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuditLogRepository
@@ -25,6 +28,8 @@ import com.kauth.fakes.FakeSessionRepository
 import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeTokenPort
 import com.kauth.fakes.FakeUserRepository
+import com.kauth.fakes.FakeWebhookDeliveryRepository
+import com.kauth.fakes.FakeWebhookEndpointRepository
 import com.kauth.infrastructure.EncryptionService
 import com.kauth.infrastructure.KeyProvisioningService
 import com.microsoft.playwright.Browser
@@ -69,6 +74,9 @@ abstract class E2ETestBase {
         val groupRepo = FakeGroupRepository()
         val auditLogRepo = FakeAuditLogRepository()
         val auditLogPort = FakeAuditLogPort()
+        val apiKeyRepo = FakeApiKeyRepository()
+        val webhookEndpointRepo = FakeWebhookEndpointRepository()
+        val webhookDeliveryRepo = FakeWebhookDeliveryRepository()
         val hasher = FakePasswordHasher()
         val tokenPort = FakeTokenPort()
         val encryptionService = EncryptionService("e2e-test-secret-key-32chars!!")
@@ -137,6 +145,18 @@ abstract class E2ETestBase {
                 auditLog = auditLogPort,
             )
 
+        private fun buildApiKeyService() =
+            ApiKeyService(
+                apiKeyRepository = apiKeyRepo,
+                tenantRepository = tenantRepo,
+            )
+
+        private fun buildWebhookService() =
+            WebhookService(
+                endpointRepository = webhookEndpointRepo,
+                deliveryRepository = webhookDeliveryRepo,
+            )
+
         private fun findFreePort(): Int = ServerSocket(0).use { it.localPort }
 
         @JvmStatic
@@ -171,6 +191,8 @@ abstract class E2ETestBase {
                             sessionRepository = sessionRepo,
                             auditLogRepository = auditLogRepo,
                             keyProvisioningService = keyProvisioningService,
+                            apiKeyService = buildApiKeyService(),
+                            webhookService = buildWebhookService(),
                             encryptionService = encryptionService,
                         )
                     }
@@ -229,6 +251,9 @@ abstract class E2ETestBase {
         roleRepo.clear()
         groupRepo.clear()
         auditLogPort.clear()
+        apiKeyRepo.clear()
+        webhookEndpointRepo.clear()
+        webhookDeliveryRepo.clear()
         tokenPort.reset()
 
         tenantRepo.add(masterTenant)

--- a/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
@@ -216,7 +216,7 @@ internal fun createRolePageImpl(
                                 }
                                 apps.forEach { app ->
                                     option {
-                                        value = app.id.toString()
+                                        value = app.id.value.toString()
                                         +app.name
                                     }
                                 }
@@ -332,14 +332,14 @@ internal fun roleDetailPageImpl(
                             role.childRoleIds.forEach { childId ->
                                 val child = allRoles.find { it.id == childId }
                                 tr {
-                                    td { span("key-table__name") { +(child?.name ?: "#$childId") } }
+                                    td { span("key-table__name") { +(child?.name ?: "#${childId.value}") } }
                                     td {
                                         form(
                                             action = "/admin/workspaces/$slug/roles/${role.id?.value}/remove-child",
                                             method = FormMethod.post,
                                         ) {
                                             input(type = InputType.hidden, name = "childRoleId") {
-                                                value = childId.toString()
+                                                value = childId.value.toString()
                                             }
                                             button(type = ButtonType.submit) {
                                                 classes = setOf("btn", "btn--ghost", "btn--sm")
@@ -365,7 +365,7 @@ internal fun roleDetailPageImpl(
                                 name = "childRoleId"
                                 availableChildren.forEach { r ->
                                     option {
-                                        value = r.id.toString()
+                                        value = r.id?.value.toString()
                                         +r.name
                                     }
                                 }
@@ -393,7 +393,7 @@ internal fun roleDetailPageImpl(
                             name = "userId"
                             allUsers.forEach { u ->
                                 option {
-                                    value = u.id.toString()
+                                    value = u.id?.value.toString()
                                     +"${u.username} (${u.email})"
                                 }
                             }
@@ -589,7 +589,7 @@ internal fun createGroupPageImpl(
                                 }
                                 groups.forEach { g ->
                                     option {
-                                        value = g.id.toString()
+                                        value = g.id?.value.toString()
                                         +g.name
                                     }
                                 }
@@ -713,7 +713,7 @@ internal fun groupDetailPageImpl(
                             group.roleIds.forEach { rid ->
                                 val r = allRoles.find { it.id == rid }
                                 tr {
-                                    td { span("key-table__name") { +(r?.name ?: "#$rid") } }
+                                    td { span("key-table__name") { +(r?.name ?: "#${rid.value}") } }
                                     td {
                                         span("badge badge--active") { +(r?.scope?.value ?: "?") }
                                     }
@@ -723,7 +723,7 @@ internal fun groupDetailPageImpl(
                                             method = FormMethod.post,
                                         ) {
                                             input(type = InputType.hidden, name = "roleId") {
-                                                value = rid.toString()
+                                                value = rid.value.toString()
                                             }
                                             button(type = ButtonType.submit) {
                                                 classes = setOf("btn", "btn--ghost", "btn--sm")
@@ -749,7 +749,7 @@ internal fun groupDetailPageImpl(
                                 name = "roleId"
                                 availableRoles.forEach { r ->
                                     option {
-                                        value = r.id.toString()
+                                        value = r.id?.value.toString()
                                         +r.name
                                     }
                                 }
@@ -791,7 +791,7 @@ internal fun groupDetailPageImpl(
                                             method = FormMethod.post,
                                         ) {
                                             input(type = InputType.hidden, name = "userId") {
-                                                value = u.id.toString()
+                                                value = u.id?.value.toString()
                                             }
                                             button(type = ButtonType.submit) {
                                                 classes = setOf("btn", "btn--ghost", "btn--sm")
@@ -817,7 +817,7 @@ internal fun groupDetailPageImpl(
                                 name = "userId"
                                 nonMembers.forEach { u ->
                                     option {
-                                        value = u.id.toString()
+                                        value = u.id?.value.toString()
                                         +"${u.username} (${u.email})"
                                     }
                                 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -60,8 +60,8 @@ internal fun activeSessionsPageImpl(
                             sessions.forEach { s ->
                                 tr {
                                     td { span("data-table__id") { +"#${s.id?.value}" } }
-                                    td { +(s.userId?.toString() ?: "M2M") }
-                                    td { +(s.clientId?.toString() ?: "—") }
+                                    td { +(s.userId?.value?.toString() ?: "M2M") }
+                                    td { +(s.clientId?.value?.toString() ?: "—") }
                                     td { span("data-table__email") { +(s.ipAddress ?: "—") } }
                                     td { +s.createdAt.toDisplayString() }
                                     td { +s.expiresAt.toDisplayString() }
@@ -189,8 +189,8 @@ internal fun auditLogPageImpl(
                                     tr {
                                         td { +e.createdAt.toDisplayString() }
                                         td { span("data-table__id") { +e.eventType.name } }
-                                        td { +(e.userId?.toString() ?: "—") }
-                                        td { +(e.clientId?.toString() ?: "—") }
+                                        td { +(e.userId?.value?.toString() ?: "—") }
+                                        td { +(e.clientId?.value?.toString() ?: "—") }
                                         td {
                                             span("data-table__email") { +(e.ipAddress ?: "—") }
                                         }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
@@ -150,7 +150,7 @@ internal fun Route.loginRoutes(
 
                 // MFA challenge redirect
                 if (mfaService != null && mfaService.shouldChallengeMfa(user.id!!)) {
-                    val mfaPending = "${user.id?.value}|$slug|${System.currentTimeMillis()}"
+                    val mfaPending = "${user.id.value}|$slug|${System.currentTimeMillis()}"
                     call.response.cookies.append(
                         name = "KOTAUTH_MFA_PENDING",
                         value = encryptionService.signCookie(mfaPending),


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a comprehensive suite of end-to-end (E2E) browser tests using Playwright to verify the admin UI's handling of domain model value classes, form actions, and redirect behaviors. It ensures that user-facing pages and form actions do not leak internal value class representations (such as `UserId(value=...)`), and that URLs and form actions use plain numeric or string identifiers as appropriate. Additionally, it updates the `Makefile` to support running these E2E tests.

**E2E Test Coverage for Admin UI:**

* Added E2E tests for user management, verifying correct redirects, form actions, and that user IDs are rendered as plain numbers without leaking value class internals (`src/e2eTest/kotlin/com/kauth/e2e/AdminUserE2ETest.kt`).
* Added E2E tests for application management, ensuring URLs and form actions use string client IDs and do not expose value class details (`src/e2eTest/kotlin/com/kauth/e2e/AdminApplicationE2ETest.kt`).
* Added E2E tests for RBAC (roles and groups), confirming that all IDs in URLs, hidden inputs, and page content are plain numbers and not value class strings (`src/e2eTest/kotlin/com/kauth/e2e/AdminRbacE2ETest.kt`).
* Added E2E tests for API key management, checking that raw keys are shown after creation, and that form actions use plain integer IDs (`src/e2eTest/kotlin/com/kauth/e2e/AdminApiKeyE2ETest.kt`).
* Added E2E tests for workspace settings (general, SMTP, security), ensuring no value class internals are leaked and that redirects work as expected (`src/e2eTest/kotlin/com/kauth/e2e/AdminSettingsE2ETest.kt`).

**Build System Updates:**

* Updated `Makefile` to add `e2e` and `e2e-headed` targets for running the new Playwright E2E tests, and included these targets in the `.PHONY` declaration. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R36-R41)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
