### PR TITLE
fix/api-partial-update

### DIFF
--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -99,8 +99,8 @@ data class ProblemDetail(
 )
 
 @Serializable data class UpdateUserRequest(
-    val email: String,
-    val fullName: String,
+    val email: String? = null,
+    val fullName: String? = null,
 )
 
 @Serializable data class CreateRoleRequest(
@@ -126,10 +126,10 @@ data class ProblemDetail(
 )
 
 @Serializable data class UpdateApplicationRequest(
-    val name: String,
+    val name: String? = null,
     val description: String? = null,
-    val accessType: String = "public",
-    val redirectUris: List<String> = emptyList(),
+    val accessType: String? = null,
+    val redirectUris: List<String>? = null,
 )
 
 // -- Response DTOs ------------------------------------------------------------

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -419,24 +419,25 @@ class AdminService(
     fun updateUser(
         userId: UserId,
         tenantId: TenantId,
-        email: String,
-        fullName: String,
+        email: String? = null,
+        fullName: String? = null,
     ): AdminResult<User> {
         val user =
             userRepository.findById(userId, tenantId)
                 ?: return AdminResult.Failure(AdminError.NotFound("User ${userId.value} not found."))
 
-        if (email.isBlank() || !email.contains('@')) {
+        val resolvedEmail = email?.trim()?.lowercase() ?: user.email
+        val resolvedFullName = fullName?.trim() ?: user.fullName
+
+        if (resolvedEmail.isBlank() || !resolvedEmail.contains('@')) {
             return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
         }
 
-        // Check email uniqueness only if it changed
-        val newEmail = email.trim().lowercase()
-        if (newEmail != user.email && userRepository.existsByEmail(tenantId, newEmail)) {
-            return AdminResult.Failure(AdminError.Conflict("Email '$newEmail' is already registered."))
+        if (resolvedEmail != user.email && userRepository.existsByEmail(tenantId, resolvedEmail)) {
+            return AdminResult.Failure(AdminError.Conflict("Email '$resolvedEmail' is already registered."))
         }
 
-        val updated = userRepository.update(user.copy(email = newEmail, fullName = fullName.trim()))
+        val updated = userRepository.update(user.copy(email = resolvedEmail, fullName = resolvedFullName))
 
         auditLog.record(
             AuditEvent(
@@ -492,10 +493,10 @@ class AdminService(
     fun updateApplication(
         appId: ApplicationId,
         tenantId: TenantId,
-        name: String,
-        description: String?,
-        accessType: String,
-        redirectUris: List<String>,
+        name: String? = null,
+        description: String? = null,
+        accessType: String? = null,
+        redirectUris: List<String>? = null,
     ): AdminResult<Application> {
         val app =
             applicationRepository.findById(appId)
@@ -504,17 +505,30 @@ class AdminService(
         if (app.tenantId != tenantId) {
             return AdminResult.Failure(AdminError.NotFound("Application not found in this workspace."))
         }
-        if (name.isBlank()) {
+
+        val resolvedName = name?.trim() ?: app.name
+        val resolvedDescription =
+            if (description !=
+                null
+            ) {
+                description.trim().takeIf { it.isNotBlank() }
+            } else {
+                app.description
+            }
+        val resolvedAccessType = accessType ?: app.accessType.value
+        val resolvedRedirectUris = redirectUris ?: app.redirectUris
+
+        if (resolvedName.isBlank()) {
             return AdminResult.Failure(AdminError.Validation("Name is required."))
         }
 
         val updated =
             applicationRepository.update(
                 appId = appId,
-                name = name.trim(),
-                description = description?.trim()?.takeIf { it.isNotBlank() },
-                accessType = accessType,
-                redirectUris = redirectUris,
+                name = resolvedName,
+                description = resolvedDescription,
+                accessType = resolvedAccessType,
+                redirectUris = resolvedRedirectUris,
             )
 
         auditLog.record(

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -330,6 +330,30 @@ class AdminServiceTest {
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_UPDATED))
     }
 
+    @Test
+    fun `updateUser - partial update email only`() {
+        val result = svc.updateUser(userId = UserId(10), tenantId = TenantId(1), email = "new@example.com")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("new@example.com", result.value.email)
+        assertEquals("Alice Test", result.value.fullName)
+    }
+
+    @Test
+    fun `updateUser - partial update fullName only`() {
+        val result = svc.updateUser(userId = UserId(10), tenantId = TenantId(1), fullName = "Alice Renamed")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice@example.com", result.value.email)
+        assertEquals("Alice Renamed", result.value.fullName)
+    }
+
+    @Test
+    fun `updateUser - no fields keeps existing values`() {
+        val result = svc.updateUser(userId = UserId(10), tenantId = TenantId(1))
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice@example.com", result.value.email)
+        assertEquals("Alice Test", result.value.fullName)
+    }
+
     // =========================================================================
     // setUserEnabled
     // =========================================================================
@@ -411,6 +435,35 @@ class AdminServiceTest {
         assertIs<AdminResult.Success<Application>>(result)
         assertEquals("Renamed App", result.value.name)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_UPDATED))
+    }
+
+    @Test
+    fun `updateApplication - partial update name only`() {
+        val result = svc.updateApplication(appId = ApplicationId(100), tenantId = TenantId(1), name = "New Name")
+        assertIs<AdminResult.Success<Application>>(result)
+        assertEquals("New Name", result.value.name)
+        assertEquals("Test app", result.value.description)
+        assertEquals(AccessType.CONFIDENTIAL, result.value.accessType)
+        assertEquals(listOf("http://localhost/callback"), result.value.redirectUris)
+    }
+
+    @Test
+    fun `updateApplication - partial update description only`() {
+        val result =
+            svc.updateApplication(appId = ApplicationId(100), tenantId = TenantId(1), description = "New desc")
+        assertIs<AdminResult.Success<Application>>(result)
+        assertEquals("My App", result.value.name)
+        assertEquals("New desc", result.value.description)
+    }
+
+    @Test
+    fun `updateApplication - no fields keeps existing values`() {
+        val result = svc.updateApplication(appId = ApplicationId(100), tenantId = TenantId(1))
+        assertIs<AdminResult.Success<Application>>(result)
+        assertEquals("My App", result.value.name)
+        assertEquals("Test app", result.value.description)
+        assertEquals(AccessType.CONFIDENTIAL, result.value.accessType)
+        assertEquals(listOf("http://localhost/callback"), result.value.redirectUris)
     }
 
     // =========================================================================


### PR DESCRIPTION
## What does this PR do?

This pull request introduces support for partial updates to users and applications in the admin service, allowing clients to update only the fields they specify while retaining existing values for unspecified fields. It also adds comprehensive tests to verify this new behavior.

**Support for partial updates:**

* The `updateUser` and `updateApplication` methods in `AdminService` now accept nullable parameters and only update the fields that are provided, leaving others unchanged. [[1]](diffhunk://#diff-237681a9de2b76fb00f31f7dd8b1bd59c4a7468691583c27c5bb29030488b7f7L422-R440) [[2]](diffhunk://#diff-237681a9de2b76fb00f31f7dd8b1bd59c4a7468691583c27c5bb29030488b7f7L495-R499) [[3]](diffhunk://#diff-237681a9de2b76fb00f31f7dd8b1bd59c4a7468691583c27c5bb29030488b7f7L507-R531)
* The associated request DTOs (`UpdateUserRequest` and `UpdateApplicationRequest` in `ApiHelpers.kt`) now have all fields nullable with default values, reflecting the partial update capability. [[1]](diffhunk://#diff-e9d2de8b4d5eb5f4d7e91fc53eccb1c84aa01c0e881282bcb2d60d3162aa684bL102-R103) [[2]](diffhunk://#diff-e9d2de8b4d5eb5f4d7e91fc53eccb1c84aa01c0e881282bcb2d60d3162aa684bL129-R132)

**Testing improvements:**

* Added new tests in `AdminServiceTest` to verify partial updates for both users and applications, including cases where only one field is updated or no fields are provided (ensuring existing values are preserved). [[1]](diffhunk://#diff-9dfe72a7e4ed42cf2648ab17c7af870020f112d03bf58ed4024ba25db14daddfR333-R356) [[2]](diffhunk://#diff-9dfe72a7e4ed42cf2648ab17c7af870020f112d03bf58ed4024ba25db14daddfR440-R468)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
