### PR TITLE
Normalize name to lowercase

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,6 @@ permissions:
   contents: read
   packages: write
 
-env:
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}
-
 jobs:
   # ── Build per-platform images in parallel (native runners, no QEMU) ─────
   build:
@@ -37,6 +34,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Normalize the repository name to lowercase (GHCR requires it).
+      - name: Normalize image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -56,7 +58,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.GHCR_IMAGE }}
+          images: ${{ steps.image.outputs.name }}
           labels: |
             org.opencontainers.image.title=Kotauth
             org.opencontainers.image.description=Self-hosted identity and authentication platform
@@ -77,7 +79,7 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.slug.outputs.pair }}
           cache-to: type=gha,scope=${{ steps.slug.outputs.pair }},mode=max
 
@@ -116,6 +118,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Normalize the repository name to lowercase (GHCR requires it).
+      - name: Normalize image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -134,7 +141,7 @@ jobs:
       - name: Build image list
         id: image-list
         run: |
-          IMAGES="${{ env.GHCR_IMAGE }}"
+          IMAGES="${{ steps.image.outputs.name }}"
           if [ -n "$DOCKERHUB_USERNAME" ]; then
             IMAGES="${IMAGES}"$'\n'"${DOCKERHUB_USERNAME}/kotauth"
           fi
@@ -164,7 +171,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
-            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+            $(printf '${{ steps.image.outputs.name }}@sha256:%s ' *)
 
       - name: Inspect image
-        run: docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect ${{ steps.image.outputs.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## What does this PR do?

This pull request updates the GitHub Actions workflow for publishing Docker images to ensure the image name is always lowercase, which is required by GitHub Container Registry (GHCR). The changes remove the use of a global environment variable for the image name and instead dynamically generate a lowercase image name using a workflow step. All subsequent references to the image name in the workflow are updated to use this normalized value.

**Image name normalization and workflow updates:**

* Added a new step in the build and manifest jobs to generate a lowercase image name (`ghcr.io/<repo>`) and output it for later use, ensuring compatibility with GHCR requirements. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R37-R41) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R121-R125)
* Replaced all references to the previous `GHCR_IMAGE` environment variable with the new normalized image name from the workflow step output in Docker build, metadata, and manifest commands. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L59-R61) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L80-R82) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L137-R144) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L167-R177)
* Removed the global `GHCR_IMAGE` environment variable from the workflow.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [ ] `./gradlew test` passes locally
- [ ] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
