### PR TITLE
Fix/query performance

### DIFF
--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresRoleRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresRoleRepository.kt
@@ -146,6 +146,24 @@ class PostgresRoleRepository : RoleRepository {
                 .map { RoleId(it[CompositeRoleMappingsTable.childRoleId]) }
         }
 
+    override fun findAllChildMappings(tenantId: TenantId): Map<RoleId, List<RoleId>> =
+        transaction {
+            val tenantRoleIds =
+                RolesTable
+                    .selectAll()
+                    .where { RolesTable.tenantId eq tenantId.value }
+                    .map { it[RolesTable.id] }
+                    .toSet()
+
+            if (tenantRoleIds.isEmpty()) return@transaction emptyMap()
+
+            CompositeRoleMappingsTable
+                .selectAll()
+                .where { CompositeRoleMappingsTable.parentRoleId inList tenantRoleIds }
+                .groupBy { RoleId(it[CompositeRoleMappingsTable.parentRoleId]) }
+                .mapValues { (_, rows) -> rows.map { RoleId(it[CompositeRoleMappingsTable.childRoleId]) } }
+        }
+
     // -------------------------------------------------------------------------
     // User ↔ Role assignment
     // -------------------------------------------------------------------------
@@ -292,21 +310,14 @@ class PostgresRoleRepository : RoleRepository {
     // Row mapping
     // -------------------------------------------------------------------------
 
-    private fun ResultRow.toRole(): Role {
-        val roleId = this[RolesTable.id]
-        return Role(
-            id = RoleId(roleId),
+    private fun ResultRow.toRole(): Role =
+        Role(
+            id = RoleId(this[RolesTable.id]),
             tenantId = TenantId(this[RolesTable.tenantId]),
             name = this[RolesTable.name],
             description = this[RolesTable.description],
             scope = RoleScope.fromValue(this[RolesTable.scope]),
             clientId = this[RolesTable.clientId]?.let { ApplicationId(it) },
-            childRoleIds =
-                CompositeRoleMappingsTable
-                    .selectAll()
-                    .where { CompositeRoleMappingsTable.parentRoleId eq roleId }
-                    .map { RoleId(it[CompositeRoleMappingsTable.childRoleId]) },
             createdAt = this[RolesTable.createdAt].toInstant(),
         )
-    }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/LoginRoutes.kt
@@ -95,7 +95,8 @@ internal fun Route.loginRoutes(
         when (val result = authService.authenticate(slug, username, password, ipAddress, userAgent)) {
             is AuthResult.Failure -> {
                 if (result.error is AuthError.PasswordExpired) {
-                    call.respondRedirect("/t/$slug/forgot-password?reason=expired")
+                    val oauthQs = if (oauthParams.isOAuthFlow) "&${oauthParams.toQueryString().drop(1)}" else ""
+                    call.respondRedirect("/t/$slug/forgot-password?reason=expired$oauthQs")
                 } else {
                     call.respondHtml(
                         HttpStatusCode.Unauthorized,

--- a/src/main/kotlin/com/kauth/domain/port/RoleRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/RoleRepository.kt
@@ -48,6 +48,9 @@ interface RoleRepository {
 
     fun findChildRoleIds(roleId: RoleId): List<RoleId>
 
+    /** Returns all parent→children composite mappings for roles in the given tenant (single query). */
+    fun findAllChildMappings(tenantId: TenantId): Map<RoleId, List<RoleId>>
+
     // User ↔ Role assignment
     fun assignRoleToUser(
         userId: UserId,

--- a/src/main/kotlin/com/kauth/domain/service/RoleGroupService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/RoleGroupService.kt
@@ -176,7 +176,14 @@ class RoleGroupService(
         return AdminResult.Success(Unit)
     }
 
-    fun listRoles(tenantId: TenantId): List<Role> = roleRepository.findByTenantId(tenantId)
+    fun listRoles(tenantId: TenantId): List<Role> {
+        val roles = roleRepository.findByTenantId(tenantId)
+        val childMappings = roleRepository.findAllChildMappings(tenantId)
+        return roles.map { role ->
+            val children = childMappings[role.id]
+            if (children != null) role.copy(childRoleIds = children) else role
+        }
+    }
 
     fun listClientRoles(
         tenantId: TenantId,

--- a/src/main/resources/db/migration/V25__performance_indexes.sql
+++ b/src/main/resources/db/migration/V25__performance_indexes.sql
@@ -1,0 +1,10 @@
+-- Composite index for findActiveByUser queries (login session limits, portal session list).
+-- The existing idx_sessions_active covers (tenant_id, revoked_at) but cannot use user_id.
+CREATE INDEX IF NOT EXISTS idx_sessions_tenant_user_active
+    ON sessions(tenant_id, user_id, expires_at)
+    WHERE revoked_at IS NULL AND user_id IS NOT NULL;
+
+-- Composite index for audit log queries ordered by created_at within a tenant.
+-- The existing separate indexes on tenant_id and created_at cannot be combined for filter + sort.
+CREATE INDEX IF NOT EXISTS idx_audit_tenant_created
+    ON audit_log(tenant_id, created_at DESC);

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
@@ -89,6 +89,19 @@ class FakeRoleRepository : RoleRepository {
     override fun findChildRoleIds(roleId: RoleId): List<RoleId> =
         composites[roleId.value]?.map { RoleId(it) } ?: emptyList()
 
+    override fun findAllChildMappings(tenantId: TenantId): Map<RoleId, List<RoleId>> {
+        val tenantRoleIds =
+            store.values
+                .filter { it.tenantId == tenantId }
+                .mapNotNull { it.id }
+                .toSet()
+        return composites
+            .filter { (parentId, _) -> RoleId(parentId) in tenantRoleIds }
+            .mapKeys { (parentId, _) -> RoleId(parentId) }
+            .mapValues { (_, childIds) -> childIds.map { RoleId(it) } }
+            .filter { (_, children) -> children.isNotEmpty() }
+    }
+
     override fun assignRoleToUser(
         userId: UserId,
         roleId: RoleId,


### PR DESCRIPTION
## What does this PR do?

This pull request introduces performance optimizations and refactors how child role relationships are loaded for roles within a tenant. The main focus is to efficiently fetch child role mappings in a single query and to ensure that `Role.childRoleIds` is correctly populated when listing roles. Additionally, database indexes are added to improve query speed for sessions and audit logs, and a small fix is made to preserve OAuth parameters during password expiry redirects.

**Role loading and child mappings improvements:**

* Added a new method `findAllChildMappings` to `RoleRepository` and its implementations (`PostgresRoleRepository`, `FakeRoleRepository`) to fetch all parent→children composite role mappings for a tenant in a single query, improving performance over per-role queries. [[1]](diffhunk://#diff-b0246c6473e6dda007eed137dce1655013c6faccb097f954b6e823e7b851ccc1R51-R53) [[2]](diffhunk://#diff-db77c0a4cfdf20001b1f63737be568472dcf809c17511d6271030b204bd14409R149-R166) [[3]](diffhunk://#diff-66e6cdca59e8829c282e686a5b7a5ba660feb89c64e61a9bb1199565d90e6b7dR92-R104)
* Updated `RoleGroupService.listRoles` to use `findAllChildMappings`, ensuring each `Role` in the returned list has its `childRoleIds` field populated efficiently.
* Refactored `PostgresRoleRepository.toRole` so that it no longer loads `childRoleIds` per role, relying instead on the new bulk mapping logic.

**Database performance enhancements:**

* Added composite indexes for session and audit log tables to improve performance of active session lookups and audit log queries filtered and sorted by tenant and creation time.

**Web authentication flow fix:**

* Fixed password expiry redirect to preserve OAuth query parameters, ensuring smoother OAuth login flows when a password reset is required.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
