### PR TITLE
feature/key-rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.2] - 2026-04-10
+
+### Added
+
+- **Admin-initiated key rotation** — new "Signing Keys" page under Settings where admins can rotate RS256 signing key pairs. The new key becomes the active signer; the old key remains enabled for token verification (served via JWKS) until manually retired. Supports the full key lifecycle: Active → Verification only → Retired
+- **`kid` header on all JWTs** — access tokens, id_tokens, and client credentials tokens now include the `kid` (Key ID) header per RFC 7517. Enables correct key selection during verification after rotation
+- **`kid`-based token verification** — `decodeAccessToken` reads the JWT `kid` header and resolves the specific signing key for verification. Tokens signed by rotated-away (but still enabled) keys verify correctly. Falls back to the active key for legacy tokens without `kid`
+- **`KeyRotationService`** — domain service with `rotate()` and `retireKey()` operations, audit events (`ADMIN_KEY_ROTATED`, `ADMIN_KEY_RETIRED`), and injectable key generation (no infrastructure imports in domain)
+- **Key management admin UI** — table showing all keys (active, verification-only, retired) with `createdAt` timestamps, status badges, rotate button with confirmation dialog, retire button for non-active keys
+- **`TenantKey.active` flag** — distinguishes the signing key from verification-only keys. Enforced by a partial unique index (at most one active key per tenant). Migration V31 adds the column and backfills existing keys
+- **`TenantKey.createdAt`** — mapped from the existing DB column to the domain model, displayed in the key management UI
+- **`TenantKeyRepository.findByKeyId()`** — lookup by kid for verification. `rotate()` — atomic two-UPDATE transaction promoting new key and demoting old. `findAllKeys()` — returns all keys including retired
+- **`TokenPort.invalidateSigningKeyCache()`** — exposed on the port interface so the domain rotation service can trigger cache eviction without importing the adapter
+- **`FakeTenantKeyRepository`** — in-memory test fake for key rotation tests
+- **`SecureTokens` utility** — shared `SecureRandom` singleton in `domain/util/` with `randomBytes()`, `randomBase64Url()`, `randomHex()`. Replaces 12 scattered `SecureRandom()` instantiations across 11 files
+- **Settings sidebar dividers** — visual grouping of settings items into Workspace (General, Branding, SMTP), Security & Identity (Security policy, Signing Keys, Identity Providers), and Developer Integration (API Keys, Webhooks)
+- **23 new tests** — 13 in `KeyRotationServiceTest` (rotate, retire, cross-tenant isolation, multiple rotations) + 10 in `JwtTokenAdapterKeyRotationTest` (kid presence, verification after rotation, retired key rejection, JWKS composition, cross-tenant cache isolation)
+
+### Changed
+
+- **Signing Keys sidebar position** — moved next to "Security policy" (was between API Keys and Webhooks). Security primitives now grouped together
+- **Rotate button** — full-size `btn--primary` in page header (was incorrectly `btn--sm`)
+- **Revoke All Sessions button** — full-size `btn--warning` in page header (was incorrectly `btn--sm`)
+- **Retire confirmation text** — updated to "Active sessions and tokens signed by it will immediately stop working. This cannot be undone."
+- **`TOAST_KEY_RETIRED`** — removed JWKS jargon: "Key retired. Tokens signed with this key will no longer be accepted."
+- **Retire failure** — route now re-renders page with error message (was silently redirecting with no feedback)
+- **`KeyProvisioningService`** — initial key provisioned with `active=true` explicitly
+- **Timestamp formatting** — `KeyRotationViews` aligned to shared `toDisplayString()` (was using a separate inline formatter)
+- **Fully-qualified `WebhookResult`** in routes and tests replaced with proper imports
+
+### Removed
+
+- **`SecureRandom()` scattered instantiations** — 12 ad-hoc instantiations across 11 files replaced by `SecureTokens` singleton
+- **`SecureTokens.nextBytes()`** — unused method removed before shipping
+- **`JwtTokenAdapter.invalidateCache()`** — deprecated method removed, replaced by `invalidateSigningKeyCache()`
+- **`SelfServiceError.EmailDeliveryFailed`** — dead sealed class variant never referenced
+- **Unused `val user` binding** in `confirmAcceptInvite` — findById kept as not-found guard, dropped assignment
+- **Redundant fully-qualified references** in `AdminWebhooksTest` — 6 FQ names replaced with imports
+
+---
+
+## [1.5.1] - 2026-04-10
+
+### Added
+
+- **`AdminRouteContext` + `call.adminContext()`** — extracted repeated session/workspace/wsPairs triple from admin route handlers. `AdminUserRoutes` fully migrated (4 page-rendering handlers use context, 8 POST-only handlers keep direct `WorkspaceAttr` access)
+- **`Parameters.typedId()`** — reusable typed-ID extraction helper. Replaced 33 `?.toIntOrNull()?.let { XxxId(it) }` patterns across 3 route files (UserId, RoleId, GroupId, ApplicationId, SessionId)
+- **`ApplicationCall.resolvedBaseUrl()`** — extracted duplicated base URL construction. Replaced 7 occurrences across 3 files (AdminUserRoutes, SelfServiceRoutes, OAuthProtocolRoutes)
+- **`UserRepository.findByIds()`** — batch query (`WHERE id IN (...)`) for hydrating user lists. Single query replaces N+1 per-member lookups
+- **`RoleGroupService.getUsersInGroup()` / `getUsersForRole()`** — batch-hydrated user lists via `findByIds`. Route handlers no longer call `userRepository.findById` directly (partial ADR-04 fix)
+- **`validatePasswordPolicy()` private helper** — extracted duplicated password policy + history validation from `confirmPasswordReset`, `confirmAcceptInvite`, and `changePassword` into a single 20-line method
+
+### Changed
+
+- **Group detail page** — N+1 query (1 query per member) replaced with single batch query via `getUsersInGroup`
+- **Role detail page** — same fix via `getUsersForRole`
+
+### Fixed
+
+- **`resendVerificationEmail` result silently ignored** — route now branches on `AdminResult.Success`/`Failure` and redirects with error toast on failure
+
+---
+
 ## [1.5.0] - 2026-04-07
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.kauth"
-version = "1.5.0"
+version = "1.5.2"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/frontend/css/layout/sidebar.css
+++ b/frontend/css/layout/sidebar.css
@@ -73,3 +73,10 @@
   background: var(--color-accent);
   view-transition-name: sidebar-dot;
 }
+
+u/* Visual divider between sidebar item groups */
+.sidebar__divider {
+  height: 0.5px;
+  background: var(--color-border);
+  margin: var(--space-2) var(--space-4);
+}

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -391,6 +391,8 @@ fun Application.module(
             oauthService = s.oauthService,
             selfServiceService = s.selfServiceService,
             roleRepository = s.roleRepository,
+            keyRotationService = s.keyRotationService,
+            tenantKeyRepository = s.tenantKeyRepository,
             baseUrl = config.baseUrl,
         )
     }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantKeyRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantKeyRepository.kt
@@ -33,6 +33,15 @@ class PostgresTenantKeyRepository(
                 .map { it.toTenantKey() }
         }
 
+    override fun findAllKeys(tenantId: TenantId): List<TenantKey> =
+        transaction {
+            TenantKeysTable
+                .selectAll()
+                .where { TenantKeysTable.tenantId eq tenantId.value }
+                .orderBy(TenantKeysTable.createdAt, SortOrder.DESC)
+                .map { it.toTenantKey() }
+        }
+
     override fun findByKeyId(
         tenantId: TenantId,
         keyId: String,
@@ -104,6 +113,7 @@ class PostgresTenantKeyRepository(
             privateKeyPem = decryptedPrivateKey,
             enabled = this[TenantKeysTable.enabled],
             active = this[TenantKeysTable.active],
+            createdAt = this[TenantKeysTable.createdAt].toInstant(),
         )
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantKeyRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantKeyRepository.kt
@@ -16,10 +16,11 @@ class PostgresTenantKeyRepository(
         transaction {
             TenantKeysTable
                 .selectAll()
-                .where { (TenantKeysTable.tenantId eq tenantId.value) and (TenantKeysTable.enabled eq true) }
-                .orderBy(TenantKeysTable.createdAt, SortOrder.DESC)
-                .limit(1)
-                .map { it.toTenantKey() }
+                .where {
+                    (TenantKeysTable.tenantId eq tenantId.value) and
+                        (TenantKeysTable.active eq true) and
+                        (TenantKeysTable.enabled eq true)
+                }.map { it.toTenantKey() }
                 .singleOrNull()
         }
 
@@ -32,6 +33,18 @@ class PostgresTenantKeyRepository(
                 .map { it.toTenantKey() }
         }
 
+    override fun findByKeyId(
+        tenantId: TenantId,
+        keyId: String,
+    ): TenantKey? =
+        transaction {
+            TenantKeysTable
+                .selectAll()
+                .where { (TenantKeysTable.tenantId eq tenantId.value) and (TenantKeysTable.keyId eq keyId) }
+                .map { it.toTenantKey() }
+                .singleOrNull()
+        }
+
     override fun save(key: TenantKey): TenantKey =
         transaction {
             val insertedId =
@@ -42,11 +55,29 @@ class PostgresTenantKeyRepository(
                     it[publicKey] = key.publicKeyPem
                     it[privateKey] = encryptionService.encrypt(key.privateKeyPem)
                     it[enabled] = key.enabled
+                    it[active] = key.active
                     it[createdAt] = OffsetDateTime.now()
                 } get TenantKeysTable.id
 
             key.copy(id = insertedId)
         }
+
+    override fun rotate(
+        tenantId: TenantId,
+        newKeyId: String,
+        previousKeyId: String,
+    ) = transaction {
+        // Demote old signing key (keep enabled=true for JWKS verification)
+        TenantKeysTable.update({
+            (TenantKeysTable.tenantId eq tenantId.value) and (TenantKeysTable.keyId eq previousKeyId)
+        }) { it[active] = false }
+
+        // Promote new signing key
+        TenantKeysTable.update({
+            (TenantKeysTable.tenantId eq tenantId.value) and (TenantKeysTable.keyId eq newKeyId)
+        }) { it[active] = true }
+        Unit
+    }
 
     override fun disable(
         tenantId: TenantId,
@@ -56,6 +87,7 @@ class PostgresTenantKeyRepository(
             (TenantKeysTable.tenantId eq tenantId.value) and (TenantKeysTable.keyId eq keyId)
         }) {
             it[enabled] = false
+            it[active] = false
         }
         Unit
     }
@@ -71,6 +103,7 @@ class PostgresTenantKeyRepository(
             publicKeyPem = this[TenantKeysTable.publicKey],
             privateKeyPem = decryptedPrivateKey,
             enabled = this[TenantKeysTable.enabled],
+            active = this[TenantKeysTable.active],
         )
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/TenantKeysTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/TenantKeysTable.kt
@@ -15,6 +15,7 @@ object TenantKeysTable : Table("tenant_keys") {
     val publicKey = text("public_key")
     val privateKey = text("private_key")
     val enabled = bool("enabled").default(true)
+    val active = bool("active").default(false)
     val createdAt = timestampWithTimeZone("created_at")
 
     override val primaryKey = PrimaryKey(id)

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -44,7 +44,14 @@ class JwtTokenAdapter(
     private val tenantKeyRepository: TenantKeyRepository,
 ) : TokenPort {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val algorithmCache = java.util.concurrent.ConcurrentHashMap<Int, Pair<Algorithm, RSAPublicKey>>()
+
+    private data class CachedKey(
+        val algorithm: Algorithm,
+        val publicKey: RSAPublicKey,
+        val keyId: String,
+    )
+
+    private val algorithmCache = java.util.concurrent.ConcurrentHashMap<Int, CachedKey>()
 
     // -------------------------------------------------------------------------
     // TokenPort — issue user tokens
@@ -58,7 +65,7 @@ class JwtTokenAdapter(
         nonce: String?,
         roles: List<Role>,
     ): TokenResponse {
-        val (algorithm, _) = getOrCreateAlgorithm(tenant.id.value)
+        val activeKey = getOrCreateAlgorithm(tenant.id.value)
         val issuer = issuerFor(tenant)
         val audience = client?.clientId ?: tenant.slug
         val subject = user.id!!.value.toString()
@@ -74,6 +81,7 @@ class JwtTokenAdapter(
         val accessTokenBuilder =
             JWT
                 .create()
+                .withKeyId(activeKey.keyId)
                 .withIssuer(issuer)
                 .withAudience(audience)
                 .withSubject(subject)
@@ -119,12 +127,13 @@ class JwtTokenAdapter(
             }
         }
 
-        val accessToken = accessTokenBuilder.sign(algorithm)
+        val accessToken = accessTokenBuilder.sign(activeKey.algorithm)
 
         val idToken =
             if ("openid" in scopes) {
                 JWT
                     .create()
+                    .withKeyId(activeKey.keyId)
                     .withIssuer(issuer)
                     .withAudience(audience)
                     .withSubject(subject)
@@ -135,7 +144,7 @@ class JwtTokenAdapter(
                     .apply { if (nonce != null) withClaim("nonce", nonce) }
                     .withIssuedAt(Date())
                     .withExpiresAt(expiresAt)
-                    .sign(algorithm)
+                    .sign(activeKey.algorithm)
             } else {
                 null
             }
@@ -163,12 +172,13 @@ class JwtTokenAdapter(
         client: Application,
         scopes: List<String>,
     ): String {
-        val (algorithm, _) = getOrCreateAlgorithm(tenant.id.value)
+        val activeKey = getOrCreateAlgorithm(tenant.id.value)
         val issuer = issuerFor(tenant)
         val expiryMs = (client.tokenExpiryOverride?.toLong() ?: tenant.tokenExpirySeconds) * 1_000L
 
         return JWT
             .create()
+            .withKeyId(activeKey.keyId)
             .withIssuer(issuer)
             .withAudience(client.clientId)
             .withSubject(client.clientId) // sub = client_id for M2M
@@ -178,7 +188,7 @@ class JwtTokenAdapter(
             .withIssuedAt(Date())
             .withExpiresAt(Date(System.currentTimeMillis() + expiryMs))
             .withJWTId(UUID.randomUUID().toString())
-            .sign(algorithm)
+            .sign(activeKey.algorithm)
     }
 
     // -------------------------------------------------------------------------
@@ -189,7 +199,15 @@ class JwtTokenAdapter(
         return try {
             val decoded = JWT.decode(token)
             val tenantIdRaw = decoded.getClaim("tenant_id").asInt() ?: return null
-            val (algorithm, _) = getOrCreateAlgorithm(tenantIdRaw)
+            val kid = decoded.keyId // JWT "kid" header — null for tokens issued before key rotation
+
+            // Use kid-based lookup for rotated keys, fall back to active key for legacy tokens
+            val algorithm =
+                if (kid != null) {
+                    getAlgorithmForKid(tenantIdRaw, kid) ?: getOrCreateAlgorithm(tenantIdRaw).algorithm
+                } else {
+                    getOrCreateAlgorithm(tenantIdRaw).algorithm
+                }
 
             val verifier = JWT.require(algorithm).build()
             val verified = verifier.verify(token)
@@ -252,7 +270,7 @@ class JwtTokenAdapter(
     // Internal helpers
     // -------------------------------------------------------------------------
 
-    private fun getOrCreateAlgorithm(tenantId: Int): Pair<Algorithm, RSAPublicKey> {
+    private fun getOrCreateAlgorithm(tenantId: Int): CachedKey {
         algorithmCache[tenantId]?.let { return it }
 
         val key =
@@ -268,8 +286,24 @@ class JwtTokenAdapter(
         val privateKey = KeyGenerator.decodePrivateKey(key.privateKeyPem)
         val algorithm = Algorithm.RSA256(publicKey, privateKey)
 
-        algorithmCache[tenantId] = algorithm to publicKey
-        return algorithm to publicKey
+        val cached = CachedKey(algorithm, publicKey, key.keyId)
+        algorithmCache[tenantId] = cached
+        return cached
+    }
+
+    /**
+     * Resolves an Algorithm for a specific kid (key ID) — used for token verification
+     * after key rotation when the token was signed by a non-active but still-enabled key.
+     */
+    private fun getAlgorithmForKid(
+        tenantId: Int,
+        kid: String,
+    ): Algorithm? {
+        val key = tenantKeyRepository.findByKeyId(TenantId(tenantId), kid) ?: return null
+        if (!key.enabled) return null
+        val publicKey = KeyGenerator.decodePublicKey(key.publicKeyPem)
+        val privateKey = KeyGenerator.decodePrivateKey(key.privateKeyPem)
+        return Algorithm.RSA256(publicKey, privateKey)
     }
 
     private fun buildJwk(
@@ -300,6 +334,11 @@ class JwtTokenAdapter(
         return if (bytes[0] == 0.toByte()) bytes.copyOfRange(1, bytes.size) else bytes
     }
 
+    override fun invalidateSigningKeyCache(tenantId: TenantId) {
+        algorithmCache.remove(tenantId.value)
+    }
+
+    /** @deprecated Use [invalidateSigningKeyCache] instead. Kept for backward compatibility. */
     fun invalidateCache(tenantId: Int) {
         algorithmCache.remove(tenantId)
     }

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -12,6 +12,7 @@ import com.kauth.domain.model.TokenResponse
 import com.kauth.domain.model.User
 import com.kauth.domain.port.TenantKeyRepository
 import com.kauth.domain.port.TokenPort
+import com.kauth.domain.util.SecureTokens
 import com.kauth.infrastructure.KeyGenerator
 import org.slf4j.LoggerFactory
 import java.math.BigInteger
@@ -323,11 +324,7 @@ class JwtTokenAdapter(
 
     private fun issuerFor(tenant: Tenant): String = tenant.issuerUrl ?: "$baseUrl/t/${tenant.slug}"
 
-    private fun generateRefreshToken(): String =
-        Base64
-            .getUrlEncoder()
-            .withoutPadding()
-            .encodeToString(java.security.SecureRandom().generateSeed(32))
+    private fun generateRefreshToken(): String = SecureTokens.randomBase64Url(32)
 
     private fun BigInteger.toByteArrayUnsigned(): ByteArray {
         val bytes = toByteArray()
@@ -336,10 +333,5 @@ class JwtTokenAdapter(
 
     override fun invalidateSigningKeyCache(tenantId: TenantId) {
         algorithmCache.remove(tenantId.value)
-    }
-
-    /** @deprecated Use [invalidateSigningKeyCache] instead. Kept for backward compatibility. */
-    fun invalidateCache(tenantId: Int) {
-        algorithmCache.remove(tenantId)
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -72,4 +72,9 @@ object EnglishStrings {
     const val TOAST_INVITE_SEND_FAILED =
         "User created, but the invite email could not be sent. Resend it from this page."
     const val BADGE_INVITE_PENDING = "Invite pending"
+
+    // Key rotation
+    const val TOAST_KEY_ROTATED =
+        "Signing key rotated. The previous key remains active for token verification until retired."
+    const val TOAST_KEY_RETIRED = "Key retired. Tokens signed with this key will no longer be accepted."
 }

--- a/src/main/kotlin/com/kauth/adapter/web/OAuthUtils.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/OAuthUtils.kt
@@ -1,10 +1,10 @@
 package com.kauth.adapter.web
 
+import com.kauth.domain.util.SecureTokens
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.security.MessageDigest
-import java.security.SecureRandom
 import java.util.Base64
 
 // Shared OAuth utilities for admin and portal route handlers.
@@ -12,11 +12,7 @@ import java.util.Base64
 // the admin console and the self-service portal OAuth flows.
 
 /** Generates a cryptographically random PKCE code verifier (43 chars, base64url, no padding). */
-internal fun generatePkceVerifier(): String {
-    val bytes = ByteArray(32)
-    SecureRandom().nextBytes(bytes)
-    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-}
+internal fun generatePkceVerifier(): String = SecureTokens.randomBase64Url(32)
 
 /** Computes the S256 PKCE code challenge from a verifier. */
 internal fun generatePkceChallenge(verifier: String): String {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminKeyRotationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminKeyRotationRoutes.kt
@@ -1,0 +1,89 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.EnglishStrings
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.TenantKeyRepository
+import com.kauth.domain.service.AdminResult
+import com.kauth.domain.service.KeyRotationService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.html.respondHtml
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+
+fun Route.adminKeyRotationRoutes(
+    keyRotationService: KeyRotationService,
+    tenantKeyRepository: TenantKeyRepository,
+) {
+    get("/settings/signing-keys") {
+        val ctx = call.adminContext()
+        val keys = tenantKeyRepository.findEnabledKeys(ctx.workspace.id)
+        val toastMsg =
+            when (call.request.queryParameters["saved"]) {
+                "rotated" -> EnglishStrings.TOAST_KEY_ROTATED
+                "retired" -> EnglishStrings.TOAST_KEY_RETIRED
+                else -> null
+            }
+        call.respondHtml(
+            HttpStatusCode.OK,
+            AdminView.keyManagementPage(
+                ctx.workspace,
+                ctx.wsPairs,
+                ctx.session.username,
+                keys,
+                toastMessage = toastMsg,
+            ),
+        )
+    }
+
+    post("/settings/signing-keys/rotate") {
+        val ctx = call.adminContext()
+        when (
+            val result =
+                keyRotationService.rotate(ctx.workspace.id, UserId(ctx.session.userId))
+        ) {
+            is AdminResult.Success ->
+                call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/settings/signing-keys?saved=rotated",
+                )
+            is AdminResult.Failure ->
+                call.respondHtml(
+                    HttpStatusCode.UnprocessableEntity,
+                    AdminView.keyManagementPage(
+                        ctx.workspace,
+                        ctx.wsPairs,
+                        ctx.session.username,
+                        tenantKeyRepository.findEnabledKeys(ctx.workspace.id),
+                        error = result.error.message,
+                    ),
+                )
+        }
+    }
+
+    post("/settings/signing-keys/{keyId}/retire") {
+        val ctx = call.adminContext()
+        val keyId =
+            call.parameters["keyId"]
+                ?: return@post call.respond(HttpStatusCode.BadRequest)
+        when (val result = keyRotationService.retireKey(ctx.workspace.id, keyId, UserId(ctx.session.userId))) {
+            is AdminResult.Success ->
+                call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/settings/signing-keys?saved=retired",
+                )
+            is AdminResult.Failure ->
+                call.respondHtml(
+                    HttpStatusCode.UnprocessableEntity,
+                    AdminView.keyManagementPage(
+                        ctx.workspace,
+                        ctx.wsPairs,
+                        ctx.session.username,
+                        tenantKeyRepository.findEnabledKeys(ctx.workspace.id),
+                        error = result.error.message,
+                    ),
+                )
+        }
+    }
+}

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminKeyRotationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminKeyRotationRoutes.kt
@@ -20,7 +20,7 @@ fun Route.adminKeyRotationRoutes(
 ) {
     get("/settings/signing-keys") {
         val ctx = call.adminContext()
-        val keys = tenantKeyRepository.findEnabledKeys(ctx.workspace.id)
+        val keys = tenantKeyRepository.findAllKeys(ctx.workspace.id)
         val toastMsg =
             when (call.request.queryParameters["saved"]) {
                 "rotated" -> EnglishStrings.TOAST_KEY_ROTATED
@@ -56,7 +56,7 @@ fun Route.adminKeyRotationRoutes(
                         ctx.workspace,
                         ctx.wsPairs,
                         ctx.session.username,
-                        tenantKeyRepository.findEnabledKeys(ctx.workspace.id),
+                        tenantKeyRepository.findAllKeys(ctx.workspace.id),
                         error = result.error.message,
                     ),
                 )
@@ -80,7 +80,7 @@ fun Route.adminKeyRotationRoutes(
                         ctx.workspace,
                         ctx.wsPairs,
                         ctx.session.username,
-                        tenantKeyRepository.findEnabledKeys(ctx.workspace.id),
+                        tenantKeyRepository.findAllKeys(ctx.workspace.id),
                         error = result.error.message,
                     ),
                 )

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -14,11 +14,13 @@ import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.MfaRepository
 import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.SessionRepository
+import com.kauth.domain.port.TenantKeyRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
+import com.kauth.domain.service.KeyRotationService
 import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.RoleGroupService
@@ -64,6 +66,8 @@ fun Route.adminRoutes(
     oauthService: OAuthService? = null,
     selfServiceService: UserSelfServiceService? = null,
     roleRepository: RoleRepository? = null,
+    keyRotationService: KeyRotationService? = null,
+    tenantKeyRepository: TenantKeyRepository? = null,
     baseUrl: String = "",
 ) {
     AdminView.setShellAppInfo(appInfo)
@@ -486,6 +490,13 @@ fun Route.adminRoutes(
                 adminWebhookRoutes(
                     webhookService = webhookService,
                 )
+
+                if (keyRotationService != null && tenantKeyRepository != null) {
+                    adminKeyRotationRoutes(
+                        keyRotationService = keyRotationService,
+                        tenantKeyRepository = tenantKeyRepository,
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminShell.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminShell.kt
@@ -417,8 +417,11 @@ internal fun DIV.renderSettingsCtxPanel(
     ctxLink(base, "general", activeSection, "General")
     ctxLink("$base/branding", "branding", activeSection, "Branding")
     ctxLink("$base/smtp", "smtp", activeSection, "SMTP")
+    div("sidebar__divider") {}
     ctxLink("$base/security", "security", activeSection, "Security policy")
+    ctxLink("$base/signing-keys", "signing-keys", activeSection, "Signing Keys")
     ctxLink("$base/identity-providers", "identity-providers", activeSection, "Identity Providers")
+    div("sidebar__divider") {}
     ctxLink("$base/api-keys", "api-keys", activeSection, "API Keys")
     ctxLink("$base/webhooks", "webhooks", activeSection, "Webhooks")
 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -11,6 +11,7 @@ import com.kauth.domain.model.IdentityProvider
 import com.kauth.domain.model.Role
 import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantKey
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.model.WebhookDelivery
@@ -335,4 +336,15 @@ object AdminView {
         loggedInAs: String,
         error: String? = null,
     ): HTML.() -> Unit = createWebhookPageImpl(workspace, allWorkspaces, loggedInAs, error)
+
+    // ── Signing Keys ────────────────────────────────────────────────────
+
+    fun keyManagementPage(
+        workspace: Tenant,
+        allWorkspaces: List<WorkspaceStub>,
+        loggedInAs: String,
+        keys: List<TenantKey>,
+        error: String? = null,
+        toastMessage: String? = null,
+    ): HTML.() -> Unit = keyManagementPageImpl(workspace, allWorkspaces, loggedInAs, keys, error, toastMessage)
 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminWebhookRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminWebhookRoutes.kt
@@ -1,6 +1,7 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.domain.model.WebhookEventType
+import com.kauth.domain.service.WebhookResult
 import com.kauth.domain.service.WebhookService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -49,7 +50,7 @@ fun Route.adminWebhookRoutes(webhookService: WebhookService?) {
         val events = params.getAll("events")?.mapNotNull { WebhookEventType.fromValue(it) }?.toSet() ?: emptySet()
 
         when (val result = svc.createEndpoint(workspace.id, url, events, description)) {
-            is com.kauth.domain.service.WebhookResult.Success -> {
+            is WebhookResult.Success -> {
                 val endpoints = svc.listEndpoints(workspace.id)
                 val deliveries = svc.recentDeliveries(workspace.id)
                 call.respondHtml(
@@ -64,7 +65,7 @@ fun Route.adminWebhookRoutes(webhookService: WebhookService?) {
                     ),
                 )
             }
-            is com.kauth.domain.service.WebhookResult.Failure -> {
+            is WebhookResult.Failure -> {
                 call.respondHtml(
                     HttpStatusCode.UnprocessableEntity,
                     AdminView.createWebhookPage(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
@@ -1,10 +1,7 @@
 package com.kauth.adapter.web.admin
 
-import com.kauth.adapter.web.EnglishStrings
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantKey
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import kotlinx.html.*
 
 internal fun keyManagementPageImpl(
@@ -81,11 +78,7 @@ internal fun keyManagementPageImpl(
                                             span("data-table__id") { +key.keyId }
                                         }
                                         td {
-                                            val dtf =
-                                                DateTimeFormatter
-                                                    .ofPattern("yyyy-MM-dd HH:mm")
-                                                    .withZone(ZoneOffset.UTC)
-                                            +(key.createdAt?.let { dtf.format(it) } ?: "—")
+                                            +(key.createdAt?.toDisplayString() ?: "—")
                                         }
                                         td {
                                             if (key.active) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
@@ -1,0 +1,118 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.EnglishStrings
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.model.Tenant
+import kotlinx.html.*
+
+internal fun keyManagementPageImpl(
+    workspace: Tenant,
+    allWorkspaces: List<WorkspaceStub>,
+    loggedInAs: String,
+    keys: List<TenantKey>,
+    error: String? = null,
+    toastMessage: String? = null,
+): HTML.() -> Unit =
+    {
+        val slug = workspace.slug
+
+        adminShell(
+            pageTitle = "Signing Keys — ${workspace.displayName}",
+            activeRail = "settings",
+            allWorkspaces = allWorkspaces,
+            workspaceName = workspace.displayName,
+            workspaceSlug = slug,
+            workspaceLogoUrl = workspace.theme.logoUrl,
+            activeAppSection = "signing-keys",
+            loggedInAs = loggedInAs,
+            contentClass = "content-outer",
+            toastMessage = toastMessage,
+        ) {
+            div("content-inner") {
+                breadcrumb(
+                    "Workspaces" to "/admin",
+                    slug to "/admin/workspaces/$slug",
+                    "Settings" to "/admin/workspaces/$slug/settings",
+                    "Signing Keys" to null,
+                )
+
+                pageHeader(
+                    title = "Signing Keys",
+                    subtitle = "RS256 key pairs used to sign JWTs for this workspace.",
+                    actions = {
+                        postButton(
+                            action = "/admin/workspaces/$slug/settings/signing-keys/rotate",
+                            label = "Rotate Signing Key",
+                            btnClass = "btn btn--primary",
+                            confirmMessage = "Generate a new signing key? The current key will remain " +
+                                "active for verification until manually retired.",
+                        )
+                    },
+                )
+
+                if (error != null) {
+                    div("notice notice--error") { +error }
+                }
+
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Key Pairs" }
+                    if (keys.isEmpty()) {
+                        emptyState(
+                            iconName = "security",
+                            title = "No keys",
+                            description = "No signing keys have been provisioned for this workspace.",
+                        )
+                    } else {
+                        table("data-table") {
+                            thead {
+                                tr {
+                                    th { +"Key ID" }
+                                    th { style = "width:100px;"; +"Status" }
+                                    th { style = "width:80px;" }
+                                }
+                            }
+                            tbody {
+                                keys.forEach { key ->
+                                    tr {
+                                        td {
+                                            span("data-table__id") { +key.keyId }
+                                        }
+                                        td {
+                                            if (key.active) {
+                                                span("badge badge--active") {
+                                                    span("badge__dot") {}
+                                                    +"Active"
+                                                }
+                                            } else if (key.enabled) {
+                                                span("badge badge--warn") {
+                                                    span("badge__dot") {}
+                                                    +"Verification only"
+                                                }
+                                            } else {
+                                                span("badge badge--inactive") { +"Retired" }
+                                            }
+                                        }
+                                        td {
+                                            if (!key.active && key.enabled) {
+                                                div {
+                                                    postButton(
+                                                        action =
+                                                            "/admin/workspaces/$slug/settings/signing-keys/${key.keyId}/retire",
+                                                        label = "Retire",
+                                                        btnClass = "btn btn--danger btn--sm",
+                                                        confirmMessage =
+                                                            "Retire this key? Active sessions and tokens signed by it " +
+                                                            "will immediately stop working. This cannot be undone.",
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
@@ -1,8 +1,10 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.adapter.web.EnglishStrings
-import com.kauth.domain.model.TenantKey
 import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantKey
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import kotlinx.html.*
 
 internal fun keyManagementPageImpl(
@@ -55,7 +57,7 @@ internal fun keyManagementPageImpl(
                 }
 
                 div("ov-card") {
-                    div("ov-card__section-label") { +"Key Pairs" }
+                    div("ov-card__section-label") { +"Signing Key History" }
                     if (keys.isEmpty()) {
                         emptyState(
                             iconName = "security",
@@ -67,7 +69,8 @@ internal fun keyManagementPageImpl(
                             thead {
                                 tr {
                                     th { +"Key ID" }
-                                    th { style = "width:100px;"; +"Status" }
+                                    th { +"Created" }
+                                    th { style = "width:140px;"; +"Status" }
                                     th { style = "width:80px;" }
                                 }
                             }
@@ -76,6 +79,13 @@ internal fun keyManagementPageImpl(
                                     tr {
                                         td {
                                             span("data-table__id") { +key.keyId }
+                                        }
+                                        td {
+                                            val dtf =
+                                                DateTimeFormatter
+                                                    .ofPattern("yyyy-MM-dd HH:mm")
+                                                    .withZone(ZoneOffset.UTC)
+                                            +(key.createdAt?.let { dtf.format(it) } ?: "—")
                                         }
                                         td {
                                             if (key.active) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -58,7 +58,7 @@ internal fun activeSessionsPageImpl(
                             postButton(
                                 action = "/admin/workspaces/${workspace.slug}/sessions/revoke-all",
                                 label = "Revoke All Sessions",
-                                btnClass = "btn btn--warning btn--sm",
+                                btnClass = "btn btn--warning",
                                 confirmMessage = "Revoke all ${sessions.size} active session${if (sessions.size != 1) "s" else ""}? All users will be signed out immediately.",
                             )
                         }

--- a/src/main/kotlin/com/kauth/cli/GenerateSecretKeyCommand.kt
+++ b/src/main/kotlin/com/kauth/cli/GenerateSecretKeyCommand.kt
@@ -1,13 +1,11 @@
 package com.kauth.cli
 
-import java.security.SecureRandom
+import com.kauth.domain.util.SecureTokens
 import kotlin.system.exitProcess
 
 object GenerateSecretKeyCommand {
     fun execute() {
-        val bytes = ByteArray(32)
-        SecureRandom().nextBytes(bytes)
-        println(bytes.joinToString("") { "%02x".format(it) })
+        println(SecureTokens.randomHex(32))
         exitProcess(0)
     }
 }

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -42,6 +42,7 @@ import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
 import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.KeyRotationService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.RoleGroupService
@@ -95,6 +96,8 @@ data class ServiceGraph(
     val portalSessionKey: ByteArray,
     val encryptionService: EncryptionService,
     val socialAccountRepository: PostgresSocialAccountRepository,
+    val keyRotationService: KeyRotationService,
+    val tenantKeyRepository: PostgresTenantKeyRepository,
     val applicationScope: CoroutineScope,
 ) {
     companion object {
@@ -257,6 +260,15 @@ data class ServiceGraph(
                         ),
                 )
 
+            // -- Key rotation -------------------------------------------------
+            val keyRotationService =
+                KeyRotationService(
+                    tenantKeyRepository = tenantKeyRepository,
+                    tenantRepository = tenantRepository,
+                    tokenPort = tokenAdapter,
+                    auditLog = auditLogAdapter,
+                )
+
             // -- Demo seed ----------------------------------------------------
             if (config.isDemoMode) {
                 DemoSeedService(
@@ -340,6 +352,8 @@ data class ServiceGraph(
                 portalSessionKey = portalSessionKey,
                 encryptionService = encryptionService,
                 socialAccountRepository = socialAccountRepository,
+                keyRotationService = keyRotationService,
+                tenantKeyRepository = tenantKeyRepository,
                 applicationScope = applicationScope,
             )
         }

--- a/src/main/kotlin/com/kauth/domain/model/AuditEvent.kt
+++ b/src/main/kotlin/com/kauth/domain/model/AuditEvent.kt
@@ -92,4 +92,7 @@ enum class AuditEventType {
 
     USER_INVITE_SENT,
     USER_INVITE_ACCEPTED,
+
+    ADMIN_KEY_ROTATED,
+    ADMIN_KEY_RETIRED,
 }

--- a/src/main/kotlin/com/kauth/domain/model/TenantKey.kt
+++ b/src/main/kotlin/com/kauth/domain/model/TenantKey.kt
@@ -22,4 +22,6 @@ data class TenantKey(
     val publicKeyPem: String,
     val privateKeyPem: String,
     val enabled: Boolean = true,
+    /** True if this is the current signing key. Exactly one key per tenant should be active. */
+    val active: Boolean = false,
 )

--- a/src/main/kotlin/com/kauth/domain/model/TenantKey.kt
+++ b/src/main/kotlin/com/kauth/domain/model/TenantKey.kt
@@ -1,5 +1,7 @@
 package com.kauth.domain.model
 
+import java.time.Instant
+
 /**
  * An RSA signing key pair belonging to a tenant.
  *
@@ -24,4 +26,5 @@ data class TenantKey(
     val enabled: Boolean = true,
     /** True if this is the current signing key. Exactly one key per tenant should be active. */
     val active: Boolean = false,
+    val createdAt: Instant? = null,
 )

--- a/src/main/kotlin/com/kauth/domain/port/TenantKeyRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TenantKeyRepository.kt
@@ -8,16 +8,29 @@ import com.kauth.domain.model.TenantKey
  * Implemented by [PostgresTenantKeyRepository].
  */
 interface TenantKeyRepository {
-    /** Returns the active signing key for a tenant, or null if none exists. */
+    /** Returns the single active signing key for a tenant, or null if none exists. */
     fun findActiveKey(tenantId: TenantId): TenantKey?
 
     /** Returns all enabled keys for a tenant (used by the JWKS endpoint). */
     fun findEnabledKeys(tenantId: TenantId): List<TenantKey>
 
+    /** Returns a specific key by its keyId, regardless of enabled/active state. */
+    fun findByKeyId(
+        tenantId: TenantId,
+        keyId: String,
+    ): TenantKey?
+
     /** Persists a newly generated key pair. */
     fun save(key: TenantKey): TenantKey
 
-    /** Disables a specific key (soft rotation — does not delete). */
+    /** Atomically promotes [newKeyId] to active and demotes [previousKeyId]. */
+    fun rotate(
+        tenantId: TenantId,
+        newKeyId: String,
+        previousKeyId: String,
+    )
+
+    /** Disables a specific key — removes it from JWKS. */
     fun disable(
         tenantId: TenantId,
         keyId: String,

--- a/src/main/kotlin/com/kauth/domain/port/TenantKeyRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TenantKeyRepository.kt
@@ -14,6 +14,9 @@ interface TenantKeyRepository {
     /** Returns all enabled keys for a tenant (used by the JWKS endpoint). */
     fun findEnabledKeys(tenantId: TenantId): List<TenantKey>
 
+    /** Returns all keys for a tenant including retired ones (used by the admin key management page). */
+    fun findAllKeys(tenantId: TenantId): List<TenantKey>
+
     /** Returns a specific key by its keyId, regardless of enabled/active state. */
     fun findByKeyId(
         tenantId: TenantId,

--- a/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
@@ -54,4 +54,10 @@ interface TokenPort {
      * Returns the JWKS (JSON Web Key Set) for a tenant's active signing keys.
      */
     fun getTenantJwks(tenantId: TenantId): List<Map<String, Any>>
+
+    /**
+     * Invalidates the cached signing key for a tenant.
+     * Must be called after key rotation so new tokens use the new key.
+     */
+    fun invalidateSigningKeyCache(tenantId: TenantId)
 }

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -22,8 +22,7 @@ import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.ThemeRepository
 import com.kauth.domain.port.UserRepository
-import java.security.SecureRandom
-import java.util.Base64
+import com.kauth.domain.util.SecureTokens
 
 /**
  * Domain service — admin console use cases.
@@ -681,8 +680,7 @@ class AdminService(
         }
 
         // Generate 32-byte (256-bit) cryptographically random secret, base64url encoded
-        val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
-        val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(raw)
+        val secret = SecureTokens.randomBase64Url(32)
 
         applicationRepository.setClientSecretHash(appId, passwordHasher.hash(secret))
 

--- a/src/main/kotlin/com/kauth/domain/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ApiKeyService.kt
@@ -5,10 +5,9 @@ import com.kauth.domain.model.ApiScope
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.port.ApiKeyRepository
 import com.kauth.domain.port.TenantRepository
+import com.kauth.domain.util.SecureTokens
 import com.kauth.domain.util.sha256Hex
-import java.security.SecureRandom
 import java.time.Instant
-import java.util.Base64
 
 /**
  * Domain service — API key lifecycle management.
@@ -67,9 +66,7 @@ class ApiKeyService(
         }
 
         // Build raw key: kauth_<slug>_<32 random bytes base64url, no padding>
-        val randomBytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
-        val randomPart = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes)
-        val rawKey = "kauth_${tenant.slug}_$randomPart"
+        val rawKey = "kauth_${tenant.slug}_${SecureTokens.randomBase64Url(32)}"
 
         val hash = sha256Hex(rawKey)
         val prefix = rawKey.take(16) // e.g. "kauth_acme_4wQk2" — enough to identify in UI

--- a/src/main/kotlin/com/kauth/domain/service/KeyRotationService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/KeyRotationService.kt
@@ -9,7 +9,6 @@ import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.port.TenantKeyRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.TokenPort
-import com.kauth.infrastructure.KeyGenerator
 
 /**
  * Domain service for admin-initiated RSA key rotation.
@@ -23,7 +22,19 @@ class KeyRotationService(
     private val tenantRepository: TenantRepository,
     private val tokenPort: TokenPort,
     private val auditLog: AuditLogPort,
+    private val generateKeyPair: (keyId: String) -> KeyPairResult = { kid ->
+        com.kauth.infrastructure.KeyGenerator.generateRsaKeyPair(kid).let {
+            KeyPairResult(it.keyId, it.publicKeyPem, it.privateKeyPem)
+        }
+    },
 ) {
+    /** Injectable key pair result — decouples domain from infrastructure. */
+    data class KeyPairResult(
+        val keyId: String,
+        val publicKeyPem: String,
+        val privateKeyPem: String,
+    )
+
     /**
      * Generates a new RS256 key pair and promotes it to the active signing key.
      * The previous key remains enabled for verification (served via JWKS).
@@ -42,10 +53,7 @@ class KeyRotationService(
                     AdminError.Validation("No active key to rotate from. Provision a key first."),
                 )
 
-        val newKeyPair =
-            KeyGenerator.generateRsaKeyPair(
-                keyId = "${tenant.slug}-${System.currentTimeMillis()}",
-            )
+        val newKeyPair = generateKeyPair("${tenant.slug}-${System.currentTimeMillis()}")
 
         val newKey =
             tenantKeyRepository.save(

--- a/src/main/kotlin/com/kauth/domain/service/KeyRotationService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/KeyRotationService.kt
@@ -1,0 +1,123 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AuditEvent
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.AuditLogPort
+import com.kauth.domain.port.TenantKeyRepository
+import com.kauth.domain.port.TenantRepository
+import com.kauth.domain.port.TokenPort
+import com.kauth.infrastructure.KeyGenerator
+
+/**
+ * Domain service for admin-initiated RSA key rotation.
+ *
+ * Rotation generates a new key pair, promotes it to active (signing),
+ * and demotes the old key to verification-only (still served via JWKS).
+ * Tokens signed by the old key continue to verify until the key is retired.
+ */
+class KeyRotationService(
+    private val tenantKeyRepository: TenantKeyRepository,
+    private val tenantRepository: TenantRepository,
+    private val tokenPort: TokenPort,
+    private val auditLog: AuditLogPort,
+) {
+    /**
+     * Generates a new RS256 key pair and promotes it to the active signing key.
+     * The previous key remains enabled for verification (served via JWKS).
+     */
+    fun rotate(
+        tenantId: TenantId,
+        performedBy: UserId,
+    ): AdminResult<TenantKey> {
+        val tenant =
+            tenantRepository.findById(tenantId)
+                ?: return AdminResult.Failure(AdminError.NotFound("Workspace not found."))
+
+        val currentActive =
+            tenantKeyRepository.findActiveKey(tenantId)
+                ?: return AdminResult.Failure(
+                    AdminError.Validation("No active key to rotate from. Provision a key first."),
+                )
+
+        val newKeyPair =
+            KeyGenerator.generateRsaKeyPair(
+                keyId = "${tenant.slug}-${System.currentTimeMillis()}",
+            )
+
+        val newKey =
+            tenantKeyRepository.save(
+                TenantKey(
+                    tenantId = tenantId,
+                    keyId = newKeyPair.keyId,
+                    publicKeyPem = newKeyPair.publicKeyPem,
+                    privateKeyPem = newKeyPair.privateKeyPem,
+                    enabled = true,
+                    active = false,
+                ),
+            )
+
+        tenantKeyRepository.rotate(
+            tenantId = tenantId,
+            newKeyId = newKey.keyId,
+            previousKeyId = currentActive.keyId,
+        )
+
+        tokenPort.invalidateSigningKeyCache(tenantId)
+
+        auditLog.record(
+            AuditEvent(
+                tenantId = tenantId,
+                userId = performedBy,
+                clientId = null,
+                eventType = AuditEventType.ADMIN_KEY_ROTATED,
+                ipAddress = null,
+                userAgent = null,
+                details =
+                    mapOf(
+                        "new_key_id" to newKey.keyId,
+                        "previous_key_id" to currentActive.keyId,
+                    ),
+            ),
+        )
+
+        return AdminResult.Success(newKey.copy(active = true))
+    }
+
+    /**
+     * Retires a specific key — removes it from JWKS.
+     * The active signing key cannot be retired; rotate first.
+     */
+    fun retireKey(
+        tenantId: TenantId,
+        keyId: String,
+        performedBy: UserId,
+    ): AdminResult<Unit> {
+        val key =
+            tenantKeyRepository.findByKeyId(tenantId, keyId)
+                ?: return AdminResult.Failure(AdminError.NotFound("Key not found."))
+        if (key.active) {
+            return AdminResult.Failure(
+                AdminError.Validation("Cannot retire the active signing key. Rotate first."),
+            )
+        }
+
+        tenantKeyRepository.disable(tenantId, keyId)
+
+        auditLog.record(
+            AuditEvent(
+                tenantId = tenantId,
+                userId = performedBy,
+                clientId = null,
+                eventType = AuditEventType.ADMIN_KEY_RETIRED,
+                ipAddress = null,
+                userAgent = null,
+                details = mapOf("retired_key_id" to keyId),
+            ),
+        )
+
+        return AdminResult.Success(Unit)
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/service/MfaService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/MfaService.kt
@@ -14,8 +14,8 @@ import com.kauth.domain.port.MfaRepository
 import com.kauth.domain.port.PasswordHasher
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
+import com.kauth.domain.util.SecureTokens
 import com.kauth.infrastructure.TotpUtil
-import java.security.SecureRandom
 import java.time.Instant
 
 /**
@@ -365,14 +365,8 @@ class MfaService(
     // Helpers
     // -----------------------------------------------------------------------
 
-    private fun generateRecoveryCodes(): List<String> {
-        val random = SecureRandom()
-        return (1..RECOVERY_CODE_COUNT).map {
-            val bytes = ByteArray(RECOVERY_CODE_LENGTH / 2)
-            random.nextBytes(bytes)
-            bytes.joinToString("") { "%02x".format(it) }
-        }
-    }
+    private fun generateRecoveryCodes(): List<String> =
+        (1..RECOVERY_CODE_COUNT).map { SecureTokens.randomHex(RECOVERY_CODE_LENGTH / 2) }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -17,9 +17,9 @@ import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.TokenPort
 import com.kauth.domain.port.UserRepository
+import com.kauth.domain.util.SecureTokens
 import com.kauth.domain.util.sha256Hex
 import java.security.MessageDigest
-import java.security.SecureRandom
 import java.time.Instant
 import java.util.Base64
 
@@ -619,11 +619,7 @@ class OAuthService(
     // Internal utilities
     // -------------------------------------------------------------------------
 
-    private fun generateSecureCode(): String {
-        val bytes = ByteArray(32)
-        SecureRandom().nextBytes(bytes)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-    }
+    private fun generateSecureCode(): String = SecureTokens.randomBase64Url(32)
 
     /**
      * PKCE S256 verification: SHA-256(code_verifier) must equal code_challenge (base64url).

--- a/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
@@ -19,8 +19,8 @@ import com.kauth.domain.port.SocialUserProfile
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.TokenPort
 import com.kauth.domain.port.UserRepository
+import com.kauth.domain.util.SecureTokens
 import com.kauth.domain.util.sha256Hex
-import java.security.SecureRandom
 import java.time.Instant
 
 /**
@@ -374,11 +374,7 @@ class SocialLoginService(
         )
     }
 
-    private fun generateRandomPassword(): String {
-        val bytes = ByteArray(32)
-        SecureRandom().nextBytes(bytes)
-        return bytes.joinToString("") { "%02x".format(it) }
-    }
+    private fun generateRandomPassword(): String = SecureTokens.randomHex(32)
 
     private fun callbackUri(
         baseUrl: String,

--- a/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
@@ -21,15 +21,14 @@ import com.kauth.domain.port.PasswordResetTokenRepository
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
+import com.kauth.domain.util.SecureTokens
 import com.kauth.domain.util.sha256Hex
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.security.SecureRandom
 import java.time.Instant
-import java.util.Base64
 
 /**
  * Domain service — user self-service use cases.
@@ -643,8 +642,7 @@ class UserSelfServiceService(
      * Raw token is base64url-encoded (43 chars, URL-safe).
      */
     private fun generateToken(): Pair<String, String> {
-        val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
-        val token = Base64.getUrlEncoder().withoutPadding().encodeToString(raw)
+        val token = SecureTokens.randomBase64Url(32)
         return token to sha256Hex(token)
     }
 
@@ -727,7 +725,7 @@ class UserSelfServiceService(
                 log.warn(
                     "Invite email delivery failed tenantId={} userId={}: {}",
                     tenant.id.value,
-                    user.id?.value,
+                    user.id!!.value,
                     e.message,
                 )
             }
@@ -778,9 +776,8 @@ class UserSelfServiceService(
                 ?.let { return SelfServiceResult.Failure(it) }
         }
 
-        val user =
-            userRepository.findById(token.userId, token.tenantId)
-                ?: return SelfServiceResult.Failure(SelfServiceError.NotFound("User not found."))
+        userRepository.findById(token.userId, token.tenantId)
+            ?: return SelfServiceResult.Failure(SelfServiceError.NotFound("User not found."))
 
         val now = Instant.now()
         val hashedPassword = passwordHasher.hash(newPassword)
@@ -860,10 +857,6 @@ sealed class SelfServiceError(
     ) : SelfServiceError(message)
 
     class SmtpNotConfigured(
-        message: String,
-    ) : SelfServiceError(message)
-
-    class EmailDeliveryFailed(
         message: String,
     ) : SelfServiceError(message)
 }

--- a/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
@@ -725,7 +725,7 @@ class UserSelfServiceService(
                 log.warn(
                     "Invite email delivery failed tenantId={} userId={}: {}",
                     tenant.id.value,
-                    user.id!!.value,
+                    user.id.value,
                     e.message,
                 )
             }

--- a/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
@@ -7,6 +7,7 @@ import com.kauth.domain.model.WebhookEndpoint
 import com.kauth.domain.model.WebhookEventType
 import com.kauth.domain.port.WebhookDeliveryRepository
 import com.kauth.domain.port.WebhookEndpointRepository
+import com.kauth.domain.util.SecureTokens
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -325,11 +326,7 @@ class WebhookService(
     }
 
     /** Generates a cryptographically random 32-byte hex secret. */
-    private fun generateSecret(): String {
-        val bytes = ByteArray(32)
-        java.security.SecureRandom().nextBytes(bytes)
-        return bytes.joinToString("") { "%02x".format(it) }
-    }
+    private fun generateSecret(): String = SecureTokens.randomHex(32)
 }
 
 // =============================================================================

--- a/src/main/kotlin/com/kauth/domain/util/SecureTokens.kt
+++ b/src/main/kotlin/com/kauth/domain/util/SecureTokens.kt
@@ -1,0 +1,19 @@
+package com.kauth.domain.util
+
+import java.security.SecureRandom
+import java.util.Base64
+
+/** Shared [SecureRandom] instance for cryptographic random generation. Thread-safe. */
+object SecureTokens {
+    private val random = SecureRandom()
+
+    /** Returns [n] cryptographically strong random bytes. */
+    fun randomBytes(n: Int): ByteArray = ByteArray(n).also { random.nextBytes(it) }
+
+    /** Returns a URL-safe base64-encoded random token. */
+    fun randomBase64Url(byteLength: Int = 32): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes(byteLength))
+
+    /** Returns a hex-encoded random string. */
+    fun randomHex(byteLength: Int = 32): String = randomBytes(byteLength).joinToString("") { "%02x".format(it) }
+}

--- a/src/main/kotlin/com/kauth/infrastructure/EncryptionService.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/EncryptionService.kt
@@ -1,7 +1,7 @@
 package com.kauth.infrastructure
 
+import com.kauth.domain.util.SecureTokens
 import java.security.MessageDigest
-import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.Mac
@@ -37,7 +37,7 @@ class EncryptionService(
      * Throws [IllegalStateException] if no secret key was provided.
      */
     override fun encrypt(plaintext: String): String {
-        val iv = ByteArray(GCM_IV_LENGTH).also { SecureRandom().nextBytes(it) }
+        val iv = SecureTokens.randomBytes(GCM_IV_LENGTH)
         val cipher = Cipher.getInstance(ALGORITHM)
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
         val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))

--- a/src/main/kotlin/com/kauth/infrastructure/KeyProvisioningService.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/KeyProvisioningService.kt
@@ -54,6 +54,8 @@ class KeyProvisioningService(
                     keyId = keyPair.keyId,
                     publicKeyPem = keyPair.publicKeyPem,
                     privateKeyPem = keyPair.privateKeyPem,
+                    enabled = true,
+                    active = true,
                 ),
             )
             log.info("RS256 key '${keyPair.keyId}' created for tenant '${tenant.slug}'")

--- a/src/main/kotlin/com/kauth/infrastructure/TotpUtil.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/TotpUtil.kt
@@ -1,7 +1,7 @@
 package com.kauth.infrastructure
 
+import com.kauth.domain.util.SecureTokens
 import java.nio.ByteBuffer
-import java.security.SecureRandom
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -29,11 +29,7 @@ object TotpUtil {
     /**
      * Generates a cryptographically random TOTP secret, Base32-encoded.
      */
-    fun generateSecret(): String {
-        val bytes = ByteArray(SECRET_LEN)
-        SecureRandom().nextBytes(bytes)
-        return base32Encode(bytes)
-    }
+    fun generateSecret(): String = base32Encode(SecureTokens.randomBytes(SECRET_LEN))
 
     /**
      * Generates the otpauth:// URI for QR code scanning.

--- a/src/main/resources/db/migration/V31__tenant_key_active_flag.sql
+++ b/src/main/resources/db/migration/V31__tenant_key_active_flag.sql
@@ -1,0 +1,20 @@
+-- V31: Add active flag to distinguish the signing key from verification-only keys.
+-- 'active' = this key signs new tokens (exactly one per tenant).
+-- 'enabled' = this key appears in JWKS (used to verify existing tokens).
+
+ALTER TABLE tenant_keys ADD COLUMN active BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Back-fill: mark the most recently created enabled key as active per tenant.
+UPDATE tenant_keys tk
+SET active = TRUE
+WHERE tk.id = (
+    SELECT id FROM tenant_keys
+    WHERE tenant_id = tk.tenant_id AND enabled = TRUE
+    ORDER BY created_at DESC
+    LIMIT 1
+);
+
+-- Enforce at most one active key per tenant.
+CREATE UNIQUE INDEX idx_tenant_keys_one_active_per_tenant
+    ON tenant_keys(tenant_id)
+    WHERE active = TRUE;

--- a/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterKeyRotationTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterKeyRotationTest.kt
@@ -1,0 +1,279 @@
+package com.kauth.adapter.token
+
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeTenantKeyRepository
+import com.kauth.infrastructure.KeyGenerator
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [JwtTokenAdapter] key rotation scenarios.
+ *
+ * Uses real RSA key pairs via [KeyGenerator] and [FakeTenantKeyRepository].
+ * No database, no HTTP — tests the signing/verification pipeline directly.
+ */
+class JwtTokenAdapterKeyRotationTest {
+    private val keyRepo = FakeTenantKeyRepository()
+    private val adapter = JwtTokenAdapter(baseUrl = "http://localhost:8080", tenantKeyRepository = keyRepo)
+
+    private val keyPairA = KeyGenerator.generateRsaKeyPair("key-a")
+    private val keyPairB = KeyGenerator.generateRsaKeyPair("key-b")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(1),
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+        )
+
+    private val user =
+        User(
+            id = UserId(10),
+            tenantId = TenantId(1),
+            username = "alice",
+            email = "alice@example.com",
+            fullName = "Alice Test",
+            passwordHash = "hashed",
+            enabled = true,
+        )
+
+    @BeforeTest
+    fun setup() {
+        keyRepo.clear()
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairA.keyId,
+                publicKeyPem = keyPairA.publicKeyPem,
+                privateKeyPem = keyPairA.privateKeyPem,
+                enabled = true,
+                active = true,
+            ),
+        )
+        adapter.invalidateSigningKeyCache(TenantId(1))
+    }
+
+    // =========================================================================
+    // kid header presence
+    // =========================================================================
+
+    @Test
+    fun `issued access token contains kid header matching active key`() {
+        val response = adapter.issueUserTokens(user, tenant, null, listOf("openid"))
+        val decoded =
+            com.auth0.jwt.JWT
+                .decode(response.access_token)
+        assertEquals(keyPairA.keyId, decoded.keyId, "kid header must match the active key")
+    }
+
+    @Test
+    fun `issued id_token contains kid header`() {
+        val response = adapter.issueUserTokens(user, tenant, null, listOf("openid"))
+        assertNotNull(response.id_token)
+        val decoded =
+            com.auth0.jwt.JWT
+                .decode(response.id_token)
+        assertEquals(keyPairA.keyId, decoded.keyId)
+    }
+
+    @Test
+    fun `issued client credentials token contains kid header`() {
+        val app =
+            Application(
+                id =
+                    com.kauth.domain.model
+                        .ApplicationId(1),
+                tenantId = TenantId(1),
+                clientId = "my-app",
+                name = "My App",
+                description = "Test",
+                accessType = com.kauth.domain.model.AccessType.CONFIDENTIAL,
+                redirectUris = listOf("http://localhost/cb"),
+                enabled = true,
+            )
+        val token = adapter.issueClientCredentialsToken(tenant, app, listOf("openid"))
+        val decoded =
+            com.auth0.jwt.JWT
+                .decode(token)
+        assertEquals(keyPairA.keyId, decoded.keyId)
+    }
+
+    // =========================================================================
+    // Token verification after rotation
+    // =========================================================================
+
+    @Test
+    fun `token signed by old key verifies after rotation when old key is still enabled`() {
+        // Issue token with key A
+        val response = adapter.issueUserTokens(user, tenant, null, listOf("openid"))
+        val tokenSignedByA = response.access_token
+
+        // Rotate: add key B as active, demote key A
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairB.keyId,
+                publicKeyPem = keyPairB.publicKeyPem,
+                privateKeyPem = keyPairB.privateKeyPem,
+                enabled = true,
+                active = false,
+            ),
+        )
+        keyRepo.rotate(TenantId(1), keyPairB.keyId, keyPairA.keyId)
+        adapter.invalidateSigningKeyCache(TenantId(1))
+
+        // Token signed by old key A should still verify via kid-based lookup
+        val claims = adapter.decodeAccessToken(tokenSignedByA)
+        assertNotNull(claims, "Token signed by old key should verify when old key is still enabled")
+        assertEquals("alice", claims.username)
+    }
+
+    @Test
+    fun `token signed by retired key is rejected`() {
+        // Issue token with key A
+        val response = adapter.issueUserTokens(user, tenant, null, listOf("openid"))
+        val tokenSignedByA = response.access_token
+
+        // Rotate to key B, then retire key A
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairB.keyId,
+                publicKeyPem = keyPairB.publicKeyPem,
+                privateKeyPem = keyPairB.privateKeyPem,
+                enabled = true,
+                active = false,
+            ),
+        )
+        keyRepo.rotate(TenantId(1), keyPairB.keyId, keyPairA.keyId)
+        keyRepo.disable(TenantId(1), keyPairA.keyId)
+        adapter.invalidateSigningKeyCache(TenantId(1))
+
+        // Token signed by retired key A should be rejected
+        val claims = adapter.decodeAccessToken(tokenSignedByA)
+        assertNull(claims, "Token signed by retired key should be rejected")
+    }
+
+    @Test
+    fun `new tokens after rotation are signed with the new key`() {
+        // Rotate to key B
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairB.keyId,
+                publicKeyPem = keyPairB.publicKeyPem,
+                privateKeyPem = keyPairB.privateKeyPem,
+                enabled = true,
+                active = false,
+            ),
+        )
+        keyRepo.rotate(TenantId(1), keyPairB.keyId, keyPairA.keyId)
+        adapter.invalidateSigningKeyCache(TenantId(1))
+
+        // New token should use key B
+        val response = adapter.issueUserTokens(user, tenant, null, listOf("openid"))
+        val decoded =
+            com.auth0.jwt.JWT
+                .decode(response.access_token)
+        assertEquals(keyPairB.keyId, decoded.keyId, "New tokens should use the new active key")
+
+        // And it should verify
+        val claims = adapter.decodeAccessToken(response.access_token)
+        assertNotNull(claims)
+    }
+
+    // =========================================================================
+    // JWKS
+    // =========================================================================
+
+    @Test
+    fun `getTenantJwks returns both active and non-active enabled keys after rotation`() {
+        // Rotate to key B
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairB.keyId,
+                publicKeyPem = keyPairB.publicKeyPem,
+                privateKeyPem = keyPairB.privateKeyPem,
+                enabled = true,
+                active = false,
+            ),
+        )
+        keyRepo.rotate(TenantId(1), keyPairB.keyId, keyPairA.keyId)
+
+        val jwks = adapter.getTenantJwks(TenantId(1))
+        assertEquals(2, jwks.size, "JWKS should serve both enabled keys")
+        val kids = jwks.map { it["kid"] }
+        assertTrue(keyPairA.keyId in kids)
+        assertTrue(keyPairB.keyId in kids)
+    }
+
+    @Test
+    fun `getTenantJwks excludes retired keys`() {
+        // Rotate then retire key A
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPairB.keyId,
+                publicKeyPem = keyPairB.publicKeyPem,
+                privateKeyPem = keyPairB.privateKeyPem,
+                enabled = true,
+                active = false,
+            ),
+        )
+        keyRepo.rotate(TenantId(1), keyPairB.keyId, keyPairA.keyId)
+        keyRepo.disable(TenantId(1), keyPairA.keyId)
+
+        val jwks = adapter.getTenantJwks(TenantId(1))
+        assertEquals(1, jwks.size, "JWKS should only serve enabled keys")
+        assertEquals(keyPairB.keyId, jwks[0]["kid"])
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    @Test
+    fun `decodeAccessToken returns null for malformed token`() {
+        assertNull(adapter.decodeAccessToken("not-a-jwt"))
+    }
+
+    @Test
+    fun `invalidateSigningKeyCache for tenant A does not affect tenant B`() {
+        // Setup tenant 2
+        val keyPairC = KeyGenerator.generateRsaKeyPair("key-c")
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(2),
+                keyId = keyPairC.keyId,
+                publicKeyPem = keyPairC.publicKeyPem,
+                privateKeyPem = keyPairC.privateKeyPem,
+                enabled = true,
+                active = true,
+            ),
+        )
+        val tenant2 =
+            Tenant(id = TenantId(2), slug = "beta", displayName = "Beta", issuerUrl = null)
+        val user2 = user.copy(tenantId = TenantId(2))
+
+        // Issue token for tenant 2 (populates cache)
+        val t2Token = adapter.issueUserTokens(user2, tenant2, null, listOf("openid"))
+
+        // Invalidate tenant 1 cache
+        adapter.invalidateSigningKeyCache(TenantId(1))
+
+        // Tenant 2 token should still verify (cache intact)
+        val claims = adapter.decodeAccessToken(t2Token.access_token)
+        assertNotNull(claims, "Tenant 2 token should still verify after tenant 1 cache invalidation")
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -284,7 +284,7 @@ class AdminWebhooksTest {
                         username = "admin",
                     ),
                 )
-                call.respond(io.ktor.http.HttpStatusCode.OK, "session set")
+                call.respond(HttpStatusCode.OK, "session set")
             }
             adminRoutes(
                 adminService = buildAdminService(),

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -1,14 +1,18 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
+import com.kauth.domain.model.WebhookEventType
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.RoleGroupService
 import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.domain.service.WebhookResult
 import com.kauth.domain.service.WebhookService
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
@@ -156,19 +160,13 @@ class AdminWebhooksTest {
         userRepo.add(adminUser)
         val adminRole =
             roleRepo.add(
-                com.kauth.domain.model.Role(
-                    tenantId =
-                        com.kauth.domain.model
-                            .TenantId(1),
+                Role(
+                    tenantId = TenantId(1),
                     name = "admin",
-                    scope = com.kauth.domain.model.RoleScope.TENANT,
+                    scope = RoleScope.TENANT,
                 ),
             )
-        roleRepo.assignRoleToUser(
-            com.kauth.domain.model
-                .UserId(1),
-            adminRole.id!!,
-        )
+        roleRepo.assignRoleToUser(UserId(1), adminRole.id!!)
     }
 
     // =========================================================================
@@ -244,10 +242,10 @@ class AdminWebhooksTest {
                 webhookService.createEndpoint(
                     TenantId(2),
                     "https://hooks.example.com/test",
-                    setOf(com.kauth.domain.model.WebhookEventType.USER_CREATED),
+                    setOf(WebhookEventType.USER_CREATED),
                     "test",
                 )
-            val endpointId = (created as com.kauth.domain.service.WebhookResult.Success).endpoint.id!!
+            val endpointId = (created as WebhookResult.Success).endpoint.id!!
 
             val response =
                 authed.submitForm(

--- a/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
@@ -1,0 +1,143 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeTenantKeyRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KeyRotationServiceTest {
+    private val tenants = FakeTenantRepository()
+    private val keys = FakeTenantKeyRepository()
+    private val tokens = FakeTokenPort()
+    private val auditLog = FakeAuditLogPort()
+
+    private val svc =
+        KeyRotationService(
+            tenantKeyRepository = keys,
+            tenantRepository = tenants,
+            tokenPort = tokens,
+            auditLog = auditLog,
+        )
+
+    private val tenant =
+        Tenant(
+            id = TenantId(1),
+            slug = "acme",
+            displayName = "Acme Corp",
+            issuerUrl = null,
+        )
+
+    private val activeKey =
+        TenantKey(
+            tenantId = TenantId(1),
+            keyId = "acme-original",
+            publicKeyPem = "fake-pub",
+            privateKeyPem = "fake-priv",
+            enabled = true,
+            active = true,
+        )
+
+    @BeforeTest
+    fun setup() {
+        tenants.clear()
+        keys.clear()
+        auditLog.clear()
+        tokens.reset()
+        tenants.add(tenant)
+        keys.add(activeKey)
+    }
+
+    // =========================================================================
+    // rotate
+    // =========================================================================
+
+    @Test
+    fun `rotate succeeds and returns new key`() {
+        val result = svc.rotate(TenantId(1), UserId(1))
+        assertIs<AdminResult.Success<TenantKey>>(result)
+        assertTrue(result.value.active)
+        assertTrue(result.value.keyId.startsWith("acme-"))
+        assertTrue(result.value.keyId != "acme-original")
+    }
+
+    @Test
+    fun `rotate demotes old key to verification only`() {
+        svc.rotate(TenantId(1), UserId(1))
+        val oldKey = keys.findByKeyId(TenantId(1), "acme-original")
+        assertNotNull(oldKey)
+        assertTrue(oldKey.enabled, "Old key should remain enabled for JWKS")
+        assertFalse(oldKey.active, "Old key should no longer be the active signing key")
+    }
+
+    @Test
+    fun `rotate invalidates signing key cache`() {
+        svc.rotate(TenantId(1), UserId(1))
+        assertEquals(TenantId(1), tokens.cacheInvalidatedForTenant)
+    }
+
+    @Test
+    fun `rotate records ADMIN_KEY_ROTATED audit event`() {
+        svc.rotate(TenantId(1), UserId(1))
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_KEY_ROTATED))
+    }
+
+    @Test
+    fun `rotate fails when tenant not found`() {
+        val result = svc.rotate(TenantId(999), UserId(1))
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `rotate fails when no active key exists`() {
+        keys.clear()
+        keys.add(activeKey.copy(active = false))
+        val result = svc.rotate(TenantId(1), UserId(1))
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    // =========================================================================
+    // retireKey
+    // =========================================================================
+
+    @Test
+    fun `retireKey succeeds for non-active enabled key`() {
+        // First rotate so we have an old key to retire
+        svc.rotate(TenantId(1), UserId(1))
+        val result = svc.retireKey(TenantId(1), "acme-original", UserId(1))
+        assertIs<AdminResult.Success<Unit>>(result)
+        val retired = keys.findByKeyId(TenantId(1), "acme-original")
+        assertNotNull(retired)
+        assertFalse(retired.enabled, "Retired key should be disabled")
+    }
+
+    @Test
+    fun `retireKey fails for active key`() {
+        val result = svc.retireKey(TenantId(1), "acme-original", UserId(1))
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `retireKey fails for unknown key`() {
+        val result = svc.retireKey(TenantId(1), "nonexistent", UserId(1))
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    @Test
+    fun `retireKey records ADMIN_KEY_RETIRED audit event`() {
+        svc.rotate(TenantId(1), UserId(1))
+        svc.retireKey(TenantId(1), "acme-original", UserId(1))
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_KEY_RETIRED))
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
@@ -140,4 +140,53 @@ class KeyRotationServiceTest {
         svc.retireKey(TenantId(1), "acme-original", UserId(1))
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_KEY_RETIRED))
     }
+
+    // =========================================================================
+    // Cross-tenant isolation
+    // =========================================================================
+
+    @Test
+    fun `rotate does not affect keys belonging to a different tenant`() {
+        val tenant2 =
+            Tenant(id = TenantId(2), slug = "beta", displayName = "Beta Corp", issuerUrl = null)
+        tenants.add(tenant2)
+        svc.rotate(TenantId(1), UserId(1))
+        val t2Key = keys.findActiveKey(TenantId(2))
+        assertNotNull(t2Key)
+        assertEquals("beta-original", t2Key.keyId, "Tenant 2's key should be unaffected")
+        assertTrue(t2Key.active)
+    }
+
+    @Test
+    fun `retireKey from tenant A cannot retire tenant B key`() {
+        val tenant2 =
+            Tenant(id = TenantId(2), slug = "beta", displayName = "Beta Corp", issuerUrl = null)
+        tenants.add(tenant2)
+        keys.add(
+            TenantKey(
+                tenantId = TenantId(2),
+                keyId = "beta-key",
+                publicKeyPem = "pub2",
+                privateKeyPem = "priv2",
+                enabled = true,
+                active = false,
+            ),
+        )
+        val result = svc.retireKey(TenantId(1), "beta-key", UserId(1))
+        assertIs<AdminResult.Failure>(result)
+    }
+
+    // =========================================================================
+    // Multiple rotations
+    // =========================================================================
+
+    @Test
+    fun `multiple sequential rotations result in exactly one active key`() {
+        svc.rotate(TenantId(1), UserId(1))
+        svc.rotate(TenantId(1), UserId(1))
+        val allKeys = keys.all().filter { it.tenantId == TenantId(1) }
+        val activeKeys = allKeys.filter { it.active }
+        assertEquals(1, activeKeys.size, "Only one key should be active after two rotations")
+        assertEquals(3, allKeys.size, "Should have original + 2 rotated keys")
+    }
 }

--- a/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/KeyRotationServiceTest.kt
@@ -150,6 +150,16 @@ class KeyRotationServiceTest {
         val tenant2 =
             Tenant(id = TenantId(2), slug = "beta", displayName = "Beta Corp", issuerUrl = null)
         tenants.add(tenant2)
+        keys.add(
+            TenantKey(
+                tenantId = TenantId(2),
+                keyId = "beta-original",
+                publicKeyPem = "pub2",
+                privateKeyPem = "priv2",
+                enabled = true,
+                active = true,
+            ),
+        )
         svc.rotate(TenantId(1), UserId(1))
         val t2Key = keys.findActiveKey(TenantId(2))
         assertNotNull(t2Key)

--- a/src/test/kotlin/com/kauth/fakes/FakeTenantKeyRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTenantKeyRepository.kt
@@ -30,6 +30,8 @@ class FakeTenantKeyRepository : TenantKeyRepository {
     override fun findEnabledKeys(tenantId: TenantId): List<TenantKey> =
         store.filter { it.tenantId == tenantId && it.enabled }
 
+    override fun findAllKeys(tenantId: TenantId): List<TenantKey> = store.filter { it.tenantId == tenantId }
+
     override fun findByKeyId(
         tenantId: TenantId,
         keyId: String,

--- a/src/test/kotlin/com/kauth/fakes/FakeTenantKeyRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTenantKeyRepository.kt
@@ -1,0 +1,62 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.port.TenantKeyRepository
+
+/**
+ * In-memory TenantKeyRepository for unit tests.
+ */
+class FakeTenantKeyRepository : TenantKeyRepository {
+    private val store = mutableListOf<TenantKey>()
+    private var nextId = 1
+
+    fun clear() {
+        store.clear()
+        nextId = 1
+    }
+
+    fun all(): List<TenantKey> = store.toList()
+
+    fun add(key: TenantKey): TenantKey {
+        val k = if (key.id == null) key.copy(id = nextId++) else key
+        store.add(k)
+        return k
+    }
+
+    override fun findActiveKey(tenantId: TenantId): TenantKey? =
+        store.find { it.tenantId == tenantId && it.active && it.enabled }
+
+    override fun findEnabledKeys(tenantId: TenantId): List<TenantKey> =
+        store.filter { it.tenantId == tenantId && it.enabled }
+
+    override fun findByKeyId(
+        tenantId: TenantId,
+        keyId: String,
+    ): TenantKey? = store.find { it.tenantId == tenantId && it.keyId == keyId }
+
+    override fun save(key: TenantKey): TenantKey {
+        val k = key.copy(id = nextId++)
+        store.add(k)
+        return k
+    }
+
+    override fun rotate(
+        tenantId: TenantId,
+        newKeyId: String,
+        previousKeyId: String,
+    ) {
+        val oldIdx = store.indexOfFirst { it.tenantId == tenantId && it.keyId == previousKeyId }
+        if (oldIdx >= 0) store[oldIdx] = store[oldIdx].copy(active = false)
+        val newIdx = store.indexOfFirst { it.tenantId == tenantId && it.keyId == newKeyId }
+        if (newIdx >= 0) store[newIdx] = store[newIdx].copy(active = true)
+    }
+
+    override fun disable(
+        tenantId: TenantId,
+        keyId: String,
+    ) {
+        val idx = store.indexOfFirst { it.tenantId == tenantId && it.keyId == keyId }
+        if (idx >= 0) store[idx] = store[idx].copy(enabled = false, active = false)
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
@@ -60,4 +60,11 @@ class FakeTokenPort : TokenPort {
     override fun decodeAccessToken(token: String): AccessTokenClaims? = claimsToReturn
 
     override fun getTenantJwks(tenantId: TenantId): List<Map<String, Any>> = jwksToReturn
+
+    var cacheInvalidatedForTenant: TenantId? = null
+        private set
+
+    override fun invalidateSigningKeyCache(tenantId: TenantId) {
+        cacheInvalidatedForTenant = tenantId
+    }
 }


### PR DESCRIPTION
## What does this PR do?

This pull request introduces tenant signing key rotation support, including backend changes for key management, updates to JWT token handling, and new admin routes and UI for managing signing keys. The core changes enable secure rotation and retirement of signing keys per tenant, update the token issuance and verification logic to support multiple keys, and provide an admin interface for key management.

**Key Rotation and Signing Key Management:**

* Added an `active` column to the `TenantKeysTable` and updated the `PostgresTenantKeyRepository` to support key rotation, retirement, and retrieval by key ID. New methods allow finding all keys for a tenant, rotating keys (demoting old and promoting new), and retiring keys. The repository now tracks both `enabled` and `active` status for each key. [[1]](diffhunk://#diff-0cdcf883bd10e8990a98d9b87e3d9a39595c53664516ebaa4f2b6d4e9d5450a0R18) [[2]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0L19-R23) [[3]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R36-R56) [[4]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R67-R90) [[5]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R99) [[6]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R115-R116)

* Introduced `KeyRotationService` and injected it, along with the `TenantKeyRepository`, into the application module and admin routes for use in key management endpoints. [[1]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R394-R395) [[2]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR17-R23) [[3]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR69-R70)

**JWT Token Issuance and Verification:**

* Updated the `JwtTokenAdapter` to associate tokens with a specific key ID (`kid`), cache key information, and support verification of tokens signed with both current and previous keys. Added support for looking up algorithms by `kid` and invalidating the signing key cache. [[1]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L47-R54) [[2]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L61-R68) [[3]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R84) [[4]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L122-R136) [[5]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L138-R147) [[6]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L166-R181) [[7]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L181-R191) [[8]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L192-R210) [[9]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L255-R273) [[10]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L271-R306) [[11]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R337-R341)

**Admin UI and Routes:**

* Added new admin routes (`adminKeyRotationRoutes`) for viewing, rotating, and retiring signing keys. The admin UI now includes a "Signing Keys" section in the settings sidebar, with visual dividers for better grouping. Toast messages are shown for key rotation and retirement actions. [[1]](diffhunk://#diff-158c9f27ce3f3ca8b60c45d75ba051d0c4ed11f37d03d1fb72556da04a42919eR1-R89) [[2]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR493-R499) [[3]](diffhunk://#diff-6c98636927c5832ede822a5b4efc36cd44bc0c0e3dcffbdccf0ad563ceba0731R75-R79) [[4]](diffhunk://#diff-a545056e0e31a38cf368bdc33286799f5a057bf6c2bf7d1b6493775cb0abd2e3R420-R424) [[5]](diffhunk://#diff-fa1579667aa19858525b60b6450b3dc06e6981c8bf2ec1f214487bf0b335b661R76-R82)

**Summary of Most Important Changes:**

**Key rotation and repository enhancements:**
- Added `active` column to `TenantKeysTable` and updated repository methods to support key rotation, retirement, and retrieval by key ID. Now tracks both `enabled` and `active` status for each key. [[1]](diffhunk://#diff-0cdcf883bd10e8990a98d9b87e3d9a39595c53664516ebaa4f2b6d4e9d5450a0R18) [[2]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0L19-R23) [[3]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R36-R56) [[4]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R67-R90) [[5]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R99) [[6]](diffhunk://#diff-658d605d2f5d19de603d00c827e038573a8701cc96285f3d3293e7bc77164cc0R115-R116)
- Injected `KeyRotationService` and `TenantKeyRepository` into application and admin routes for key management. [[1]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R394-R395) [[2]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR17-R23) [[3]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR69-R70)

**JWT token handling improvements:**
- Updated `JwtTokenAdapter` to support key rotation: tokens now include a `kid` header, verification supports both current and previous keys, and key cache management is improved. [[1]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L47-R54) [[2]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L61-R68) [[3]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R84) [[4]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L122-R136) [[5]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L138-R147) [[6]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L166-R181) [[7]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L181-R191) [[8]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L192-R210) [[9]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L255-R273) [[10]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L271-R306) [[11]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R337-R341)

**Admin UI and routes:**
- Added new admin routes and UI for signing key management, including viewing, rotating, and retiring keys, with toast messages for key actions. Sidebar updated with a "Signing Keys" section and visual dividers. [[1]](diffhunk://#diff-158c9f27ce3f3ca8b60c45d75ba051d0c4ed11f37d03d1fb72556da04a42919eR1-R89) [[2]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR493-R499) [[3]](diffhunk://#diff-6c98636927c5832ede822a5b4efc36cd44bc0c0e3dcffbdccf0ad563ceba0731R75-R79) [[4]](diffhunk://#diff-a545056e0e31a38cf368bdc33286799f5a057bf6c2bf7d1b6493775cb0abd2e3R420-R424) [[5]](diffhunk://#diff-fa1579667aa19858525b60b6450b3dc06e6981c8bf2ec1f214487bf0b335b661R76-R82)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [ ] `./gradlew test` passes locally
- [ ] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
