### PR TITLE
fix/dependency-upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.3] - 2026-04-10
+
+### Security
+
+- **Netty upgraded to 4.1.132.Final** — patches CVE-2026-33870 (HTTP request smuggling, High severity) and CVE-2026-33871 (HTTP/2 CONTINUATION frame DoS, High severity). Previous pin at 4.1.124.Final was vulnerable to both
+
+### Changed
+
+- **Kotlin upgraded to 2.3.20** — from 1.9.24. Source-compatible, no breaking changes. Enables K2 compiler, aligns with latest JetBrains toolchain. Gradle deprecation warnings persist (source: Ktor 2.3.12 plugin, resolved when migrating to Ktor 3.x in v2.0)
+- **Dependency upgrade plan rewritten** — `docs/internal/GRADLE_UPGRADE_PLAN.md` now contains a deep migration impact analysis for the v2.0 framework upgrade: Ktor 3.x (2.5 days, 4 intercept→plugin conversions + 30 mechanical changes), Exposed 1.0 (1.5 days, limit/offset + TransactionManager accessor), Flyway 11 (30 min). Total: ~4.25 days. Migrations are independent and ordered: Flyway → Exposed → Ktor
+
+---
+
 ## [1.5.2] - 2026-04-10
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,14 +5,14 @@ val flywayVersion = "9.22.3"
 val logstashEncoderVersion = "8.0"
 
 plugins {
-    kotlin("jvm") version "1.9.24"
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.serialization") version "2.3.20"
     id("io.ktor.plugin") version "2.3.12"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
 }
 
 group = "com.kauth"
-version = "1.5.2"
+version = "1.5.3"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")
@@ -25,8 +25,8 @@ repositories {
 dependencies {
     // ---- Security: override vulnerable transitive dependencies from Ktor 2.3.x ----
     constraints {
-        implementation("io.netty:netty-codec-http2:4.1.124.Final") { because("CVE-2025-55163") }
-        implementation("io.netty:netty-handler:4.1.124.Final") { because("CVE-2025-24970") }
+        implementation("io.netty:netty-codec-http2:4.1.132.Final") { because("CVE-2026-33870, CVE-2026-33871") }
+        implementation("io.netty:netty-handler:4.1.132.Final") { because("CVE-2026-33870, CVE-2026-33871") }
         implementation("com.fasterxml.jackson:jackson-bom:2.18.6") { because("GHSA-72hv-8253-57qq") }
         implementation("com.fasterxml.jackson.core:jackson-core:2.18.6") { because("GHSA-72hv-8253-57qq") }
         implementation("com.fasterxml.jackson.core:jackson-databind:2.18.6") { because("GHSA-72hv-8253-57qq") }


### PR DESCRIPTION
## What does this PR do?

This pull request updates the project to version 1.5.3, focusing on critical security fixes and key dependency upgrades. It also revises the internal documentation for future upgrade planning, especially for the upcoming v2.0 framework migration.

Security improvements:
* Upgraded Netty to version 4.1.132.Final, addressing two high-severity vulnerabilities: CVE-2026-33870 (HTTP request smuggling) and CVE-2026-33871 (HTTP/2 CONTINUATION frame DoS). The previous version (4.1.124.Final) was vulnerable to both.

Dependency upgrades:
* Upgraded Kotlin from 1.9.24 to 2.3.20, enabling the K2 compiler and aligning with the latest JetBrains toolchain. This upgrade is source-compatible and introduces no breaking changes, though some Gradle deprecation warnings remain (to be resolved in v2.0 with Ktor 3.x).

Documentation updates:
* Rewrote the dependency upgrade plan in `docs/internal/GRADLE_UPGRADE_PLAN.md`, providing a detailed migration impact analysis for the v2.0 framework upgrade (Ktor 3.x, Exposed 1.0, Flyway 11), including estimated migration times and an ordered, independent migration sequence.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `./gradlew test` passes locally
- [x] `./gradlew ktlintCheck` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
