### PR TITLE
fix/security-hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.4] - 2026-03-26
+
+### Security
+
+- **CVE-2025-55163** — Netty HTTP/2 DDoS vulnerability. Mitigated by constraining `netty-codec-http2` to 4.1.124.Final
+- **CVE-2025-24970** — Netty native SSL crash on crafted packet. Mitigated by constraining `netty-handler` to 4.1.124.Final
+- **GHSA-72hv-8253-57qq** — Jackson async parser DoS. Mitigated by constraining `jackson-core` to 2.18.6
+- **CVE-2025-11226 / CVE-2026-1225** — Logback arbitrary code execution. Fixed by upgrading to 1.5.32
+- **CVE-2025-49146** — PostgreSQL JDBC MITM attack. Fixed by upgrading to 42.7.10
+- **CSRF protection** — Added `SameSite=Lax` attribute to both `KOTAUTH_ADMIN` and `KOTAUTH_PORTAL` session cookies
+- **Content Security Policy** — Added `Content-Security-Policy` header to all responses (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; form-action 'self'`)
+- **Thread-safe JWT cache** — Replaced `mutableMapOf` with `ConcurrentHashMap` in `JwtTokenAdapter.algorithmCache` to prevent data race under concurrent token issuance
+
+### Fixed
+
+- **Webhook `X-KotAuth-Event` header** — was incorrectly sending the endpoint URL instead of the event type (e.g., `user.created`). Receivers relying on this header for event routing now get the correct value
+
+### Changed
+
+- **Dependency upgrades** (no breaking changes):
+  - Logback 1.4.14 → 1.5.32
+  - PostgreSQL JDBC 42.7.3 → 42.7.10
+  - Logstash encoder 7.4 → 8.0
+  - Exposed 0.50.1 → 0.55.0
+  - java-jwt 4.4.0 → 4.5.1
+  - MockK 1.13.10 → 1.13.16
+  - JUnit Jupiter 5.10.2 → 5.10.5
+
+### Removed
+
+- **`ktor-server-auth-jwt`** dependency — declared but unused (zero imports). All JWT operations use `com.auth0:java-jwt` directly
+
+---
+
 ## [1.1.3] - 2026-03-25
 
 ### Added
@@ -176,7 +210,8 @@ Initial stable release.
 
 ---
 
-[Unreleased]: https://github.com/inumansoul/kotauth/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/inumansoul/kotauth/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/inumansoul/kotauth/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/inumansoul/kotauth/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/inumansoul/kotauth/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/inumansoul/kotauth/compare/v1.1.0...v1.1.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,15 @@ repositories {
 }
 
 dependencies {
+    // ---- Security: override vulnerable transitive dependencies from Ktor 2.3.x ----
+    constraints {
+        implementation("io.netty:netty-codec-http2:4.1.124.Final") { because("CVE-2025-55163") }
+        implementation("io.netty:netty-handler:4.1.124.Final") { because("CVE-2025-24970") }
+        implementation("com.fasterxml.jackson:jackson-bom:2.18.6") { because("GHSA-72hv-8253-57qq") }
+        implementation("com.fasterxml.jackson.core:jackson-core:2.18.6") { because("GHSA-72hv-8253-57qq") }
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.18.6") { because("GHSA-72hv-8253-57qq") }
+    }
+
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-auth:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 val ktorVersion = "2.3.12"
-val exposedVersion = "0.50.1"
-val logbackVersion = "1.4.14"
+val exposedVersion = "0.55.0"
+val logbackVersion = "1.5.32"
 val flywayVersion = "9.22.3"
-val logstashEncoderVersion = "7.4"
+val logstashEncoderVersion = "8.0"
 
 plugins {
     kotlin("jvm") version "1.9.24"
@@ -35,7 +35,6 @@ dependencies {
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-auth:$ktorVersion")
-    implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-server-html-builder:$ktorVersion")
@@ -49,10 +48,10 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
 
-    implementation("org.postgresql:postgresql:42.7.3")
+    implementation("org.postgresql:postgresql:42.7.10")
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("org.flywaydb:flyway-core:$flywayVersion")
-    implementation("com.auth0:java-jwt:4.4.0")
+    implementation("com.auth0:java-jwt:4.5.1")
     implementation("at.favre.lib:bcrypt:0.10.2")
 
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
@@ -65,9 +64,9 @@ dependencies {
     // Kotlin test assertions + JUnit 5 runner
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     // MockK — Kotlin-native mocking (HTTP integration tests only)
-    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("io.mockk:mockk:1.13.16")
     // JUnit 5 engine
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.5")
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.kauth"
-version = "1.1.3"
+version = "1.1.4"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -103,6 +103,10 @@ fun Application.module(
         header("X-Content-Type-Options", "nosniff")
         header("X-Frame-Options", "DENY")
         header("Referrer-Policy", "strict-origin-when-cross-origin")
+        header(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; form-action 'self'",
+        )
         header(HttpHeaders.Server, "KotAuth")
         if (config.isHttps) {
             header(
@@ -154,11 +158,13 @@ fun Application.module(
             cookie.httpOnly = true
             cookie.secure = secureCookies
             cookie.maxAgeInSeconds = 3600 * 8
+            cookie.extensions["SameSite"] = "Lax"
         }
         cookie<PortalSession>("KOTAUTH_PORTAL") {
             cookie.httpOnly = true
             cookie.secure = secureCookies
             cookie.maxAgeInSeconds = 3600 * 4
+            cookie.extensions["SameSite"] = "Lax"
             transform(
                 SessionTransportTransformerMessageAuthentication(
                     s.portalSessionKey,

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogRepository.kt
@@ -31,7 +31,8 @@ class PostgresAuditLogRepository : AuditLogRepository {
             if (userId != null) query.andWhere { AuditLogTable.userId eq userId.value }
             query
                 .orderBy(AuditLogTable.createdAt, SortOrder.DESC)
-                .limit(limit, offset.toLong())
+                .limit(limit)
+                .offset(offset.toLong())
                 .map { it.toAuditEvent() }
         }
 

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -44,7 +44,7 @@ class JwtTokenAdapter(
     private val tenantKeyRepository: TenantKeyRepository,
 ) : TokenPort {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val algorithmCache = mutableMapOf<Int, Pair<Algorithm, RSAPublicKey>>()
+    private val algorithmCache = java.util.concurrent.ConcurrentHashMap<Int, Pair<Algorithm, RSAPublicKey>>()
 
     // -------------------------------------------------------------------------
     // TokenPort — issue user tokens

--- a/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
@@ -182,7 +182,7 @@ class WebhookService(
         val delayMs = retryDelaysMs[attemptNumber]
         if (delayMs > 0) delay(delayMs)
 
-        val (responseStatus, success) = sendRequest(endpoint, delivery.payload)
+        val (responseStatus, success) = sendRequest(endpoint, delivery.payload, delivery.eventType)
         val now = Instant.now()
         val newAttempts = delivery.attempts + 1
         val newStatus =
@@ -232,6 +232,7 @@ class WebhookService(
     private fun sendRequest(
         endpoint: WebhookEndpoint,
         payload: String,
+        eventType: String,
     ): Pair<Int?, Boolean> =
         try {
             val url = URI(endpoint.url).toURL()
@@ -242,7 +243,7 @@ class WebhookService(
             conn.readTimeout = readTimeoutMs
             conn.setRequestProperty("Content-Type", "application/json; charset=utf-8")
             conn.setRequestProperty("User-Agent", "KotAuth-Webhook/1.0")
-            conn.setRequestProperty("X-KotAuth-Event", endpoint.url)
+            conn.setRequestProperty("X-KotAuth-Event", eventType)
             conn.setRequestProperty("X-KotAuth-Signature", computeSignature(endpoint.secret, payload))
 
             OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(payload) }


### PR DESCRIPTION
## What does this PR do?

This pull request introduces several security and concurrency improvements to the application, as well as an update to webhook event handling. The most important changes include the addition of a strict Content Security Policy header, enhancements to cookie security, making the JWT algorithm cache thread-safe, and correcting the event type sent in webhook requests.

**Security enhancements:**

* Added a `Content-Security-Policy` header to HTTP responses to restrict sources for scripts, styles, images, and form actions, improving protection against XSS and related attacks. (`src/main/kotlin/com/kauth/Application.kt`)
* Set the `SameSite=Lax` attribute for session cookies to help prevent CSRF attacks. (`src/main/kotlin/com/kauth/Application.kt`)

**Concurrency improvements:**

* Changed the `algorithmCache` in `JwtTokenAdapter` from a mutable map to a `ConcurrentHashMap` to ensure thread-safety when caching JWT algorithms and keys. (`src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt`)

**Webhook handling improvements:**

* Modified the webhook delivery process to pass the correct event type to the `sendRequest` function and set the `X-KotAuth-Event` header to the actual event type instead of the endpoint URL. (`src/main/kotlin/com/kauth/domain/service/WebhookService.kt`) [[1]](diffhunk://#diff-9251e3a62d0cf9810393b7c5e92a42a8417dd45266ef9939ab954354cc4e3d95L185-R185) [[2]](diffhunk://#diff-9251e3a62d0cf9810393b7c5e92a42a8417dd45266ef9939ab954354cc4e3d95R235) [[3]](diffhunk://#diff-9251e3a62d0cf9810393b7c5e92a42a8417dd45266ef9939ab954354cc4e3d95L245-R246)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
