### PR TITLE
feature/ktor-route-intercepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.3] - 2026-03-25
+
+### Added
+
+- **HikariCP connection pool** — replaced bare JDBC `DriverManager.getConnection()` (new TCP connection per transaction) with HikariCP 5.1.0 pooled connections. Eliminates 10-20ms of TCP/TLS/auth overhead per DB call. Pool configured with leak detection (4s threshold), connection keepalive, and max lifetime rotation
+- **`DB_POOL_MAX_SIZE`** environment variable — configurable maximum pool size (default: 10)
+- **`DB_POOL_MIN_IDLE`** environment variable — configurable minimum idle connections (default: 2)
+- **Multi-arch Docker images** — publish workflow now builds `linux/amd64` and `linux/arm64` natively in parallel using GitHub's free arm64 runners. No QEMU emulation
+
+### Changed
+
+- **Async email delivery** — verification and password-reset emails are now sent in a background coroutine (`CoroutineScope + SupervisorJob + Dispatchers.IO`), matching the existing async webhook pattern. HTTP responses return immediately instead of blocking on SMTP
+- **Admin route intercepts** — extracted ~60 duplicate `findBySlug` + `findAll` calls from 7 admin sub-route files into a single `intercept(ApplicationCallPipeline.Call)` block at the `/{slug}` route level. Workspace and sidebar data resolved once per request via `call.attributes`
+- **Auth route intercepts** — extracted ~21 duplicate `findBySlug` calls from 6 auth sub-route files into a single intercept at the `/t/{slug}` route level. Tenant, theme, and workspace name resolved once per request via `AuthTenantContext`
+
+---
+
 ## [1.1.2] - 2026-03-25
 
 ### Added
@@ -159,7 +176,8 @@ Initial stable release.
 
 ---
 
-[Unreleased]: https://github.com/inumansoul/kotauth/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/inumansoul/kotauth/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/inumansoul/kotauth/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/inumansoul/kotauth/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/inumansoul/kotauth/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/inumansoul/kotauth/compare/v1.0.3...v1.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.kauth"
-version = "1.1.2"
+version = "1.1.3"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApiKeyRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApiKeyRoutes.kt
@@ -1,6 +1,5 @@
 package com.kauth.adapter.web.admin
 
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.ApiKeyService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -14,16 +13,11 @@ import io.ktor.server.routing.post
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 
-fun Route.adminApiKeyRoutes(
-    tenantRepository: TenantRepository,
-    apiKeyService: ApiKeyService?,
-) {
+fun Route.adminApiKeyRoutes(apiKeyService: ApiKeyService?) {
     get("/settings/api-keys") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val keys = apiKeyService?.listForTenant(workspace.id) ?: emptyList()
         call.respondHtml(
             HttpStatusCode.OK,
@@ -33,10 +27,8 @@ fun Route.adminApiKeyRoutes(
 
     get("/settings/api-keys/new") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         call.respondHtml(
             HttpStatusCode.OK,
             AdminView.createApiKeyPage(workspace, wsPairs, session.username),
@@ -45,10 +37,8 @@ fun Route.adminApiKeyRoutes(
 
     post("/settings/api-keys") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val svc = apiKeyService ?: return@post call.respond(HttpStatusCode.ServiceUnavailable)
 
         val params = call.receiveParameters()
@@ -93,21 +83,19 @@ fun Route.adminApiKeyRoutes(
     }
 
     post("/settings/api-keys/{keyId}/revoke") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val keyId =
             call.parameters["keyId"]?.toIntOrNull() ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
         apiKeyService?.revoke(keyId, workspace.id)
         call.respondRedirect("/admin/workspaces/$slug/settings/api-keys")
     }
 
     post("/settings/api-keys/{keyId}/delete") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val keyId =
             call.parameters["keyId"]?.toIntOrNull() ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
         apiKeyService?.delete(keyId, workspace.id)
         call.respondRedirect("/admin/workspaces/$slug/settings/api-keys")
     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
@@ -1,7 +1,6 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.domain.port.ApplicationRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
 import io.ktor.http.HttpStatusCode
@@ -19,16 +18,13 @@ import io.ktor.server.sessions.sessions
 
 fun Route.adminApplicationRoutes(
     adminService: AdminService,
-    tenantRepository: TenantRepository,
     applicationRepository: ApplicationRepository,
 ) {
     route("/applications") {
         get("/new") {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             call.respondHtml(
                 HttpStatusCode.OK,
                 AdminView.createApplicationPage(workspace, wsPairs, session.username),
@@ -37,9 +33,8 @@ fun Route.adminApplicationRoutes(
 
         post {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+            val workspace = call.attributes[WorkspaceAttr]
+            val slug = workspace.slug
             val params = call.receiveParameters()
             val clientId = params["clientId"]?.trim()?.lowercase() ?: ""
             val name = params["name"]?.trim() ?: ""
@@ -72,7 +67,7 @@ fun Route.adminApplicationRoutes(
                     else -> null
                 }
             if (error != null) {
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 return@post call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.createApplicationPage(
@@ -91,16 +86,13 @@ fun Route.adminApplicationRoutes(
         route("/{clientId}") {
             get {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val workspace = call.attributes[WorkspaceAttr]
                 val clientId =
                     call.parameters["clientId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
                 val app =
                     applicationRepository.findByClientId(workspace.id, clientId)
                         ?: return@get call.respond(HttpStatusCode.NotFound)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 val allApps = applicationRepository.findByTenantId(workspace.id)
                 val newSecret = call.request.queryParameters["newSecret"]
                 call.respondHtml(
@@ -118,16 +110,13 @@ fun Route.adminApplicationRoutes(
 
             get("/edit") {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val workspace = call.attributes[WorkspaceAttr]
                 val clientId =
                     call.parameters["clientId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
                 val app =
                     applicationRepository.findByClientId(workspace.id, clientId)
                         ?: return@get call.respond(HttpStatusCode.NotFound)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 val allApps = applicationRepository.findByTenantId(workspace.id)
                 call.respondHtml(
                     HttpStatusCode.OK,
@@ -137,12 +126,10 @@ fun Route.adminApplicationRoutes(
 
             post("/edit") {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val clientId =
                     call.parameters["clientId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
                 val app =
                     applicationRepository.findByClientId(workspace.id, clientId)
                         ?: return@post call.respond(HttpStatusCode.NotFound)
@@ -169,7 +156,7 @@ fun Route.adminApplicationRoutes(
                     is AdminResult.Success ->
                         call.respondRedirect("/admin/workspaces/$slug/applications/$clientId")
                     is AdminResult.Failure -> {
-                        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                        val wsPairs = call.attributes[WsPairsAttr]
                         val allApps = applicationRepository.findByTenantId(workspace.id)
                         call.respondHtml(
                             HttpStatusCode.UnprocessableEntity,
@@ -187,12 +174,10 @@ fun Route.adminApplicationRoutes(
             }
 
             post("/toggle") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val clientId =
                     call.parameters["clientId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
                 val app =
                     applicationRepository.findByClientId(workspace.id, clientId)
                         ?: return@post call.respond(HttpStatusCode.NotFound)
@@ -201,12 +186,10 @@ fun Route.adminApplicationRoutes(
             }
 
             post("/regenerate-secret") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val clientId =
                     call.parameters["clientId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
                 val app =
                     applicationRepository.findByClientId(workspace.id, clientId)
                         ?: return@post call.respond(HttpStatusCode.NotFound)

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminHelpers.kt
@@ -1,0 +1,10 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.domain.model.Tenant
+import io.ktor.util.AttributeKey
+
+/** Resolved workspace for the current `/{slug}` admin route. */
+internal val WorkspaceAttr = AttributeKey<Tenant>("Workspace")
+
+/** Slug → display-name pairs for the workspace sidebar navigation. */
+internal val WsPairsAttr = AttributeKey<List<Pair<String, String>>>("WsPairs")

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutes.kt
@@ -6,7 +6,6 @@ import com.kauth.domain.model.RoleId
 import com.kauth.domain.model.RoleScope
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.ApplicationRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.RoleGroupService
@@ -25,7 +24,6 @@ import io.ktor.server.sessions.sessions
 
 fun Route.adminRbacRoutes(
     roleGroupService: RoleGroupService,
-    tenantRepository: TenantRepository,
     applicationRepository: ApplicationRepository,
     userRepository: UserRepository,
 ) {
@@ -36,10 +34,8 @@ fun Route.adminRbacRoutes(
     route("/roles") {
         get {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             val roles = roleGroupService.listRoles(workspace.id)
             call.respondHtml(
                 HttpStatusCode.OK,
@@ -49,10 +45,8 @@ fun Route.adminRbacRoutes(
 
         get("/create") {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             val apps = applicationRepository.findByTenantId(workspace.id)
             call.respondHtml(
                 HttpStatusCode.OK,
@@ -61,9 +55,8 @@ fun Route.adminRbacRoutes(
         }
 
         post {
-            val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+            val workspace = call.attributes[WorkspaceAttr]
+            val slug = workspace.slug
             val params = call.receiveParameters()
             val name = params["name"]?.trim() ?: ""
             val desc = params["description"]?.trim()?.takeIf { it.isNotBlank() }
@@ -84,7 +77,7 @@ fun Route.adminRbacRoutes(
                     call.respondRedirect("/admin/workspaces/$slug/roles")
                 is AdminResult.Failure -> {
                     val session = call.sessions.get<AdminSession>()!!
-                    val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                    val wsPairs = call.attributes[WsPairsAttr]
                     val apps = applicationRepository.findByTenantId(workspace.id)
                     call.respondHtml(
                         HttpStatusCode.UnprocessableEntity,
@@ -103,14 +96,11 @@ fun Route.adminRbacRoutes(
         route("/{roleId}") {
             get {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val workspace = call.attributes[WorkspaceAttr]
+                val wsPairs = call.attributes[WsPairsAttr]
                 val roles = roleGroupService.listRoles(workspace.id)
                 val role =
                     roles.find { it.id == roleId } ?: return@get call.respond(HttpStatusCode.NotFound)
@@ -122,13 +112,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/edit") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val params = call.receiveParameters()
                 roleGroupService.updateRole(
                     roleId,
@@ -140,25 +128,21 @@ fun Route.adminRbacRoutes(
             }
 
             post("/delete") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 roleGroupService.deleteRole(roleId, workspace.id)
                 call.respondRedirect("/admin/workspaces/$slug/roles")
             }
 
             post("/children") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val childId =
                     call.receiveParameters()["childRoleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -167,13 +151,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/remove-child") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val childId =
                     call.receiveParameters()["childRoleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -182,13 +164,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/assign-user") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val userId =
                     call.receiveParameters()["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -197,13 +177,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/unassign-user") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val roleId =
                     call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val userId =
                     call.receiveParameters()["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -220,10 +198,8 @@ fun Route.adminRbacRoutes(
     route("/groups") {
         get {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             val groups = roleGroupService.listGroups(workspace.id)
             val roles = roleGroupService.listRoles(workspace.id)
             call.respondHtml(
@@ -234,10 +210,8 @@ fun Route.adminRbacRoutes(
 
         get("/create") {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             val groups = roleGroupService.listGroups(workspace.id)
             call.respondHtml(
                 HttpStatusCode.OK,
@@ -246,9 +220,8 @@ fun Route.adminRbacRoutes(
         }
 
         post {
-            val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+            val workspace = call.attributes[WorkspaceAttr]
+            val slug = workspace.slug
             val params = call.receiveParameters()
             val name = params["name"]?.trim() ?: ""
             val desc = params["description"]?.trim()?.takeIf { it.isNotBlank() }
@@ -259,7 +232,7 @@ fun Route.adminRbacRoutes(
                     call.respondRedirect("/admin/workspaces/$slug/groups")
                 is AdminResult.Failure -> {
                     val session = call.sessions.get<AdminSession>()!!
-                    val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                    val wsPairs = call.attributes[WsPairsAttr]
                     val groups = roleGroupService.listGroups(workspace.id)
                     call.respondHtml(
                         HttpStatusCode.UnprocessableEntity,
@@ -278,14 +251,11 @@ fun Route.adminRbacRoutes(
         route("/{groupId}") {
             get {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val workspace = call.attributes[WorkspaceAttr]
+                val wsPairs = call.attributes[WsPairsAttr]
                 val groups = roleGroupService.listGroups(workspace.id)
                 val group =
                     groups.find { it.id == groupId } ?: return@get call.respond(HttpStatusCode.NotFound)
@@ -309,13 +279,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/edit") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val params = call.receiveParameters()
                 roleGroupService.updateGroup(
                     groupId,
@@ -327,25 +295,21 @@ fun Route.adminRbacRoutes(
             }
 
             post("/delete") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 roleGroupService.deleteGroup(groupId, workspace.id)
                 call.respondRedirect("/admin/workspaces/$slug/groups")
             }
 
             post("/assign-role") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val roleId =
                     call.receiveParameters()["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -354,13 +318,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/unassign-role") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val roleId =
                     call.receiveParameters()["roleId"]?.toIntOrNull()?.let { RoleId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -369,13 +331,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/add-member") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val userId =
                     call.receiveParameters()["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -384,13 +344,11 @@ fun Route.adminRbacRoutes(
             }
 
             post("/remove-member") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val groupId =
                     call.parameters["groupId"]?.toIntOrNull()?.let { GroupId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val userId =
                     call.receiveParameters()["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -210,12 +210,23 @@ fun Route.adminRoutes(
             // -----------------------------------------------------------
 
             route("/{slug}") {
+                // Resolve workspace + sidebar pairs once per request
+                intercept(ApplicationCallPipeline.Call) {
+                    val slug =
+                        call.parameters["slug"]
+                            ?: return@intercept call.respond(HttpStatusCode.BadRequest).also { finish() }
+                    val workspace =
+                        tenantRepository.findBySlug(slug)
+                            ?: return@intercept call.respond(HttpStatusCode.NotFound).also { finish() }
+                    val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                    call.attributes.put(WorkspaceAttr, workspace)
+                    call.attributes.put(WsPairsAttr, wsPairs)
+                }
+
                 get {
                     val session = call.sessions.get<AdminSession>()!!
-                    val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                    val workspace =
-                        tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-                    val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                    val workspace = call.attributes[WorkspaceAttr]
+                    val wsPairs = call.attributes[WsPairsAttr]
                     val apps = applicationRepository.findByTenantId(workspace.id)
                     call.respondHtml(
                         HttpStatusCode.OK,
@@ -225,7 +236,6 @@ fun Route.adminRoutes(
 
                 adminSettingsRoutes(
                     adminService = adminService,
-                    tenantRepository = tenantRepository,
                     userRepository = userRepository,
                     identityProviderRepository = identityProviderRepository,
                     mfaRepository = mfaRepository,
@@ -234,38 +244,32 @@ fun Route.adminRoutes(
 
                 adminApplicationRoutes(
                     adminService = adminService,
-                    tenantRepository = tenantRepository,
                     applicationRepository = applicationRepository,
                 )
 
                 adminUserRoutes(
                     adminService = adminService,
                     roleGroupService = roleGroupService,
-                    tenantRepository = tenantRepository,
                     userRepository = userRepository,
                     sessionRepository = sessionRepository,
                 )
 
                 adminSessionAuditRoutes(
-                    tenantRepository = tenantRepository,
                     sessionRepository = sessionRepository,
                     auditLogRepository = auditLogRepository,
                 )
 
                 adminRbacRoutes(
                     roleGroupService = roleGroupService,
-                    tenantRepository = tenantRepository,
                     applicationRepository = applicationRepository,
                     userRepository = userRepository,
                 )
 
                 adminApiKeyRoutes(
-                    tenantRepository = tenantRepository,
                     apiKeyService = apiKeyService,
                 )
 
                 adminWebhookRoutes(
-                    tenantRepository = tenantRepository,
                     webhookService = webhookService,
                 )
             }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSessionAuditRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSessionAuditRoutes.kt
@@ -4,7 +4,6 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.SessionId
 import com.kauth.domain.port.AuditLogRepository
 import com.kauth.domain.port.SessionRepository
-import com.kauth.domain.port.TenantRepository
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
@@ -18,7 +17,6 @@ import io.ktor.server.sessions.sessions
 import java.time.Instant
 
 fun Route.adminSessionAuditRoutes(
-    tenantRepository: TenantRepository,
     sessionRepository: SessionRepository,
     auditLogRepository: AuditLogRepository,
 ) {
@@ -28,11 +26,9 @@ fun Route.adminSessionAuditRoutes(
 
     get("/sessions") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
         val sessions = sessionRepository.findActiveByTenant(workspace.id)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val wsPairs = call.attributes[WsPairsAttr]
         call.respondHtml(
             HttpStatusCode.OK,
             AdminView.activeSessionsPage(workspace, sessions, wsPairs, session.username),
@@ -40,7 +36,8 @@ fun Route.adminSessionAuditRoutes(
     }
 
     post("/sessions/{sessionId}/revoke") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val sessionId =
             call.parameters["sessionId"]?.toIntOrNull()?.let { SessionId(it) }
                 ?: return@post call.respond(HttpStatusCode.BadRequest)
@@ -54,9 +51,7 @@ fun Route.adminSessionAuditRoutes(
 
     get("/logs") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
         val page =
             call.request.queryParameters["page"]
                 ?.toIntOrNull()
@@ -73,7 +68,7 @@ fun Route.adminSessionAuditRoutes(
                 offset = offset,
             )
         val total = auditLogRepository.countByTenant(workspace.id, eventType)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val wsPairs = call.attributes[WsPairsAttr]
         call.respondHtml(
             HttpStatusCode.OK,
             AdminView.auditLogPage(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -6,7 +6,6 @@ import com.kauth.domain.model.SocialProvider
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.MfaRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
@@ -25,7 +24,6 @@ import io.ktor.server.sessions.sessions
 
 fun Route.adminSettingsRoutes(
     adminService: AdminService,
-    tenantRepository: TenantRepository,
     userRepository: UserRepository,
     identityProviderRepository: IdentityProviderRepository?,
     mfaRepository: MfaRepository?,
@@ -37,10 +35,8 @@ fun Route.adminSettingsRoutes(
 
     get("/settings") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val saved = call.request.queryParameters["saved"] == "true"
         call.respondHtml(
             HttpStatusCode.OK,
@@ -50,9 +46,8 @@ fun Route.adminSettingsRoutes(
 
     post("/settings") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val params = call.receiveParameters()
         when (
             val result =
@@ -84,7 +79,7 @@ fun Route.adminSettingsRoutes(
                 call.respondRedirect("/admin/workspaces/$slug/settings?saved=true")
             }
             is AdminResult.Failure -> {
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.workspaceSettingsPage(
@@ -104,10 +99,8 @@ fun Route.adminSettingsRoutes(
 
     get("/settings/smtp") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val saved = call.request.queryParameters["saved"] == "true"
         call.respondHtml(
             HttpStatusCode.OK,
@@ -117,7 +110,8 @@ fun Route.adminSettingsRoutes(
 
     post("/settings/smtp") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val params = call.receiveParameters()
         when (
             val result =
@@ -136,9 +130,7 @@ fun Route.adminSettingsRoutes(
             is AdminResult.Success ->
                 call.respondRedirect("/admin/workspaces/$slug/settings/smtp?saved=true")
             is AdminResult.Failure -> {
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.smtpSettingsPage(
@@ -158,10 +150,8 @@ fun Route.adminSettingsRoutes(
 
     get("/settings/identity-providers") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val providers = identityProviderRepository?.findAllByTenant(workspace.id) ?: emptyList()
         call.respondHtml(
             HttpStatusCode.OK,
@@ -176,15 +166,13 @@ fun Route.adminSettingsRoutes(
 
     post("/settings/identity-providers/{provider}") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
         val provName = call.parameters["provider"] ?: return@post call.respond(HttpStatusCode.BadRequest)
         val provider =
             SocialProvider.fromValueOrNull(provName)
                 ?: return@post call.respond(HttpStatusCode.BadRequest, "Unsupported provider: $provName")
 
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val params = call.receiveParameters()
 
         val newClientId = params["clientId"]?.trim() ?: ""
@@ -260,17 +248,17 @@ fun Route.adminSettingsRoutes(
             )
         }
 
+        val slug = workspace.slug
         call.respondRedirect("/admin/workspaces/$slug/settings/identity-providers?saved=true")
     }
 
     post("/settings/identity-providers/{provider}/delete") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
         val provName = call.parameters["provider"] ?: return@post call.respond(HttpStatusCode.BadRequest)
         val provider =
             SocialProvider.fromValueOrNull(provName)
                 ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         identityProviderRepository?.delete(workspace.id, provider)
         call.respondRedirect("/admin/workspaces/$slug/settings/identity-providers")
     }
@@ -281,10 +269,8 @@ fun Route.adminSettingsRoutes(
 
     get("/settings/security") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val saved = call.request.queryParameters["saved"] == "true"
         call.respondHtml(
             HttpStatusCode.OK,
@@ -294,9 +280,8 @@ fun Route.adminSettingsRoutes(
 
     post("/settings/security") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val params = call.receiveParameters()
         when (
             val result =
@@ -321,7 +306,7 @@ fun Route.adminSettingsRoutes(
             is AdminResult.Success ->
                 call.respondRedirect("/admin/workspaces/$slug/settings/security?saved=true")
             is AdminResult.Failure -> {
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.securityPolicyPage(
@@ -341,10 +326,8 @@ fun Route.adminSettingsRoutes(
 
     get("/settings/branding") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val saved = call.request.queryParameters["saved"] == "true"
         call.respondHtml(
             HttpStatusCode.OK,
@@ -354,9 +337,8 @@ fun Route.adminSettingsRoutes(
 
     post("/settings/branding") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val params = call.receiveParameters()
         val theme =
             TenantTheme(
@@ -378,7 +360,7 @@ fun Route.adminSettingsRoutes(
             is AdminResult.Success ->
                 call.respondRedirect("/admin/workspaces/$slug/settings/branding?saved=true")
             is AdminResult.Failure -> {
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.brandingPage(
@@ -398,10 +380,8 @@ fun Route.adminSettingsRoutes(
 
     get("/mfa") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val users = userRepository.findByTenantId(workspace.id, null)
         val (enrolled, notEnrolled) =
             if (mfaRepository != null) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -2,7 +2,6 @@ package com.kauth.adapter.web.admin
 
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.SessionRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
@@ -25,22 +24,19 @@ import io.ktor.server.sessions.sessions
 fun Route.adminUserRoutes(
     adminService: AdminService,
     roleGroupService: RoleGroupService,
-    tenantRepository: TenantRepository,
     userRepository: UserRepository,
     sessionRepository: SessionRepository,
 ) {
     route("/users") {
         get {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+            val workspace = call.attributes[WorkspaceAttr]
             val search =
                 call.request.queryParameters["q"]
                     ?.trim()
                     ?.takeIf { it.isNotBlank() }
             val users = userRepository.findByTenantId(workspace.id, search)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val wsPairs = call.attributes[WsPairsAttr]
             call.respondHtml(
                 HttpStatusCode.OK,
                 AdminView.userListPage(workspace, users, wsPairs, session.username, search),
@@ -49,10 +45,8 @@ fun Route.adminUserRoutes(
 
         get("/new") {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+            val workspace = call.attributes[WorkspaceAttr]
+            val wsPairs = call.attributes[WsPairsAttr]
             call.respondHtml(
                 HttpStatusCode.OK,
                 AdminView.createUserPage(workspace, wsPairs, session.username),
@@ -61,9 +55,8 @@ fun Route.adminUserRoutes(
 
         post {
             val session = call.sessions.get<AdminSession>()!!
-            val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-            val workspace =
-                tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+            val workspace = call.attributes[WorkspaceAttr]
+            val slug = workspace.slug
             val params = call.receiveParameters()
             val username = params["username"]?.trim() ?: ""
             val email = params["email"]?.trim() ?: ""
@@ -73,7 +66,7 @@ fun Route.adminUserRoutes(
                 is AdminResult.Success ->
                     call.respondRedirect("/admin/workspaces/$slug/users/${result.value.id?.value}")
                 is AdminResult.Failure -> {
-                    val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                    val wsPairs = call.attributes[WsPairsAttr]
                     val prefill = UserPrefill(username = username, email = email, fullName = fullName)
                     call.respondHtml(
                         HttpStatusCode.UnprocessableEntity,
@@ -92,18 +85,15 @@ fun Route.adminUserRoutes(
         route("/{userId}") {
             get {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
                 val user =
                     userRepository.findById(userId) ?: return@get call.respond(HttpStatusCode.NotFound)
                 if (user.tenantId != workspace.id) return@get call.respond(HttpStatusCode.NotFound)
                 val sessions = sessionRepository.findActiveByUser(workspace.id, userId)
-                val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                val wsPairs = call.attributes[WsPairsAttr]
                 val userRoles = roleGroupService.getRolesForUser(userId)
                 val userGroups = roleGroupService.getGroupsForUser(userId)
                 val savedParam = call.request.queryParameters["saved"]
@@ -131,13 +121,10 @@ fun Route.adminUserRoutes(
             }
 
             get("/profile-fragment") {
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
                 val user =
                     userRepository.findById(userId) ?: return@get call.respond(HttpStatusCode.NotFound)
                 if (user.tenantId != workspace.id) return@get call.respond(HttpStatusCode.NotFound)
@@ -154,13 +141,10 @@ fun Route.adminUserRoutes(
             }
 
             get("/edit-fragment") {
-                val slug =
-                    call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
                 val user =
                     userRepository.findById(userId) ?: return@get call.respond(HttpStatusCode.NotFound)
                 if (user.tenantId != workspace.id) return@get call.respond(HttpStatusCode.NotFound)
@@ -171,13 +155,11 @@ fun Route.adminUserRoutes(
             }
 
             post("/toggle") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val user =
                     userRepository.findById(userId) ?: return@post call.respond(HttpStatusCode.NotFound)
                 if (user.tenantId != workspace.id) return@post call.respond(HttpStatusCode.NotFound)
@@ -187,13 +169,11 @@ fun Route.adminUserRoutes(
 
             post("/edit") {
                 val session = call.sessions.get<AdminSession>()!!
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val user =
                     userRepository.findById(userId) ?: return@post call.respond(HttpStatusCode.NotFound)
                 if (user.tenantId != workspace.id) return@post call.respond(HttpStatusCode.NotFound)
@@ -233,7 +213,7 @@ fun Route.adminUserRoutes(
                             )
                         } else {
                             val sessions = sessionRepository.findActiveByUser(workspace.id, userId)
-                            val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+                            val wsPairs = call.attributes[WsPairsAttr]
                             val userRoles = roleGroupService.getRolesForUser(userId)
                             val userGroups = roleGroupService.getGroupsForUser(userId)
                             call.respondHtml(
@@ -255,38 +235,32 @@ fun Route.adminUserRoutes(
             }
 
             post("/revoke-sessions") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 sessionRepository.revokeAllForUser(workspace.id, userId)
                 call.respondRedirect("/admin/workspaces/$slug/users/${userId.value}")
             }
 
             post("/send-verification") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val baseUrl = call.request.local.let { "${it.scheme}://${it.serverHost}:${it.serverPort}" }
                 adminService.resendVerificationEmail(userId, workspace.id, baseUrl)
                 call.respondRedirect("/admin/workspaces/$slug/users/${userId.value}?saved=true")
             }
 
             post("/send-reset-email") {
-                val slug =
-                    call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 val userId =
                     call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
-                val workspace =
-                    tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
                 val baseUrl = call.request.local.let { "${it.scheme}://${it.serverHost}:${it.serverPort}" }
                 when (val result = adminService.sendPasswordResetEmail(userId, workspace.id, baseUrl)) {
                     is AdminResult.Success ->

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminWebhookRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminWebhookRoutes.kt
@@ -1,6 +1,5 @@
 package com.kauth.adapter.web.admin
 
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.WebhookService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -14,16 +13,11 @@ import io.ktor.server.routing.post
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 
-fun Route.adminWebhookRoutes(
-    tenantRepository: TenantRepository,
-    webhookService: WebhookService?,
-) {
+fun Route.adminWebhookRoutes(webhookService: WebhookService?) {
     get("/settings/webhooks") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val endpoints = webhookService?.listEndpoints(workspace.id) ?: emptyList()
         val deliveries = webhookService?.recentDeliveries(workspace.id) ?: emptyList()
         call.respondHtml(
@@ -34,10 +28,8 @@ fun Route.adminWebhookRoutes(
 
     get("/settings/webhooks/new") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         call.respondHtml(
             HttpStatusCode.OK,
             AdminView.createWebhookPage(workspace, wsPairs, session.username),
@@ -46,10 +38,8 @@ fun Route.adminWebhookRoutes(
 
     post("/settings/webhooks") {
         val session = call.sessions.get<AdminSession>()!!
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
-        val wsPairs = tenantRepository.findAll().map { it.slug to it.displayName }
+        val workspace = call.attributes[WorkspaceAttr]
+        val wsPairs = call.attributes[WsPairsAttr]
         val svc = webhookService ?: return@post call.respond(HttpStatusCode.ServiceUnavailable)
 
         val params = call.receiveParameters()
@@ -88,13 +78,11 @@ fun Route.adminWebhookRoutes(
     }
 
     post("/settings/webhooks/{endpointId}/toggle") {
-        val slug =
-            call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val endpointId =
             call.parameters["endpointId"]?.toIntOrNull()
                 ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
         val params = call.receiveParameters()
         val enabled = params["enabled"] == "true"
         webhookService?.toggleEndpoint(endpointId, workspace.id, enabled)
@@ -102,13 +90,11 @@ fun Route.adminWebhookRoutes(
     }
 
     post("/settings/webhooks/{endpointId}/delete") {
-        val slug =
-            call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val workspace = call.attributes[WorkspaceAttr]
+        val slug = workspace.slug
         val endpointId =
             call.parameters["endpointId"]?.toIntOrNull()
                 ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val workspace =
-            tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
         webhookService?.deleteEndpoint(endpointId, workspace.id)
         call.respondRedirect("/admin/workspaces/$slug/settings/webhooks")
     }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
@@ -1,5 +1,7 @@
 package com.kauth.adapter.web.auth
 
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.service.AuthError
 import com.kauth.domain.service.OAuthError
 import com.kauth.domain.service.SocialLoginError
@@ -9,6 +11,23 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import io.ktor.util.AttributeKey
+
+/**
+ * Tenant context resolved once per request by the auth route intercept.
+ *
+ * [tenant] is nullable — some auth pages render a default theme when the
+ * tenant slug does not match. Handlers that require a non-null tenant
+ * (e.g., OAuth protocol endpoints) check `ctx.tenant ?: return 404`.
+ */
+data class AuthTenantContext(
+    val slug: String,
+    val tenant: Tenant?,
+    val theme: TenantTheme,
+    val workspaceName: String,
+)
+
+internal val AuthTenantAttr = AttributeKey<AuthTenantContext>("AuthTenantContext")
 
 internal suspend fun oauthError(
     call: ApplicationCall,

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
@@ -1,5 +1,6 @@
 package com.kauth.adapter.web.auth
 
+import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
 import com.kauth.domain.port.RoleRepository
@@ -10,6 +11,10 @@ import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginService
 import com.kauth.domain.service.UserSelfServiceService
 import com.kauth.infrastructure.EncryptionService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
 
@@ -29,10 +34,26 @@ fun Route.authRoutes(
     encryptionService: EncryptionService,
 ) {
     route("/t/{slug}") {
+        // Resolve tenant context once per request
+        intercept(ApplicationCallPipeline.Call) {
+            val slug =
+                call.parameters["slug"]
+                    ?: return@intercept call.respond(HttpStatusCode.BadRequest).also { finish() }
+            val tenant = tenantRepository.findBySlug(slug)
+            call.attributes.put(
+                AuthTenantAttr,
+                AuthTenantContext(
+                    slug = slug,
+                    tenant = tenant,
+                    theme = tenant?.theme ?: TenantTheme.DEFAULT,
+                    workspaceName = tenant?.displayName ?: "KotAuth",
+                ),
+            )
+        }
+
         loginRoutes(
             authService = authService,
             oauthService = oauthService,
-            tenantRepository = tenantRepository,
             loginRateLimiter = loginRateLimiter,
             mfaService = mfaService,
             roleRepository = roleRepository,
@@ -42,27 +63,23 @@ fun Route.authRoutes(
 
         registerRoutes(
             authService = authService,
-            tenantRepository = tenantRepository,
             registerRateLimiter = registerRateLimiter,
             identityProviderRepository = identityProviderRepository,
         )
 
         selfServiceRoutes(
-            tenantRepository = tenantRepository,
             selfServiceService = selfServiceService,
             registerRateLimiter = registerRateLimiter,
         )
 
         mfaRoutes(
             oauthService = oauthService,
-            tenantRepository = tenantRepository,
             mfaService = mfaService,
             encryptionService = encryptionService,
         )
 
         socialLoginRoutes(
             oauthService = oauthService,
-            tenantRepository = tenantRepository,
             socialLoginService = socialLoginService,
             identityProviderRepository = identityProviderRepository,
             encryptionService = encryptionService,
@@ -71,7 +88,6 @@ fun Route.authRoutes(
 
         oauthProtocolRoutes(
             oauthService = oauthService,
-            tenantRepository = tenantRepository,
             identityProviderRepository = identityProviderRepository,
             tokenRateLimiter = tokenRateLimiter,
         )

--- a/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
@@ -1,10 +1,8 @@
 package com.kauth.adapter.web.auth
 
-import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
 import com.kauth.domain.port.RoleRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.AuthError
 import com.kauth.domain.service.AuthResult
 import com.kauth.domain.service.AuthService
@@ -26,7 +24,6 @@ import io.ktor.server.routing.post
 internal fun Route.loginRoutes(
     authService: AuthService,
     oauthService: OAuthService,
-    tenantRepository: TenantRepository,
     loginRateLimiter: RateLimiterPort,
     mfaService: MfaService?,
     roleRepository: RoleRepository?,
@@ -34,10 +31,11 @@ internal fun Route.loginRoutes(
     encryptionService: EncryptionService,
 ) {
     get("/login") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val registered = call.request.queryParameters["registered"] == "true"
         val oauthParams = call.request.queryParameters.toOAuthParams()
         val enabledProviders =
@@ -61,10 +59,11 @@ internal fun Route.loginRoutes(
     }
 
     post("/login") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val enabledProviders =
             if (tenant != null && identityProviderRepository != null) {
                 identityProviderRepository.findEnabledByTenant(tenant.id).map { it.provider }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
@@ -1,8 +1,6 @@
 package com.kauth.adapter.web.auth
 
-import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.UserId
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.MfaResult
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthResult
@@ -20,15 +18,14 @@ import io.ktor.server.routing.post
 
 internal fun Route.mfaRoutes(
     oauthService: OAuthService,
-    tenantRepository: TenantRepository,
     mfaService: MfaService?,
     encryptionService: EncryptionService,
 ) {
     get("/mfa-challenge") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val oauthParams = call.request.queryParameters.toOAuthParams()
 
         val rawPendingGet = call.request.cookies["KOTAUTH_MFA_PENDING"]
@@ -43,10 +40,10 @@ internal fun Route.mfaRoutes(
     }
 
     post("/mfa-challenge") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val params = call.receiveParameters()
         val code = params["code"]?.trim() ?: ""
         val ipAddress = call.request.local.remoteAddress

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -2,7 +2,6 @@ package com.kauth.adapter.web.auth
 
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.IntrospectionResult
 import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
@@ -20,14 +19,14 @@ import kotlinx.serialization.json.*
 
 internal fun Route.oauthProtocolRoutes(
     oauthService: OAuthService,
-    tenantRepository: TenantRepository,
     identityProviderRepository: IdentityProviderRepository?,
     tokenRateLimiter: RateLimiterPort,
 ) {
     get("/.well-known/openid-configuration") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
         val tenant =
-            tenantRepository.findBySlug(slug)
+            ctx.tenant
                 ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
 
         val openidBaseUrl = call.request.local.let { "${it.scheme}://${it.serverHost}:${it.serverPort}" }
@@ -89,9 +88,9 @@ internal fun Route.oauthProtocolRoutes(
     }
 
     get("/protocol/openid-connect/certs") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val ctx = call.attributes[AuthTenantAttr]
         val tenant =
-            tenantRepository.findBySlug(slug)
+            ctx.tenant
                 ?: return@get call.respond(HttpStatusCode.NotFound)
 
         val jwks = oauthService.getJwks(tenant.id)
@@ -99,7 +98,8 @@ internal fun Route.oauthProtocolRoutes(
     }
 
     get("/protocol/openid-connect/auth") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
         val q = call.request.queryParameters
 
         val responseType = q["response_type"] ?: ""
@@ -133,11 +133,9 @@ internal fun Route.oauthProtocolRoutes(
             return@get
         }
 
-        val tenant = tenantRepository.findBySlug(slug)
-        if (tenant == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
-            return@get
-        }
+        val tenant =
+            ctx.tenant
+                ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
 
         val oauthParams =
             AuthView.OAuthParams(

--- a/src/main/kotlin/com/kauth/adapter/web/auth/RegisterRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/RegisterRoutes.kt
@@ -1,16 +1,13 @@
 package com.kauth.adapter.web.auth
 
-import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.AuthResult
 import com.kauth.domain.service.AuthService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
 import io.ktor.server.request.receiveParameters
-import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
@@ -18,15 +15,15 @@ import io.ktor.server.routing.post
 
 internal fun Route.registerRoutes(
     authService: AuthService,
-    tenantRepository: TenantRepository,
     registerRateLimiter: RateLimiterPort,
     identityProviderRepository: IdentityProviderRepository?,
 ) {
     get("/register") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val enabledProviders =
             if (tenant != null && identityProviderRepository != null) {
                 identityProviderRepository.findEnabledByTenant(tenant.id).map { it.provider }
@@ -40,10 +37,11 @@ internal fun Route.registerRoutes(
     }
 
     post("/register") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val enabledProviders =
             if (tenant != null && identityProviderRepository != null) {
                 identityProviderRepository.findEnabledByTenant(tenant.id).map { it.provider }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SelfServiceRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SelfServiceRoutes.kt
@@ -1,30 +1,26 @@
 package com.kauth.adapter.web.auth
 
-import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.RateLimiterPort
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.SelfServiceResult
 import com.kauth.domain.service.UserSelfServiceService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
 import io.ktor.server.request.receiveParameters
-import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 
 internal fun Route.selfServiceRoutes(
-    tenantRepository: TenantRepository,
     selfServiceService: UserSelfServiceService,
     registerRateLimiter: RateLimiterPort,
 ) {
     get("/forgot-password") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val sent = call.request.queryParameters["sent"] == "true"
         val reason = call.request.queryParameters["reason"]
         val errorMsg =
@@ -40,7 +36,7 @@ internal fun Route.selfServiceRoutes(
     }
 
     post("/forgot-password") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val slug = call.attributes[AuthTenantAttr].slug
         val params = call.receiveParameters()
         val email = params["email"]?.trim() ?: ""
         val ipAddress = call.request.local.remoteAddress
@@ -56,10 +52,10 @@ internal fun Route.selfServiceRoutes(
     }
 
     get("/reset-password") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val token = call.request.queryParameters["token"] ?: ""
 
         if (token.isBlank()) {
@@ -69,10 +65,10 @@ internal fun Route.selfServiceRoutes(
     }
 
     post("/reset-password") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val params = call.receiveParameters()
         val token = params["token"] ?: ""
         val newPassword = params["new_password"] ?: ""
@@ -99,10 +95,10 @@ internal fun Route.selfServiceRoutes(
     }
 
     get("/verify-email") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val token = call.request.queryParameters["token"] ?: ""
 
         if (token.isBlank()) {

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
@@ -1,9 +1,7 @@
 package com.kauth.adapter.web.auth
 
 import com.kauth.domain.model.SocialProvider
-import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
-import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginResult
@@ -21,14 +19,17 @@ import io.ktor.server.routing.post
 
 internal fun Route.socialLoginRoutes(
     oauthService: OAuthService,
-    tenantRepository: TenantRepository,
     socialLoginService: SocialLoginService?,
     identityProviderRepository: IdentityProviderRepository?,
     encryptionService: EncryptionService,
     baseUrl: String,
 ) {
     get("/auth/social/{provider}/redirect") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val provName = call.parameters["provider"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         val provider =
             SocialProvider.fromValueOrNull(provName)
@@ -55,9 +56,6 @@ internal fun Route.socialLoginRoutes(
         when (val result = socialLoginService.buildRedirectUrl(slug, provider, signedState, baseUrl)) {
             is SocialLoginResult.Success -> call.respondRedirect(result.value)
             is SocialLoginResult.Failure -> {
-                val tenant = tenantRepository.findBySlug(slug)
-                val theme = tenant?.theme ?: TenantTheme.DEFAULT
-                val workspaceName = tenant?.displayName ?: "KotAuth"
                 val enabledProviders =
                     if (tenant != null && identityProviderRepository != null) {
                         identityProviderRepository.findEnabledByTenant(tenant.id).map { it.provider }
@@ -81,15 +79,16 @@ internal fun Route.socialLoginRoutes(
     }
 
     get("/auth/social/{provider}/callback") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant
+        val theme = ctx.theme
+        val workspaceName = ctx.workspaceName
         val provName = call.parameters["provider"] ?: return@get call.respond(HttpStatusCode.BadRequest)
         val provider =
             SocialProvider.fromValueOrNull(provName)
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "unsupported_provider"))
 
-        val tenant = tenantRepository.findBySlug(slug)
-        val theme = tenant?.theme ?: TenantTheme.DEFAULT
-        val workspaceName = tenant?.displayName ?: "KotAuth"
         val enabledProviders =
             if (tenant != null && identityProviderRepository != null) {
                 identityProviderRepository.findEnabledByTenant(tenant.id).map { it.provider }
@@ -261,8 +260,9 @@ internal fun Route.socialLoginRoutes(
 
     // Social registration completion
     get("/auth/social/complete-registration") {
-        val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug) ?: return@get call.respond(HttpStatusCode.NotFound)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant ?: return@get call.respond(HttpStatusCode.NotFound)
         val theme = tenant.theme
         val workspaceName = tenant.displayName
 
@@ -298,8 +298,9 @@ internal fun Route.socialLoginRoutes(
     }
 
     post("/auth/social/complete-registration") {
-        val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-        val tenant = tenantRepository.findBySlug(slug) ?: return@post call.respond(HttpStatusCode.NotFound)
+        val ctx = call.attributes[AuthTenantAttr]
+        val slug = ctx.slug
+        val tenant = ctx.tenant ?: return@post call.respond(HttpStatusCode.NotFound)
         val theme = tenant.theme
         val workspaceName = tenant.displayName
 


### PR DESCRIPTION
## What does this PR do?

This pull request refactors the admin route handlers to remove direct dependencies on `TenantRepository` and instead rely on pre-resolved request attributes for workspace and workspace pairs. This change streamlines the route handlers, making them cleaner and more consistent by accessing `WorkspaceAttr` and `WsPairsAttr` attributes from the request context.

The most important changes are:

**Refactoring route handler dependencies:**

* All admin route handler functions (`adminApiKeyRoutes`, `adminApplicationRoutes`, `adminRbacRoutes`) no longer accept or use a `TenantRepository` parameter. Instead, they retrieve the current workspace and workspace pairs from request attributes (`WorkspaceAttr`, `WsPairsAttr`). [[1]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L17-R20) [[2]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L22-R27) [[3]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L28)

* All lookups for the current workspace and workspace pairs within route handlers have been replaced with reads from `call.attributes[WorkspaceAttr]` and `call.attributes[WsPairsAttr]`, eliminating repeated repository calls and parameter checks. [[1]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L17-R20) [[2]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L36-R31) [[3]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L48-R41) [[4]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L96-L110) [[5]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L22-R27) [[6]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L40-R37) [[7]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L75-R70) [[8]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L94-R95) [[9]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L121-R119) [[10]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L140-L145) [[11]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L172-R159) [[12]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L190-L195) [[13]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L204-L209) [[14]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L39-R38) [[15]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L52-R49) [[16]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L64-R59) [[17]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L87-R80) [[18]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L106-R103) [[19]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L125-R119)

**Introduction of shared attribute keys:**

* Added a new file, `AdminHelpers.kt`, which defines the `WorkspaceAttr` and `WsPairsAttr` attribute keys for sharing resolved workspace and workspace pairs in the request context.

**Cleanup of unused imports:**

* Removed unused imports of `TenantRepository` from all affected route files. [[1]](diffhunk://#diff-4a0bb6de449139b372f3a0aa58c12b114f648e2541054593ada9f455d6867dd7L3) [[2]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0L4) [[3]](diffhunk://#diff-6921d7242d3f75ff8b314dd9932cd905268812d2bfdffd76ff2f20bc0bd95b88L9)

This refactor improves code clarity, reduces repeated logic, and centralizes workspace resolution for admin routes.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
