### PR TITLE
feat/multi-tenant-cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.7] - 2026-04-21
+
+### Added
+
+- **Multi-tenant CORS policy** — every OIDC endpoint now emits correct `Access-Control-*` headers. Allowed origins are derived automatically from the `client_redirect_uris.uri` of registered, enabled OIDC clients within the tenant: an operator who adds a redirect URI implicitly authorizes that origin for cross-origin SPA traffic to the tenant's token, userinfo, logout, revoke, and introspect endpoints. Discovery (`/.well-known/openid-configuration`) and JWKS (`/protocol/openid-connect/certs`) remain globally readable via `Access-Control-Allow-Origin: *` per OIDC spec. Denied origins produce a structured `WARN cors_denied tenant=X origin=Y method=Z path=P` log line for operator debugging. See [ADR-08](docs/adr/ADR-08-multi-tenant-cors-policy.md)
+- **`Send credentials cross-origin` tenant toggle** — opt-in per-tenant flag on the Security Policy page that enables `Access-Control-Allow-Credentials: true` for BFF / cookie-based cross-origin flows. Default off — standard PKCE public clients using Bearer tokens do not need it
+- **V32 migration** — `tenant_security_config.cors_allow_credentials BOOLEAN NOT NULL DEFAULT FALSE`
+- **`TenantCorsPlugin`** — route-scoped Ktor plugin installed under `/t/{slug}` (auth routes) and `/t/{tenantSlug}/api/v1` (api routes). Handles OPTIONS preflight terminally (204 for allowed origins, 403 for denied) and injects response headers for actual requests. Path-aware: discovery + JWKS get wildcard ACAO; everything else goes through the tenant's origin allowlist
+- **In-process origin cache** — `CorsOriginCache` wraps `PostgresCorsAdapter` with a 60-second TTL; mutations on `AdminService` (`updateApplication`, `setApplicationEnabled`, `updateWorkspaceSettings`) and `AdminApplicationRoutes` client-create invalidate the cache entry for the affected tenant so changes propagate immediately
+
+---
+
 ## [1.5.6] - 2026-04-21
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.5.6"
+version = "1.5.7"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/adr/ADR-08-multi-tenant-cors-policy.md
+++ b/docs/adr/ADR-08-multi-tenant-cors-policy.md
@@ -1,0 +1,54 @@
+# ADR-08: Multi-Tenant CORS Policy
+
+**Status:** Accepted
+**Date:** 2026-04-21
+
+## Context
+
+Before 1.5.7 Kotauth installed no CORS plugin. Every browser-driven request from an SPA to any OIDC endpoint (`/t/{slug}/.well-known/openid-configuration`, `/protocol/openid-connect/token`, `/userinfo`, etc.) was blocked by the browser. SPAs could not consume Kotauth at all.
+
+Three models were evaluated:
+
+- **A) Global env-var allowlist** — `KAUTH_CORS_ALLOWED_ORIGINS` applied to every tenant.
+- **B) Separate per-tenant CORS table** — operators configure allowed origins explicitly in a dedicated admin page.
+- **C) Derive per-tenant origins from registered OIDC clients** — the origin of every registered `client_redirect_uris.uri` becomes the allowed CORS origin for that tenant.
+
+## Decision
+
+**Option C — derive origins from `client_redirect_uris`.** One additional opt-in knob per tenant — `tenant_security_config.cors_allow_credentials` — lets operators enable `Access-Control-Allow-Credentials: true` for BFF / cookie-based cross-origin flows. Default off; PKCE public clients with Bearer tokens do not need it.
+
+## Rationale
+
+**One source of truth.** A separate allowlist table drifts. Every registered client already has a redirect URI; its origin is, by definition, an origin the operator has authorized for this tenant. The admin UI where operators register a client (`Applications`) is the same place they implicitly manage CORS — no separate CORS nav entry, no separate mental model.
+
+**Scales across thousands of tenants with zero operational burden.** A new SaaS customer registers a client with their SPA's redirect URI — CORS works. No ticket to platform ops, no env var to edit per tenant.
+
+**Preflight works without auth.** CORS preflight (`OPTIONS`) carries no Authorization, no client_id, no session — only the tenant slug from the path plus the `Origin` header. The model keys on `(tenant_slug, origin)`, which is resolvable from request data alone.
+
+**Public endpoints remain public.** `/.well-known/openid-configuration` and `/protocol/openid-connect/certs` (JWKS) are globally readable per the OIDC spec. The plugin emits `Access-Control-Allow-Origin: *` on those paths regardless of tenant or origin, so discovery and key-fetch work for any consumer.
+
+## Alternatives Rejected
+
+**Option A (global env-var allowlist):** Does not scale to a multi-tenant SaaS where each tenant's SPA is hosted on a different domain. An operator adding a new tenant would have to restart Kotauth with an updated env var.
+
+**Option B (dedicated CORS table + admin page):** Adds a parallel source of truth to `client_redirect_uris`. Operators must maintain two lists in sync. The only use case it unlocks — whitelisting an origin that is not an OIDC client's redirect URI (e.g., a backend-for-frontend or CLI tool) — can be added later via a `tenant_cors_extra_origins` table without breaking the Option C model.
+
+**Using Ktor's built-in `install(CORS)` plugin:** Its origin allowlist is statically configured at install time. Per-request, per-tenant dynamic resolution requires a custom plugin.
+
+## Consequences
+
+- **Fresh-install tenants with no registered clients receive no CORS headers.** This is strict and correct — a tenant with zero clients has no browser traffic to authorize. Operators must register at least one client with a redirect URI before any cross-origin SPA can consume that tenant.
+- **Policy is cached in-process with a 60-second TTL.** `CorsOriginCache` in `adapter/web/plugin/`. Every mutation on `AdminService` that changes a tenant's client list or CORS config invalidates the cache entry for that tenant, so updates propagate immediately; TTL is the safety net for any write path not yet routed through the service.
+- **Denials emit a structured log line** — `WARN cors_denied tenant=X origin=Y method=Z path=P` — so an operator with log access can diagnose "my SPA is blocked" without a new admin tool.
+- **Origin extraction is exact.** `https://app.example.com/callback` → origin `https://app.example.com`. Localhost dev origins (`http://localhost:3000`) work naturally via exact match. No wildcards.
+- **Opt-in credentials** — `tenant_security_config.cors_allow_credentials` (V32, default `FALSE`) enables `Access-Control-Allow-Credentials: true`. Surfaced as a checkbox on the Security Policy page.
+
+## Implementation Notes
+
+- Domain: `domain/model/CorsDecision.kt` (sealed: `Public`, `Allowed(origin, allowCredentials)`, `Denied`), `domain/port/CorsPort.kt` (`policyForTenant(slug): CorsPolicy?`, `invalidate(slug)`), `domain/service/CorsService.kt` (`decide(slug, origin, path): CorsDecision`).
+- Adapter: `adapter/persistence/PostgresCorsAdapter.kt` joins `client_redirect_uris` + `clients` + `tenants` + `tenant_security_config`, extracts origin via `java.net.URI`, filters by `clients.enabled = true`.
+- Cache: `adapter/web/plugin/CorsOriginCache.kt` — `ConcurrentHashMap` with injectable `ttlMillis` and `clock` for tests.
+- Ktor: `adapter/web/plugin/TenantCorsPlugin.kt` — `createRouteScopedPlugin` installed at `/t/{slug}` (auth routes) and `/t/{tenantSlug}/api/v1` (api routes). Path-aware: public paths get `ACAO: *`, client-scoped paths get exact-match allowlist. Terminates OPTIONS preflight with 204 (allowed) or 403 (denied).
+- Invalidation: `AdminService.updateApplication`, `AdminService.setApplicationEnabled`, `AdminService.updateWorkspaceSettings`, and `AdminApplicationRoutes` client-create all call `CorsPort.invalidate(tenantSlug)`.
+- Migration: `V32__tenant_cors_allow_credentials.sql` adds `cors_allow_credentials BOOLEAN NOT NULL DEFAULT FALSE`.
+- Tests: `CorsServiceTest` (11 cases, fakes), `CorsOriginCacheTest` (4 cases, injectable clock), `TenantCorsPluginTest` (11 cases, `testApplication`).

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -349,6 +349,7 @@ fun Application.module(
             identityProviderRepository = s.identityProviderRepository,
             baseUrl = config.baseUrl,
             encryptionService = s.encryptionService,
+            corsService = s.corsService,
         )
 
         portalRoutes(
@@ -372,6 +373,7 @@ fun Application.module(
             auditLogRepository = s.auditLogRepository,
             roleGroupService = s.roleGroupService,
             adminService = s.adminService,
+            corsService = s.corsService,
         )
 
         adminRoutes(
@@ -395,6 +397,7 @@ fun Application.module(
             roleRepository = s.roleRepository,
             keyRotationService = s.keyRotationService,
             tenantKeyRepository = s.tenantKeyRepository,
+            corsPort = s.corsOriginCache,
             baseUrl = config.baseUrl,
         )
     }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresCorsAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresCorsAdapter.kt
@@ -1,0 +1,59 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.port.CorsPolicy
+import com.kauth.domain.port.CorsPort
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.net.URI
+
+class PostgresCorsAdapter : CorsPort {
+    override fun policyForTenant(tenantSlug: String): CorsPolicy? =
+        transaction {
+            val tenantRow =
+                TenantsTable
+                    .join(
+                        TenantSecurityConfigTable,
+                        JoinType.LEFT,
+                        additionalConstraint = { TenantsTable.id eq TenantSecurityConfigTable.tenantId },
+                    ).selectAll()
+                    .where { TenantsTable.slug eq tenantSlug }
+                    .singleOrNull() ?: return@transaction null
+
+            val tenantId = tenantRow[TenantsTable.id]
+            val allowCredentials =
+                tenantRow.getOrNull(TenantSecurityConfigTable.corsAllowCredentials) ?: false
+
+            val origins =
+                ClientRedirectUrisTable
+                    .join(
+                        ClientsTable,
+                        JoinType.INNER,
+                        additionalConstraint = {
+                            ClientRedirectUrisTable.clientId eq ClientsTable.id
+                        },
+                    ).selectAll()
+                    .where { (ClientsTable.tenantId eq tenantId) and (ClientsTable.enabled eq true) }
+                    .mapNotNull { row -> row[ClientRedirectUrisTable.uri].toOriginOrNull() }
+                    .toSet()
+
+            CorsPolicy(allowedOrigins = origins, allowCredentials = allowCredentials)
+        }
+
+    private fun String.toOriginOrNull(): String? =
+        runCatching {
+            val uri = URI(this)
+            val scheme = uri.scheme?.lowercase() ?: return null
+            val host = uri.host ?: return null
+            val port = uri.port
+            if (port < 0 || port == defaultPort(scheme)) "$scheme://$host" else "$scheme://$host:$port"
+        }.getOrNull()
+
+    private fun defaultPort(scheme: String): Int =
+        when (scheme) {
+            "https" -> 443
+            "http" -> 80
+            else -> -1
+        }
+}

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
@@ -121,6 +121,7 @@ class PostgresTenantRepository(
                     it[mfaPolicy] = tenant.securityConfig.mfaPolicy
                     it[lockoutMaxAttempts] = tenant.securityConfig.lockoutMaxAttempts
                     it[lockoutDurationMinutes] = tenant.securityConfig.lockoutDurationMinutes
+                    it[corsAllowCredentials] = tenant.securityConfig.corsAllowCredentials
                 }
             if (updatedRows == 0) {
                 TenantSecurityConfigTable.insert {
@@ -135,6 +136,7 @@ class PostgresTenantRepository(
                     it[mfaPolicy] = tenant.securityConfig.mfaPolicy
                     it[lockoutMaxAttempts] = tenant.securityConfig.lockoutMaxAttempts
                     it[lockoutDurationMinutes] = tenant.securityConfig.lockoutDurationMinutes
+                    it[corsAllowCredentials] = tenant.securityConfig.corsAllowCredentials
                 }
             }
             tenantJoined
@@ -212,6 +214,7 @@ class PostgresTenantRepository(
             mfaPolicy = this[TenantSecurityConfigTable.mfaPolicy],
             lockoutMaxAttempts = this[TenantSecurityConfigTable.lockoutMaxAttempts],
             lockoutDurationMinutes = this[TenantSecurityConfigTable.lockoutDurationMinutes],
+            corsAllowCredentials = this[TenantSecurityConfigTable.corsAllowCredentials],
         )
     }
 

--- a/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
@@ -23,6 +23,7 @@ object TenantSecurityConfigTable : Table("tenant_security_config") {
     val mfaPolicy = varchar("mfa_policy", 30).default("optional")
     val lockoutMaxAttempts = integer("lockout_max_attempts").default(0)
     val lockoutDurationMinutes = integer("lockout_duration_minutes").default(15)
+    val corsAllowCredentials = bool("cors_allow_credentials").default(false)
     val createdAt = timestampWithTimeZone("created_at")
     val updatedAt = timestampWithTimeZone("updated_at")
 

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
@@ -1,6 +1,7 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.domain.port.ApplicationRepository
+import com.kauth.domain.port.CorsPort
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
 import io.ktor.http.HttpStatusCode
@@ -19,6 +20,7 @@ import io.ktor.server.sessions.sessions
 fun Route.adminApplicationRoutes(
     adminService: AdminService,
     applicationRepository: ApplicationRepository,
+    corsPort: CorsPort? = null,
 ) {
     route("/applications") {
         get("/new") {
@@ -80,6 +82,7 @@ fun Route.adminApplicationRoutes(
                 )
             }
             applicationRepository.create(workspace.id, clientId, name, desc, accessType, redirectUris)
+            corsPort?.invalidate(workspace.slug)
             call.respondRedirect("/admin/workspaces/$slug/applications/$clientId")
         }
 

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -10,6 +10,7 @@ import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogRepository
+import com.kauth.domain.port.CorsPort
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.MfaRepository
 import com.kauth.domain.port.RoleRepository
@@ -67,6 +68,7 @@ fun Route.adminRoutes(
     roleRepository: RoleRepository? = null,
     keyRotationService: KeyRotationService? = null,
     tenantKeyRepository: TenantKeyRepository? = null,
+    corsPort: CorsPort? = null,
     baseUrl: String = "",
 ) {
     AdminView.setShellAppInfo(appInfo)
@@ -472,6 +474,7 @@ fun Route.adminRoutes(
                 adminApplicationRoutes(
                     adminService = adminService,
                     applicationRepository = applicationRepository,
+                    corsPort = corsPort,
                 )
 
                 adminUserRoutes(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -320,6 +320,7 @@ fun Route.adminSettingsRoutes(
                     lockoutDurationMinutes =
                         params["lockoutDurationMinutes"]?.toIntOrNull()
                             ?: workspace.securityConfig.lockoutDurationMinutes,
+                    corsAllowCredentials = params["corsAllowCredentials"] == "true",
                 )
         ) {
             is AdminResult.Success ->

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
@@ -341,7 +341,10 @@ internal fun createApplicationPageImpl(
                                 "https://app.example.com/callback\nhttps://localhost:3000/callback"
                             +prefill.redirectUris
                         }
-                        div("edit-row__hint") { +"One URI per line. These are allowed OAuth2 callback URLs." }
+                        div("edit-row__hint") {
+                            +"One URI per line. Their origins are automatically CORS-allowed "
+                            +"for SPAs in this workspace."
+                        }
                     }
                 }
             }
@@ -493,7 +496,10 @@ internal fun editApplicationPageImpl(
                                 "https://app.example.com/callback\nhttps://localhost:3000/callback"
                             +application.redirectUris.joinToString("\n")
                         }
-                        div("edit-row__hint") { +"One URI per line." }
+                        div("edit-row__hint") {
+                            +"One URI per line. Their origins are automatically CORS-allowed "
+                            +"for SPAs in this workspace."
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -775,6 +775,25 @@ internal fun securityPolicyPageImpl(
                         }
                     }
                 }
+
+                // ── Cross-Origin (CORS) ──────────────────────────────
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Cross-Origin (CORS)" }
+                    label("check-row") {
+                        input(type = InputType.checkBox, name = "corsAllowCredentials") {
+                            attributes["value"] = "true"
+                            if (workspace.securityConfig.corsAllowCredentials) checked = true
+                        }
+                        div("check-row__body") {
+                            span("check-row__label") { +"Send credentials cross-origin" }
+                            span("check-row__desc") {
+                                +"Off by default. Enable only if your SPA sends cookies cross-origin "
+                                +"to Kotauth (BFF pattern). PKCE public clients using Bearer tokens "
+                                +"do not need this."
+                            }
+                        }
+                    }
+                }
             }
                     }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
@@ -1,5 +1,6 @@
 package com.kauth.adapter.web.api
 
+import com.kauth.adapter.web.plugin.TenantCorsPlugin
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogRepository
 import com.kauth.domain.port.GroupRepository
@@ -8,6 +9,7 @@ import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
+import com.kauth.domain.service.CorsService
 import com.kauth.domain.service.RoleGroupService
 import com.kauth.infrastructure.ApiKeyPrincipal
 import io.ktor.http.ContentType
@@ -32,6 +34,7 @@ fun Route.apiRoutes(
     auditLogRepository: AuditLogRepository,
     roleGroupService: RoleGroupService,
     adminService: AdminService,
+    corsService: CorsService? = null,
 ) {
     get("/api/docs") {
         call.respondText(ContentType.Text.Html, HttpStatusCode.OK) {
@@ -51,6 +54,13 @@ fun Route.apiRoutes(
 
     authenticate("api-key") {
         route("/t/{tenantSlug}/api/v1") {
+            if (corsService != null) {
+                install(TenantCorsPlugin) {
+                    this.corsService = corsService
+                    tenantSlugParam = "tenantSlug"
+                }
+            }
+
             val apiContextPlugin =
                 createRouteScopedPlugin("ApiContextPlugin") {
                     on(AuthenticationChecked) { call ->

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
@@ -1,11 +1,13 @@
 package com.kauth.adapter.web.auth
 
+import com.kauth.adapter.web.plugin.TenantCorsPlugin
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
 import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.CorsService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginService
@@ -33,8 +35,15 @@ fun Route.authRoutes(
     identityProviderRepository: IdentityProviderRepository? = null,
     baseUrl: String = "",
     encryptionService: EncryptionService,
+    corsService: CorsService? = null,
 ) {
     route("/t/{slug}") {
+        if (corsService != null) {
+            install(TenantCorsPlugin) {
+                this.corsService = corsService
+            }
+        }
+
         // Resolve tenant context once per request
         val authTenantPlugin =
             createRouteScopedPlugin("AuthTenantPlugin") {

--- a/src/main/kotlin/com/kauth/adapter/web/plugin/CorsOriginCache.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/plugin/CorsOriginCache.kt
@@ -1,0 +1,37 @@
+package com.kauth.adapter.web.plugin
+
+import com.kauth.domain.port.CorsPolicy
+import com.kauth.domain.port.CorsPort
+import java.util.concurrent.ConcurrentHashMap
+
+class CorsOriginCache(
+    private val delegate: CorsPort,
+    private val ttlMillis: Long = 60_000,
+    private val clock: () -> Long = System::currentTimeMillis,
+) : CorsPort {
+    private data class Entry(
+        val policy: CorsPolicy?,
+        val loadedAt: Long,
+    )
+
+    private val cache = ConcurrentHashMap<String, Entry>()
+
+    override fun policyForTenant(tenantSlug: String): CorsPolicy? {
+        val now = clock()
+        val cached = cache[tenantSlug]
+        if (cached != null && now - cached.loadedAt < ttlMillis) {
+            return cached.policy
+        }
+        val fresh = delegate.policyForTenant(tenantSlug)
+        cache[tenantSlug] = Entry(fresh, now)
+        return fresh
+    }
+
+    override fun invalidate(tenantSlug: String) {
+        cache.remove(tenantSlug)
+    }
+
+    fun evictAll() {
+        cache.clear()
+    }
+}

--- a/src/main/kotlin/com/kauth/adapter/web/plugin/CorsOriginCache.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/plugin/CorsOriginCache.kt
@@ -30,8 +30,4 @@ class CorsOriginCache(
     override fun invalidate(tenantSlug: String) {
         cache.remove(tenantSlug)
     }
-
-    fun evictAll() {
-        cache.clear()
-    }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/plugin/TenantCorsPlugin.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/plugin/TenantCorsPlugin.kt
@@ -1,0 +1,76 @@
+package com.kauth.adapter.web.plugin
+
+import com.kauth.domain.model.CorsDecision
+import com.kauth.domain.service.CorsService
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import org.slf4j.LoggerFactory
+
+class TenantCorsPluginConfig {
+    lateinit var corsService: CorsService
+    var tenantSlugParam: String = "slug"
+    var allowedMethods: String = "GET, POST, OPTIONS"
+    var allowedHeaders: String = "Authorization, Content-Type"
+    var maxAge: String = "600"
+}
+
+val TenantCorsPlugin =
+    createRouteScopedPlugin("TenantCorsPlugin", ::TenantCorsPluginConfig) {
+        val service = pluginConfig.corsService
+        val slugParam = pluginConfig.tenantSlugParam
+        val allowedMethods = pluginConfig.allowedMethods
+        val allowedHeaders = pluginConfig.allowedHeaders
+        val maxAge = pluginConfig.maxAge
+        val logger = LoggerFactory.getLogger("cors")
+
+        onCall { call ->
+            val origin = call.request.headers[HttpHeaders.Origin] ?: return@onCall
+            if (origin == "null") return@onCall
+
+            val slug = call.parameters[slugParam] ?: return@onCall
+            val path = call.request.path()
+            val isPreflight =
+                call.request.httpMethod == HttpMethod.Options &&
+                    call.request.headers.contains(HttpHeaders.AccessControlRequestMethod)
+
+            val decision = service.decide(slug, origin, path)
+
+            when (decision) {
+                CorsDecision.Public -> {
+                    call.response.headers.append(HttpHeaders.AccessControlAllowOrigin, "*")
+                    call.response.headers.append(HttpHeaders.AccessControlAllowMethods, "GET, OPTIONS")
+                    call.response.headers.append(HttpHeaders.AccessControlAllowHeaders, allowedHeaders)
+                    call.response.headers.append(HttpHeaders.AccessControlMaxAge, maxAge)
+                    if (isPreflight) call.respond(HttpStatusCode.NoContent)
+                }
+
+                is CorsDecision.Allowed -> {
+                    call.response.headers.append(HttpHeaders.AccessControlAllowOrigin, decision.origin)
+                    call.response.headers.append(HttpHeaders.Vary, HttpHeaders.Origin)
+                    call.response.headers.append(HttpHeaders.AccessControlAllowMethods, allowedMethods)
+                    call.response.headers.append(HttpHeaders.AccessControlAllowHeaders, allowedHeaders)
+                    call.response.headers.append(HttpHeaders.AccessControlMaxAge, maxAge)
+                    if (decision.allowCredentials) {
+                        call.response.headers.append(HttpHeaders.AccessControlAllowCredentials, "true")
+                    }
+                    if (isPreflight) call.respond(HttpStatusCode.NoContent)
+                }
+
+                CorsDecision.Denied -> {
+                    logger.warn(
+                        "cors_denied tenant={} origin={} method={} path={}",
+                        slug,
+                        origin,
+                        call.request.httpMethod.value,
+                        path,
+                    )
+                    if (isPreflight) call.respond(HttpStatusCode.Forbidden)
+                }
+            }
+        }
+    }

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -6,6 +6,7 @@ import com.kauth.adapter.persistence.PostgresApplicationRepository
 import com.kauth.adapter.persistence.PostgresAuditLogAdapter
 import com.kauth.adapter.persistence.PostgresAuditLogRepository
 import com.kauth.adapter.persistence.PostgresAuthorizationCodeRepository
+import com.kauth.adapter.persistence.PostgresCorsAdapter
 import com.kauth.adapter.persistence.PostgresEmailVerificationTokenRepository
 import com.kauth.adapter.persistence.PostgresGroupRepository
 import com.kauth.adapter.persistence.PostgresIdentityProviderRepository
@@ -26,6 +27,7 @@ import com.kauth.adapter.social.GitHubOAuthAdapter
 import com.kauth.adapter.social.GoogleOAuthAdapter
 import com.kauth.adapter.token.BcryptPasswordHasher
 import com.kauth.adapter.token.JwtTokenAdapter
+import com.kauth.adapter.web.plugin.CorsOriginCache
 import com.kauth.domain.model.SocialProvider
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogRepository
@@ -42,6 +44,7 @@ import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
 import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.CorsService
 import com.kauth.domain.service.KeyRotationService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
@@ -74,6 +77,8 @@ data class ServiceGraph(
     val socialLoginService: SocialLoginService,
     val apiKeyService: ApiKeyService,
     val webhookService: WebhookService,
+    val corsService: CorsService,
+    val corsOriginCache: CorsOriginCache,
     val tenantRepository: TenantRepository,
     val applicationRepository: ApplicationRepository,
     val userRepository: UserRepository,
@@ -128,6 +133,8 @@ data class ServiceGraph(
             val webhookEndpointRepository = PostgresWebhookEndpointRepository()
             val webhookDeliveryRepository = PostgresWebhookDeliveryRepository()
             val mfaRepository = PostgresMfaRepository(encryptionService)
+            val corsOriginCache = CorsOriginCache(PostgresCorsAdapter())
+            val corsService = CorsService(corsOriginCache)
 
             // -- Key provisioning ---------------------------------------------
             val keyProvisioning =
@@ -220,6 +227,7 @@ data class ServiceGraph(
                     themeRepository = themeRepository,
                     portalConfigRepository = portalConfigRepository,
                     emailPort = emailAdapter,
+                    corsPort = corsOriginCache,
                 )
             val roleGroupService =
                 RoleGroupService(
@@ -330,6 +338,8 @@ data class ServiceGraph(
                 socialLoginService = socialLoginService,
                 apiKeyService = apiKeyService,
                 webhookService = webhookService,
+                corsService = corsService,
+                corsOriginCache = corsOriginCache,
                 tenantRepository = tenantRepository,
                 applicationRepository = applicationRepository,
                 userRepository = userRepository,

--- a/src/main/kotlin/com/kauth/domain/model/CorsDecision.kt
+++ b/src/main/kotlin/com/kauth/domain/model/CorsDecision.kt
@@ -1,0 +1,12 @@
+package com.kauth.domain.model
+
+sealed class CorsDecision {
+    data object Public : CorsDecision()
+
+    data class Allowed(
+        val origin: String,
+        val allowCredentials: Boolean,
+    ) : CorsDecision()
+
+    data object Denied : CorsDecision()
+}

--- a/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
+++ b/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
@@ -22,6 +22,8 @@ data class SecurityConfig(
     // Account lockout
     val lockoutMaxAttempts: Int = 0,
     val lockoutDurationMinutes: Int = 15,
+    // CORS
+    val corsAllowCredentials: Boolean = false,
 ) {
     /** Lockout is active when max attempts is > 0. */
     val isLockoutEnabled: Boolean get() = lockoutMaxAttempts > 0

--- a/src/main/kotlin/com/kauth/domain/port/CorsPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/CorsPort.kt
@@ -1,0 +1,14 @@
+package com.kauth.domain.port
+
+data class CorsPolicy(
+    val allowedOrigins: Set<String>,
+    val allowCredentials: Boolean,
+)
+
+interface CorsPort {
+    /** Returns the CORS policy for a tenant, or null if the tenant does not exist. */
+    fun policyForTenant(tenantSlug: String): CorsPolicy?
+
+    /** Invalidates any cached policy for [tenantSlug]. No-op for implementations without caching. */
+    fun invalidate(tenantSlug: String) {}
+}

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -14,6 +14,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogPort
+import com.kauth.domain.port.CorsPort
 import com.kauth.domain.port.EmailPort
 import com.kauth.domain.port.PasswordHasher
 import com.kauth.domain.port.PasswordPolicyPort
@@ -46,7 +47,12 @@ class AdminService(
     private val themeRepository: ThemeRepository? = null,
     private val portalConfigRepository: PortalConfigRepository? = null,
     private val emailPort: EmailPort? = null,
+    private val corsPort: CorsPort? = null,
 ) {
+    private fun invalidateCors(tenantId: TenantId) {
+        val port = corsPort ?: return
+        tenantRepository.findById(tenantId)?.slug?.let(port::invalidate)
+    }
     // =========================================================================
     // Workspace settings
     // =========================================================================
@@ -110,6 +116,7 @@ class AdminService(
         mfaPolicy: String = "optional",
         lockoutMaxAttempts: Int = 0,
         lockoutDurationMinutes: Int = 15,
+        corsAllowCredentials: Boolean = false,
     ): AdminResult<Tenant> {
         val tenant =
             tenantRepository.findBySlug(slug)
@@ -153,10 +160,13 @@ class AdminService(
                         mfaPolicy = mfaPolicy,
                         lockoutMaxAttempts = lockoutMaxAttempts.coerceAtLeast(0),
                         lockoutDurationMinutes = lockoutDurationMinutes.coerceAtLeast(1),
+                        corsAllowCredentials = corsAllowCredentials,
                     ),
             )
 
         val saved = tenantRepository.update(updated)
+
+        corsPort?.invalidate(slug)
 
         auditLog.record(
             AuditEvent(
@@ -614,6 +624,8 @@ class AdminService(
                 redirectUris = resolvedRedirectUris,
             )
 
+        invalidateCors(tenantId)
+
         auditLog.record(
             AuditEvent(
                 tenantId = tenantId,
@@ -646,6 +658,8 @@ class AdminService(
         }
 
         applicationRepository.setEnabled(appId, enabled)
+
+        invalidateCors(tenantId)
 
         auditLog.record(
             AuditEvent(

--- a/src/main/kotlin/com/kauth/domain/service/CorsService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/CorsService.kt
@@ -1,0 +1,25 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.CorsDecision
+import com.kauth.domain.port.CorsPort
+
+class CorsService(
+    private val corsPort: CorsPort,
+) {
+    fun decide(
+        tenantSlug: String,
+        origin: String,
+        endpointPath: String,
+    ): CorsDecision {
+        if (isPublicEndpoint(endpointPath)) return CorsDecision.Public
+
+        val policy = corsPort.policyForTenant(tenantSlug) ?: return CorsDecision.Denied
+        if (origin !in policy.allowedOrigins) return CorsDecision.Denied
+
+        return CorsDecision.Allowed(origin, policy.allowCredentials)
+    }
+
+    private fun isPublicEndpoint(path: String): Boolean =
+        path.endsWith("/.well-known/openid-configuration") ||
+            path.endsWith("/protocol/openid-connect/certs")
+}

--- a/src/main/resources/db/migration/V32__tenant_cors_allow_credentials.sql
+++ b/src/main/resources/db/migration/V32__tenant_cors_allow_credentials.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tenant_security_config
+    ADD COLUMN cors_allow_credentials BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/com/kauth/adapter/web/plugin/CorsOriginCacheTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/plugin/CorsOriginCacheTest.kt
@@ -1,0 +1,72 @@
+package com.kauth.adapter.web.plugin
+
+import com.kauth.fakes.FakeCorsPort
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CorsOriginCacheTest {
+    @Test
+    fun `hits delegate on first call and returns same policy on second call within TTL`() {
+        val delegate =
+            FakeCorsPort().apply {
+                setPolicy("oriana", setOf("https://desk.example.com"))
+            }
+        var now = 0L
+        val cache = CorsOriginCache(delegate, ttlMillis = 60_000, clock = { now })
+
+        val first = cache.policyForTenant("oriana")
+        now = 30_000
+        val second = cache.policyForTenant("oriana")
+
+        assertEquals(first, second)
+        assertEquals(setOf("https://desk.example.com"), first?.allowedOrigins)
+    }
+
+    @Test
+    fun `reloads from delegate after TTL expires`() {
+        val delegate =
+            FakeCorsPort().apply {
+                setPolicy("oriana", setOf("https://old.example.com"))
+            }
+        var now = 0L
+        val cache = CorsOriginCache(delegate, ttlMillis = 60_000, clock = { now })
+
+        cache.policyForTenant("oriana")
+        delegate.setPolicy("oriana", setOf("https://new.example.com"))
+        now = 60_001
+        val reloaded = cache.policyForTenant("oriana")
+
+        assertEquals(setOf("https://new.example.com"), reloaded?.allowedOrigins)
+    }
+
+    @Test
+    fun `evict forces reload on next call`() {
+        val delegate =
+            FakeCorsPort().apply {
+                setPolicy("oriana", setOf("https://old.example.com"))
+            }
+        val cache = CorsOriginCache(delegate, ttlMillis = Long.MAX_VALUE, clock = { 0L })
+
+        cache.policyForTenant("oriana")
+        delegate.setPolicy("oriana", setOf("https://new.example.com"))
+        cache.invalidate("oriana")
+
+        assertEquals(setOf("https://new.example.com"), cache.policyForTenant("oriana")?.allowedOrigins)
+    }
+
+    @Test
+    fun `null tenant policies are cached`() {
+        val delegate = FakeCorsPort()
+        val cache = CorsOriginCache(delegate, ttlMillis = Long.MAX_VALUE, clock = { 0L })
+
+        assertNull(cache.policyForTenant("ghost"))
+
+        // Even if delegate gains a policy later, the null lookup is cached.
+        delegate.setPolicy("ghost", setOf("https://new.example.com"))
+        assertNull(cache.policyForTenant("ghost"))
+
+        cache.invalidate("ghost")
+        assertEquals(setOf("https://new.example.com"), cache.policyForTenant("ghost")?.allowedOrigins)
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/plugin/TenantCorsPluginTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/plugin/TenantCorsPluginTest.kt
@@ -8,7 +8,6 @@ import io.ktor.client.request.options
 import io.ktor.client.request.post
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.install
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.options

--- a/src/test/kotlin/com/kauth/adapter/web/plugin/TenantCorsPluginTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/plugin/TenantCorsPluginTest.kt
@@ -1,0 +1,197 @@
+package com.kauth.adapter.web.plugin
+
+import com.kauth.domain.service.CorsService
+import com.kauth.fakes.FakeCorsPort
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.options
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.options
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TenantCorsPluginTest {
+    private fun setup(block: suspend (io.ktor.client.HttpClient) -> Unit) =
+        testApplication {
+            val corsPort =
+                FakeCorsPort().apply {
+                    setPolicy(
+                        tenantSlug = "oriana",
+                        allowedOrigins = setOf("https://desk.oriana-platform.orb.local"),
+                        allowCredentials = false,
+                    )
+                    setPolicy(
+                        tenantSlug = "bff-tenant",
+                        allowedOrigins = setOf("https://bff.example.com"),
+                        allowCredentials = true,
+                    )
+                }
+            val service = CorsService(corsPort)
+
+            application {
+                routing {
+                    route("/t/{slug}") {
+                        install(TenantCorsPlugin) { corsService = service }
+
+                        get("/.well-known/openid-configuration") { call.respondText("{}") }
+                        get("/protocol/openid-connect/certs") { call.respondText("{}") }
+                        post("/protocol/openid-connect/token") { call.respondText("{}") }
+                        get("/protocol/openid-connect/userinfo") { call.respondText("{}") }
+                        options("/{...}") { call.respondText("") }
+                    }
+                }
+            }
+            block(client)
+        }
+
+    @Test
+    fun `discovery endpoint returns wildcard origin for any requester`() =
+        setup { client ->
+            val response =
+                client.get("/t/oriana/.well-known/openid-configuration") {
+                    headers { append(HttpHeaders.Origin, "https://random.example.com") }
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("*", response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `jwks endpoint returns wildcard origin`() =
+        setup { client ->
+            val response =
+                client.get("/t/oriana/protocol/openid-connect/certs") {
+                    headers { append(HttpHeaders.Origin, "https://random.example.com") }
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("*", response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `discovery endpoint on unknown tenant still public`() =
+        setup { client ->
+            val response =
+                client.get("/t/ghost/.well-known/openid-configuration") {
+                    headers { append(HttpHeaders.Origin, "https://random.example.com") }
+                }
+            // Underlying route returns 404, but CORS plugin must still emit the wildcard
+            // header so the browser sees an error body instead of an opaque CORS block.
+            assertEquals("*", response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `token endpoint allows registered SPA origin`() =
+        setup { client ->
+            val response =
+                client.post("/t/oriana/protocol/openid-connect/token") {
+                    headers { append(HttpHeaders.Origin, "https://desk.oriana-platform.orb.local") }
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(
+                "https://desk.oriana-platform.orb.local",
+                response.headers[HttpHeaders.AccessControlAllowOrigin],
+            )
+            assertEquals("Origin", response.headers[HttpHeaders.Vary])
+            assertNull(response.headers[HttpHeaders.AccessControlAllowCredentials])
+        }
+
+    @Test
+    fun `token endpoint denies unregistered origin by omitting headers`() =
+        setup { client ->
+            val response =
+                client.post("/t/oriana/protocol/openid-connect/token") {
+                    headers { append(HttpHeaders.Origin, "https://evil.example.com") }
+                }
+            // Request proceeds to handler (browser enforces CORS client-side),
+            // but no ACAO header is emitted — browser will block the response.
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `preflight for allowed origin returns 204 with correct headers`() =
+        setup { client ->
+            val response =
+                client.options("/t/oriana/protocol/openid-connect/token") {
+                    headers {
+                        append(HttpHeaders.Origin, "https://desk.oriana-platform.orb.local")
+                        append(HttpHeaders.AccessControlRequestMethod, "POST")
+                        append(HttpHeaders.AccessControlRequestHeaders, "Authorization, Content-Type")
+                    }
+                }
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            assertEquals(
+                "https://desk.oriana-platform.orb.local",
+                response.headers[HttpHeaders.AccessControlAllowOrigin],
+            )
+            assertEquals("GET, POST, OPTIONS", response.headers[HttpHeaders.AccessControlAllowMethods])
+            assertEquals("Authorization, Content-Type", response.headers[HttpHeaders.AccessControlAllowHeaders])
+            assertEquals("600", response.headers[HttpHeaders.AccessControlMaxAge])
+        }
+
+    @Test
+    fun `preflight for denied origin returns 403 without CORS headers`() =
+        setup { client ->
+            val response =
+                client.options("/t/oriana/protocol/openid-connect/token") {
+                    headers {
+                        append(HttpHeaders.Origin, "https://evil.example.com")
+                        append(HttpHeaders.AccessControlRequestMethod, "POST")
+                    }
+                }
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `allow_credentials=true tenant emits credentials header`() =
+        setup { client ->
+            val response =
+                client.get("/t/bff-tenant/protocol/openid-connect/userinfo") {
+                    headers { append(HttpHeaders.Origin, "https://bff.example.com") }
+                }
+            assertEquals("true", response.headers[HttpHeaders.AccessControlAllowCredentials])
+            assertEquals(
+                "https://bff.example.com",
+                response.headers[HttpHeaders.AccessControlAllowOrigin],
+            )
+        }
+
+    @Test
+    fun `unknown tenant on client-scoped endpoint is denied`() =
+        setup { client ->
+            val response =
+                client.post("/t/ghost/protocol/openid-connect/token") {
+                    headers { append(HttpHeaders.Origin, "https://anywhere.example.com") }
+                }
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `request without Origin header is ignored`() =
+        setup { client ->
+            val response = client.post("/t/oriana/protocol/openid-connect/token")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+
+    @Test
+    fun `origin null from sandboxed context is treated as no origin`() =
+        setup { client ->
+            val response =
+                client.post("/t/oriana/protocol/openid-connect/token") {
+                    headers { append(HttpHeaders.Origin, "null") }
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertNull(response.headers[HttpHeaders.AccessControlAllowOrigin])
+        }
+}

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -13,6 +13,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeCorsPort
 import com.kauth.fakes.FakeEmailPort
 import com.kauth.fakes.FakeEmailVerificationTokenRepository
 import com.kauth.fakes.FakePasswordHasher
@@ -600,6 +601,70 @@ class AdminServiceTest {
         val result = svc.setApplicationEnabled(appId = ApplicationId(100), tenantId = TenantId(1), enabled = false)
         assertIs<AdminResult.Success<Unit>>(result)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_DISABLED))
+    }
+
+    // =========================================================================
+    // CORS cache invalidation hooks
+    // =========================================================================
+
+    /** Builds a service variant with an observable [FakeCorsPort] wired in. */
+    private fun svcWithCors(corsPort: FakeCorsPort): AdminService =
+        AdminService(
+            tenantRepository = tenants,
+            userRepository = users,
+            applicationRepository = apps,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessions,
+            selfServiceService = selfService,
+            passwordPolicy = passwordPolicy,
+            corsPort = corsPort,
+        )
+
+    @Test
+    fun `updateWorkspaceSettings invalidates CORS cache for tenant slug`() {
+        val corsPort = FakeCorsPort()
+        val result =
+            svcWithCors(corsPort).updateWorkspaceSettings(
+                slug = "acme",
+                displayName = "Acme Corp",
+                issuerUrl = null,
+                tokenExpirySeconds = 3600L,
+                refreshTokenExpirySeconds = 86400L,
+                registrationEnabled = true,
+                emailVerificationRequired = false,
+                passwordPolicyMinLength = 8,
+                passwordPolicyRequireSpecial = false,
+                mfaPolicy = "optional",
+            )
+        assertIs<AdminResult.Success<Tenant>>(result)
+        assertEquals(listOf("acme"), corsPort.invalidated)
+    }
+
+    @Test
+    fun `updateApplication invalidates CORS cache for tenant slug`() {
+        val corsPort = FakeCorsPort()
+        val result =
+            svcWithCors(corsPort).updateApplication(
+                appId = ApplicationId(100),
+                tenantId = TenantId(1),
+                name = "Renamed",
+            )
+        assertIs<AdminResult.Success<Application>>(result)
+        assertEquals(listOf("acme"), corsPort.invalidated)
+    }
+
+    @Test
+    fun `setApplicationEnabled invalidates CORS cache for tenant slug`() {
+        val corsPort = FakeCorsPort()
+        val result =
+            svcWithCors(corsPort).setApplicationEnabled(
+                appId = ApplicationId(100),
+                tenantId = TenantId(1),
+                enabled = false,
+            )
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(listOf("acme"), corsPort.invalidated)
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/CorsServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/CorsServiceTest.kt
@@ -1,0 +1,176 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.CorsDecision
+import com.kauth.fakes.FakeCorsPort
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CorsServiceTest {
+    private val cors = FakeCorsPort()
+    private val service = CorsService(cors)
+
+    @BeforeTest
+    fun reset() {
+        cors.removePolicy("oriana")
+        cors.removePolicy("acme")
+    }
+
+    @Test
+    fun `discovery endpoint is public regardless of origin or tenant`() {
+        val decision =
+            service.decide(
+                tenantSlug = "unknown",
+                origin = "https://anywhere.example.com",
+                endpointPath = "/.well-known/openid-configuration",
+            )
+        assertEquals(CorsDecision.Public, decision)
+    }
+
+    @Test
+    fun `jwks endpoint is public regardless of origin or tenant`() {
+        val decision =
+            service.decide(
+                tenantSlug = "unknown",
+                origin = "https://anywhere.example.com",
+                endpointPath = "/protocol/openid-connect/certs",
+            )
+        assertEquals(CorsDecision.Public, decision)
+    }
+
+    @Test
+    fun `unknown tenant denies non-public endpoints`() {
+        val decision =
+            service.decide(
+                tenantSlug = "does-not-exist",
+                origin = "https://desk.oriana-platform.orb.local",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(CorsDecision.Denied, decision)
+    }
+
+    @Test
+    fun `known tenant with matching origin is allowed`() {
+        cors.setPolicy("oriana", setOf("https://desk.oriana-platform.orb.local"))
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://desk.oriana-platform.orb.local",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(
+            CorsDecision.Allowed("https://desk.oriana-platform.orb.local", allowCredentials = false),
+            decision,
+        )
+    }
+
+    @Test
+    fun `known tenant with non-matching origin is denied`() {
+        cors.setPolicy("oriana", setOf("https://desk.oriana-platform.orb.local"))
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://evil.example.com",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(CorsDecision.Denied, decision)
+    }
+
+    @Test
+    fun `tenant with allow_credentials enabled propagates to decision`() {
+        cors.setPolicy(
+            "oriana",
+            setOf("https://desk.oriana-platform.orb.local"),
+            allowCredentials = true,
+        )
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://desk.oriana-platform.orb.local",
+                endpointPath = "/protocol/openid-connect/userinfo",
+            )
+        assertEquals(
+            CorsDecision.Allowed("https://desk.oriana-platform.orb.local", allowCredentials = true),
+            decision,
+        )
+    }
+
+    @Test
+    fun `tenant with no registered origins denies everything non-public`() {
+        cors.setPolicy("oriana", emptySet())
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://desk.oriana-platform.orb.local",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(CorsDecision.Denied, decision)
+    }
+
+    @Test
+    fun `origin matching is exact - subdomain mismatch denied`() {
+        cors.setPolicy("oriana", setOf("https://desk.oriana-platform.orb.local"))
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://evil.desk.oriana-platform.orb.local",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(CorsDecision.Denied, decision)
+    }
+
+    @Test
+    fun `origin matching is exact - port mismatch denied`() {
+        cors.setPolicy("oriana", setOf("https://desk.oriana-platform.orb.local"))
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "https://desk.oriana-platform.orb.local:8443",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(CorsDecision.Denied, decision)
+    }
+
+    @Test
+    fun `localhost dev origin works when explicitly registered`() {
+        cors.setPolicy("oriana", setOf("http://localhost:3000"))
+
+        val decision =
+            service.decide(
+                tenantSlug = "oriana",
+                origin = "http://localhost:3000",
+                endpointPath = "/protocol/openid-connect/token",
+            )
+        assertEquals(
+            CorsDecision.Allowed("http://localhost:3000", allowCredentials = false),
+            decision,
+        )
+    }
+
+    @Test
+    fun `multiple origins in policy - any registered origin matches`() {
+        cors.setPolicy(
+            "oriana",
+            setOf(
+                "https://desk.oriana-platform.orb.local",
+                "http://localhost:3000",
+                "https://staging.oriana-platform.orb.local",
+            ),
+        )
+
+        setOf(
+            "https://desk.oriana-platform.orb.local",
+            "http://localhost:3000",
+            "https://staging.oriana-platform.orb.local",
+        ).forEach { origin ->
+            val decision = service.decide("oriana", origin, "/protocol/openid-connect/token")
+            assertEquals(CorsDecision.Allowed(origin, allowCredentials = false), decision)
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeCorsPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeCorsPort.kt
@@ -1,0 +1,34 @@
+package com.kauth.fakes
+
+import com.kauth.domain.port.CorsPolicy
+import com.kauth.domain.port.CorsPort
+
+class FakeCorsPort : CorsPort {
+    private val policies = mutableMapOf<String, CorsPolicy>()
+    private val _invalidated = mutableListOf<String>()
+
+    /** Slugs that have been passed to [invalidate] since the last [clearInvalidated] call. */
+    val invalidated: List<String> get() = _invalidated.toList()
+
+    fun setPolicy(
+        tenantSlug: String,
+        allowedOrigins: Set<String>,
+        allowCredentials: Boolean = false,
+    ) {
+        policies[tenantSlug] = CorsPolicy(allowedOrigins, allowCredentials)
+    }
+
+    fun removePolicy(tenantSlug: String) {
+        policies.remove(tenantSlug)
+    }
+
+    fun clearInvalidated() {
+        _invalidated.clear()
+    }
+
+    override fun policyForTenant(tenantSlug: String): CorsPolicy? = policies[tenantSlug]
+
+    override fun invalidate(tenantSlug: String) {
+        _invalidated.add(tenantSlug)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a comprehensive multi-tenant CORS (Cross-Origin Resource Sharing) policy to the project, enabling browser-based SPAs to interact securely with OIDC endpoints on a per-tenant basis. CORS origins are now dynamically derived from registered OIDC client redirect URIs, and a new per-tenant toggle allows opt-in support for credentialed cross-origin requests. The implementation includes a new Ktor plugin, in-process caching, database migration, and admin UI/UX updates to support these features.

**Multi-Tenant CORS Policy Implementation:**

- **Dynamic CORS Origin Allowlist:** Each tenant’s allowed CORS origins are automatically derived from the origins of registered, enabled OIDC client redirect URIs. This ensures that only operator-approved SPAs can make cross-origin requests to sensitive endpoints. Public endpoints (discovery and JWKS) remain globally readable. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R21) [[2]](diffhunk://#diff-178b7c0cd80343df97c892f5ffd11b473ac634f8a5a96823b17437c297737a27R1-R54)
- **New Ktor Plugin and Caching:** Introduced `TenantCorsPlugin` (route-scoped Ktor plugin) and `CorsOriginCache` (with 60s TTL) to efficiently enforce CORS policies per tenant and invalidate cache on relevant admin mutations. [[1]](diffhunk://#diff-178b7c0cd80343df97c892f5ffd11b473ac634f8a5a96823b17437c297737a27R1-R54) [[2]](diffhunk://#diff-dc5b9b2ad62364406fbfd73830ed60387706bd9d9aa1faa8eac38e57614e36a4R1-R59)

**Admin and API Integration:**

- **Admin UI and Service Updates:** The admin UI now surfaces a "Send credentials cross-origin" toggle per tenant, and form hints clarify that redirect URI origins are automatically CORS-allowed. Admin service and route handlers have been updated to propagate CORS policy changes and invalidate the cache as needed. [[1]](diffhunk://#diff-47522b97f4d91fde53545fd9aa82e27e26d7aacc6d897fdb124b708a0fa9d604R323) [[2]](diffhunk://#diff-cf4ffcba6d2bd0d8bbd8c0b13f674db6b81ca78f33517dbe1b6e0968ecd45df4L344-R347) [[3]](diffhunk://#diff-cf4ffcba6d2bd0d8bbd8c0b13f674db6b81ca78f33517dbe1b6e0968ecd45df4L496-R502) [[4]](diffhunk://#diff-c61dc0bb14b43172d4c97b63f69b62bdc4582bfcfe2683956a381014f3578697R778-R796) [[5]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R352) [[6]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R376) [[7]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R400) [[8]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R4) [[9]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R23) [[10]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R85) [[11]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR13) [[12]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR71) [[13]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR477)

**Persistence and Migration:**

- **Database Schema Changes:** Added a `cors_allow_credentials` boolean column to `tenant_security_config` (with migration V32) and updated the persistence layer to read/write this property for each tenant. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R21) [[2]](diffhunk://#diff-fb39c7bef8ec3227338925b11cf788d9fe90dfacf1625079a995fd5be441f9a9R26) [[3]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R124) [[4]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R139) [[5]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R217)

**Documentation:**

- **Architectural Decision Record:** Added ADR-08, documenting the rationale, alternatives, and implementation details of the multi-tenant CORS policy.

**API Layer Integration:**

- **API Route Wiring:** Integrated the new CORS service and plugin into the API routes to ensure enforcement across all relevant endpoints. [[1]](diffhunk://#diff-56e8c7296306e6e922635a0b7e251731ef356e49c16bfb50bf882a6277f8471aR3) [[2]](diffhunk://#diff-56e8c7296306e6e922635a0b7e251731ef356e49c16bfb50bf882a6277f8471aR12)

These changes collectively enable secure, scalable, and operator-friendly CORS handling for multi-tenant OIDC deployments, with clear admin controls and robust caching/invalidation.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
