### PR TITLE
fix/flyway-shadow-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.6] - 2026-04-21
+
+### Fixed
+
+- **Fat-jar `META-INF/services/**` files are now merged** — the Ktor Gradle plugin sets `duplicatesStrategy = EXCLUDE` on `shadowJar`, which silently dropped duplicate service-provider files before `ServiceFileTransformer` could concatenate them. In Flyway 10+, location-scanner plugins (`classpath:`, `filesystem:`) are registered via `META-INF/services/org.flywaydb.core.extensibility.Plugin`; the `flyway-database-postgresql` copy overwrote the 29-entry `flyway-core` copy, leaving the registered-prefix list empty. Kotauth crashed on boot with `FlywayException: Unknown prefix for location (should be one of ): classpath:db/callback` (note the empty parens). Fix: `com.gradleup.shadow` added as an explicit plugin, `shadowJar` configured with `duplicatesStrategy = INCLUDE` and `mergeServiceFiles()`. Plugin SPI file in the built jar now has 31 entries including `ClasspathLocationHandlerImpl` and `FilesystemLocationHandler`
+
+---
+
 ## [1.5.5] - 2026-04-20
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,17 @@ plugins {
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.serialization") version "2.3.20"
     id("io.ktor.plugin") version "3.4.2"
+    id("com.gradleup.shadow") version "9.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    mergeServiceFiles()
+}
+
 group = "com.kauth"
-version = "1.5.5"
+version = "1.5.6-rc1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.5.6-rc1"
+version = "1.5.6"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")


### PR DESCRIPTION
## What does this PR do?

Fix flyway shadow service in gradlew

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [ ] `make test` passes locally
- [ ] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
