### PR TITLE
feature/user-attributes-claim-mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.6.0-rc1] - 2026-04-24
+
+### Added
+
+- **Custom user attributes + JWT claim mapping** — per-user string key/value metadata that admins (or a billing integration) can project into issued JWTs with configurable claim names. Inspired by Keycloak's "User Attributes + Protocol Mappers" and Auth0's `app_metadata`, but deliberately simpler: declarative string-to-string projection only, no scripting, no conditional logic. Enables use cases like `custom:plan = pro`, `custom:trial_ends = 2026-05-21`, `custom:sifen_env = production` flowing through the access/id tokens SPAs and APIs consume. Attribute changes propagate on the next token issuance — worst-case staleness bounded by the 60-second mapper cache TTL
+- **`user_attributes` table** (V33 migration) — per-user key/value with cascade-on-user-delete, `PRIMARY KEY (user_id, key)`, max 64-char key, max 1024-char value (DB `CHECK` constraint + service-layer validation). `idx_user_attributes_tenant_user` covers the hot "all attributes for user X" lookup on token issuance
+- **`tenant_claim_mappers` table** (V34 migration) — tenant-level mapping `(tenant_id, attribute_key) → (claim_name, include_in_access, include_in_id)`. `UNIQUE INDEX (tenant_id, claim_name)` enforces one attribute per claim name within a tenant (race-safe defense-in-depth alongside service validation)
+- **`UserAttribute` + `TenantClaimMapper` domain models** with `MAX_KEY_LENGTH = 64`, `MAX_VALUE_LENGTH = 1024`, `MAX_CLAIM_NAME_LENGTH = 128`, `MAX_MAPPERS_PER_TENANT = 20` (soft cap preventing JWT bloat)
+- **`UserAttributeRepository` + `TenantClaimMapperRepository` ports** — hexagonal separation; Postgres adapters backed by Exposed
+- **`UserAttributeService` + `ClaimMapperService`** domain services with sealed `AttributeResult<T>` type (`Success`, `NotFound`, `ValidationError`, `ReservedClaimName`, `DuplicateClaimName`, `LimitReached`). Reserved OIDC/proprietary claim-name blocklist enforced at write time: 41 names including `sub`, `iss`, `aud`, `exp`, `iat`, `email`, `tenant_id`, `realm_access`, etc. The `projectClaims(mappers, attributes, tokenType)` pure function is the token-issuance hot path — no I/O, safe to call per-token
+- **`CachingClaimMapperService`** infrastructure decorator — 60-second TTL on mapper reads, self-invalidating on writes via a `ClaimMapperCacheInvalidator` fun interface. Pluggable clock for deterministic tests. Cross-tenant isolation: invalidating tenant A's cache doesn't disturb tenant B's
+- **`TokenPort.issueUserTokens` signature extended** with `customAccessClaims: Map<String, String>` and `customIdClaims: Map<String, String>` (both default `emptyMap()` — preserves byte-identical token shape for callers that don't opt in). `JwtTokenAdapter` stamps each map entry onto the appropriate `JWT.create()` builder after roles, before signing. `OAuthService` projects claims via a lambda `(TenantId) -> List<TenantClaimMapper>` injected from the composition root — keeps infrastructure caching out of the domain
+- **Refresh-token flow re-projects claims on every call** — billing systems that flip `plan = trial → pro` see the new claim value in the next refreshed access token, not at the next full login
+- **REST API — 6 endpoints** under `/t/{slug}/api/v1/`: `GET /users/{userId}/attributes`, `PUT/DELETE /users/{userId}/attributes/{key}`, `GET /claim-mappers`, `PUT/DELETE /claim-mappers/{attributeKey}`. 4 new API scopes: `user_attributes:read`, `user_attributes:write`, `claim_mappers:read`, `claim_mappers:write`. Error responses follow RFC 7807 (`application/problem+json`): reserved claim → 400, validation → 422, duplicate claim name → 409, tenant cap → 409
+- **Admin UI — User Attributes section** on the user detail page (between Profile and Active Sessions): table with key/value/edit/delete, "Configure mapping →" link for unmapped keys, `→ custom:claim` badge for mapped keys, delete-confirm copy that dynamically warns about mapper impact
+- **Admin UI — Claim Mappers settings page** at `/admin/workspaces/{slug}/settings/claim-mappers` with sidebar link after Webhooks. Table: attribute key, claim name, Access Token Yes/No badge, ID Token Yes/No badge, Delete. Dedicated New/Edit pages with readonly attribute-key field in edit mode, checkbox toggles for `includeInAccess`/`includeInId`, inline hints pointing to reserved-claim list
+- **OpenAPI v1 spec updated** — 6 new endpoint definitions, 5 new schemas (`UserAttributesDto`, `UpsertUserAttributeRequest`, `ClaimMapperDto`, `ClaimMappersDto`, `UpsertClaimMapperRequest`), 2 new tags (User Attributes, Claim Mappers), PII-in-JWT warning prominent in the feature description
+- **79 new domain/service tests** — `UserAttributeServiceTest` (15), `ClaimMapperServiceTest` (17), `CachingClaimMapperServiceTest` (7), `TokenClaimMappingTest` (12 integration covering full acceptance criteria: attribute+mapper → claim in token, DELETE attribute → claim absent, DELETE mapper → claim absent, zero mappers → byte-identical token, refresh-token re-projection, cross-tenant isolation). 26 new REST API tests (`ApiUserAttributeRoutesTest` + `ApiClaimMapperRoutesTest`). 10 new admin UI tests (`AdminUserAttributesAndClaimMappersTest`)
+
+### Changed
+
+- **`JwtTokenAdapter.issueUserTokens` now takes two extra parameters** (`customAccessClaims`, `customIdClaims`). Both default to `emptyMap()` — existing call sites that do not pass them receive the pre-feature token shape verbatim
+- **`OAuthService` constructor** gained optional `userAttributeRepository: UserAttributeRepository? = null` and `claimMappersFor: (TenantId) -> List<TenantClaimMapper> = { _ -> emptyList() }` parameters. Default-null wiring ensures existing `OAuthService(...)` callers in tests continue to compile and produce zero custom claims
+- **`adminRoutes()` signature** gained required `userAttributeService` + `claimMapperService` parameters. Existing admin test fixtures updated
+- **`ServiceGraph`** wires `UserAttributeService` and `CachingClaimMapperService` and exposes them as fields. The caching decorator registers itself as the `ClaimMapperCacheInvalidator` of its own wrapped `ClaimMapperService` — writes immediately drop the cached mapper list for that tenant
+
+### Security
+
+- **Reserved claim-name blocklist** prevents admins from stomping on standard OIDC and KotAuth-proprietary claims. Attempts return `400 Bad Request` with a specific claim name in the error body, both via API and admin UI
+- **Tenant-scoped `UNIQUE INDEX (tenant_id, claim_name)`** on `tenant_claim_mappers` closes a TOCTOU race between service-layer validation and DB insert — two concurrent writes mapping different attribute keys to the same claim name cannot both succeed
+- **PII warning** added prominently to OpenAPI spec and embedded in admin UI hints: "Attribute values flow unencrypted into JWTs, which are base64-decodable by anyone in possession of the token."
+- **20-mapper soft cap per tenant** prevents JWT-size abuse from admins configuring dozens of claim projections
+
+### Infrastructure
+
+- **Dependency wiring is self-invalidating** — `CachingClaimMapperService` implements `ClaimMapperCacheInvalidator` itself, passes `this` to the wrapped domain `ClaimMapperService` at construction. No mutable lateinit, no circular-reference workarounds
+
+---
+
 ## [1.5.8] - 2026-04-22
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.5.8"
+version = "1.6.0"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
+++ b/src/e2eTest/kotlin/com/kauth/e2e/E2ETestBase.kt
@@ -205,6 +205,15 @@ abstract class E2ETestBase {
                             webhookService = buildWebhookService(),
                             encryptionService = encryptionService,
                             roleRepository = roleRepo,
+                            userAttributeService =
+                                com.kauth.domain.service.UserAttributeService(
+                                    userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                                    userRepository = userRepo,
+                                ),
+                            claimMapperService =
+                                com.kauth.infrastructure.CachingClaimMapperService(
+                                    mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                                ),
                         )
                     }
                 }

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -370,6 +370,8 @@ fun Application.module(
             auditLogRepository = s.auditLogRepository,
             roleGroupService = s.roleGroupService,
             adminService = s.adminService,
+            userAttributeService = s.userAttributeService,
+            claimMapperService = s.claimMapperService,
             corsService = s.corsService,
         )
 

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -396,6 +396,8 @@ fun Application.module(
             roleRepository = s.roleRepository,
             keyRotationService = s.keyRotationService,
             tenantKeyRepository = s.tenantKeyRepository,
+            userAttributeService = s.userAttributeService,
+            claimMapperService = s.claimMapperService,
             corsPort = s.corsOriginCache,
             baseUrl = config.baseUrl,
         )

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantClaimMapperRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantClaimMapperRepository.kt
@@ -1,0 +1,76 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.TenantClaimMapperRepository
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+class PostgresTenantClaimMapperRepository : TenantClaimMapperRepository {
+    override fun findAll(tenantId: TenantId): List<TenantClaimMapper> =
+        transaction {
+            TenantClaimMappersTable
+                .selectAll()
+                .where { TenantClaimMappersTable.tenantId eq tenantId.value }
+                .orderBy(TenantClaimMappersTable.attributeKey to SortOrder.ASC)
+                .map { it.toMapper() }
+        }
+
+    override fun upsert(mapper: TenantClaimMapper) {
+        transaction {
+            val existing =
+                TenantClaimMappersTable
+                    .selectAll()
+                    .where {
+                        (TenantClaimMappersTable.tenantId eq mapper.tenantId.value) and
+                            (TenantClaimMappersTable.attributeKey eq mapper.attributeKey)
+                    }.any()
+
+            if (existing) {
+                TenantClaimMappersTable.update({
+                    (TenantClaimMappersTable.tenantId eq mapper.tenantId.value) and
+                        (TenantClaimMappersTable.attributeKey eq mapper.attributeKey)
+                }) {
+                    it[claimName] = mapper.claimName
+                    it[includeInAccess] = mapper.includeInAccess
+                    it[includeInId] = mapper.includeInId
+                }
+            } else {
+                TenantClaimMappersTable.insert {
+                    it[tenantId] = mapper.tenantId.value
+                    it[attributeKey] = mapper.attributeKey
+                    it[claimName] = mapper.claimName
+                    it[includeInAccess] = mapper.includeInAccess
+                    it[includeInId] = mapper.includeInId
+                }
+            }
+        }
+    }
+
+    override fun delete(
+        tenantId: TenantId,
+        attributeKey: String,
+    ): Boolean =
+        transaction {
+            TenantClaimMappersTable.deleteWhere {
+                (TenantClaimMappersTable.tenantId eq tenantId.value) and
+                    (TenantClaimMappersTable.attributeKey eq attributeKey)
+            } > 0
+        }
+
+    private fun ResultRow.toMapper(): TenantClaimMapper =
+        TenantClaimMapper(
+            tenantId = TenantId(this[TenantClaimMappersTable.tenantId]),
+            attributeKey = this[TenantClaimMappersTable.attributeKey],
+            claimName = this[TenantClaimMappersTable.claimName],
+            includeInAccess = this[TenantClaimMappersTable.includeInAccess],
+            includeInId = this[TenantClaimMappersTable.includeInId],
+        )
+}

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserAttributeRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserAttributeRepository.kt
@@ -1,0 +1,98 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.UserAttributeRepository
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class PostgresUserAttributeRepository : UserAttributeRepository {
+    override fun findAll(
+        userId: UserId,
+        tenantId: TenantId,
+    ): Map<String, String> =
+        transaction {
+            UserAttributesTable
+                .selectAll()
+                .where {
+                    (UserAttributesTable.userId eq userId.value) and
+                        (UserAttributesTable.tenantId eq tenantId.value)
+                }.associate { it[UserAttributesTable.key] to it[UserAttributesTable.value] }
+        }
+
+    override fun upsert(attribute: UserAttribute) {
+        transaction {
+            val updatedAt = OffsetDateTime.ofInstant(attribute.updatedAt, ZoneOffset.UTC)
+            val existing =
+                UserAttributesTable
+                    .selectAll()
+                    .where {
+                        (UserAttributesTable.userId eq attribute.userId.value) and
+                            (UserAttributesTable.key eq attribute.key)
+                    }.any()
+
+            if (existing) {
+                UserAttributesTable.update({
+                    (UserAttributesTable.userId eq attribute.userId.value) and
+                        (UserAttributesTable.key eq attribute.key)
+                }) {
+                    it[value] = attribute.value
+                    it[this.updatedAt] = updatedAt
+                    it[tenantId] = attribute.tenantId.value
+                }
+            } else {
+                UserAttributesTable.insert {
+                    it[userId] = attribute.userId.value
+                    it[tenantId] = attribute.tenantId.value
+                    it[key] = attribute.key
+                    it[value] = attribute.value
+                    it[this.updatedAt] = updatedAt
+                }
+            }
+        }
+    }
+
+    override fun delete(
+        userId: UserId,
+        tenantId: TenantId,
+        key: String,
+    ): Boolean =
+        transaction {
+            UserAttributesTable.deleteWhere {
+                (UserAttributesTable.userId eq userId.value) and
+                    (UserAttributesTable.tenantId eq tenantId.value) and
+                    (UserAttributesTable.key eq key)
+            } > 0
+        }
+
+    override fun deleteAllForUser(
+        userId: UserId,
+        tenantId: TenantId,
+    ) {
+        transaction {
+            UserAttributesTable.deleteWhere {
+                (UserAttributesTable.userId eq userId.value) and
+                    (UserAttributesTable.tenantId eq tenantId.value)
+            }
+        }
+    }
+
+    @Suppress("unused")
+    private fun ResultRow.toUserAttribute(): UserAttribute =
+        UserAttribute(
+            userId = UserId(this[UserAttributesTable.userId]),
+            tenantId = TenantId(this[UserAttributesTable.tenantId]),
+            key = this[UserAttributesTable.key],
+            value = this[UserAttributesTable.value],
+            updatedAt = this[UserAttributesTable.updatedAt].toInstant(),
+        )
+}

--- a/src/main/kotlin/com/kauth/adapter/persistence/TenantClaimMappersTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/TenantClaimMappersTable.kt
@@ -1,0 +1,17 @@
+package com.kauth.adapter.persistence
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * Exposed mapping for 'tenant_claim_mappers' (V34 migration).
+ * Schema is Flyway-owned — no constraint declarations here.
+ */
+object TenantClaimMappersTable : Table("tenant_claim_mappers") {
+    val tenantId = integer("tenant_id")
+    val attributeKey = varchar("attribute_key", 64)
+    val claimName = varchar("claim_name", 128)
+    val includeInAccess = bool("include_in_access").default(true)
+    val includeInId = bool("include_in_id").default(false)
+
+    override val primaryKey = PrimaryKey(tenantId, attributeKey)
+}

--- a/src/main/kotlin/com/kauth/adapter/persistence/UserAttributesTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/UserAttributesTable.kt
@@ -1,0 +1,18 @@
+package com.kauth.adapter.persistence
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.javatime.timestampWithTimeZone
+
+/**
+ * Exposed mapping for 'user_attributes' (V33 migration).
+ * Schema is Flyway-owned — no constraint declarations here.
+ */
+object UserAttributesTable : Table("user_attributes") {
+    val userId = integer("user_id")
+    val tenantId = integer("tenant_id")
+    val key = varchar("key", 64)
+    val value = text("value")
+    val updatedAt = timestampWithTimeZone("updated_at")
+
+    override val primaryKey = PrimaryKey(userId, key)
+}

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -65,6 +65,8 @@ class JwtTokenAdapter(
         scopes: List<String>,
         nonce: String?,
         roles: List<Role>,
+        customAccessClaims: Map<String, String>,
+        customIdClaims: Map<String, String>,
     ): TokenResponse {
         val activeKey = getOrCreateAlgorithm(tenant.id.value)
         val issuer = issuerFor(tenant)
@@ -128,6 +130,11 @@ class JwtTokenAdapter(
             }
         }
 
+        // Stamp tenant-configured custom claims (see ClaimMapperService).
+        for ((claimName, value) in customAccessClaims) {
+            accessTokenBuilder.withClaim(claimName, value)
+        }
+
         val accessToken = accessTokenBuilder.sign(activeKey.algorithm)
 
         val idToken =
@@ -143,7 +150,11 @@ class JwtTokenAdapter(
                     .withClaim("name", user.fullName)
                     .withClaim("preferred_username", user.username)
                     .apply { if (nonce != null) withClaim("nonce", nonce) }
-                    .withIssuedAt(Date())
+                    .apply {
+                        for ((claimName, value) in customIdClaims) {
+                            withClaim(claimName, value)
+                        }
+                    }.withIssuedAt(Date())
                     .withExpiresAt(expiresAt)
                     .sign(activeKey.algorithm)
             } else {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminClaimMapperRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminClaimMapperRoutes.kt
@@ -1,0 +1,176 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.service.AttributeResult
+import com.kauth.infrastructure.CachingClaimMapperService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.html.respondHtml
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+
+fun Route.adminClaimMapperRoutes(claimMapperService: CachingClaimMapperService) {
+    // ── List ────────────────────────────────────────────────────────────
+    get("/settings/claim-mappers") {
+        val ctx = call.adminContext()
+        val mappers = claimMapperService.list(ctx.workspace.id)
+        val toastMsg =
+            when (call.request.queryParameters["saved"]) {
+                "created" -> "Claim mapper created."
+                "updated" -> "Claim mapper updated."
+                "deleted" -> "Claim mapper deleted."
+                else -> null
+            }
+        call.respondHtml(
+            HttpStatusCode.OK,
+            AdminView.claimMappersListPage(
+                workspace = ctx.workspace,
+                allWorkspaces = ctx.wsPairs,
+                loggedInAs = ctx.session.username,
+                mappers = mappers,
+                toastMessage = toastMsg,
+            ),
+        )
+    }
+
+    // ── New mapper form ─────────────────────────────────────────────────
+    get("/settings/claim-mappers/new") {
+        val ctx = call.adminContext()
+        val prefilledKey = call.request.queryParameters["attributeKey"]
+        val prefill =
+            if (prefilledKey != null) {
+                TenantClaimMapper(
+                    tenantId = ctx.workspace.id,
+                    attributeKey = prefilledKey,
+                    claimName = "",
+                )
+            } else {
+                null
+            }
+        call.respondHtml(
+            HttpStatusCode.OK,
+            AdminView.claimMapperFormPage(
+                workspace = ctx.workspace,
+                allWorkspaces = ctx.wsPairs,
+                loggedInAs = ctx.session.username,
+                prefill = prefill,
+            ),
+        )
+    }
+
+    // ── Edit mapper form ────────────────────────────────────────────────
+    get("/settings/claim-mappers/{attributeKey}/edit") {
+        val ctx = call.adminContext()
+        val attributeKey =
+            call.parameters["attributeKey"]
+                ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val existing =
+            claimMapperService.list(ctx.workspace.id).firstOrNull { it.attributeKey == attributeKey }
+                ?: return@get call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/settings/claim-mappers",
+                )
+        call.respondHtml(
+            HttpStatusCode.OK,
+            AdminView.claimMapperFormPage(
+                workspace = ctx.workspace,
+                allWorkspaces = ctx.wsPairs,
+                loggedInAs = ctx.session.username,
+                prefill = existing,
+            ),
+        )
+    }
+
+    // ── Create (POST) ───────────────────────────────────────────────────
+    post("/settings/claim-mappers") {
+        val ctx = call.adminContext()
+        val params = call.receiveParameters()
+        val mapper = parseMapperForm(ctx.workspace.id, params)
+
+        when (val result = claimMapperService.upsert(mapper)) {
+            is AttributeResult.Success ->
+                call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/settings/claim-mappers?saved=created",
+                )
+            else ->
+                call.respondHtml(
+                    HttpStatusCode.UnprocessableEntity,
+                    AdminView.claimMapperFormPage(
+                        workspace = ctx.workspace,
+                        allWorkspaces = ctx.wsPairs,
+                        loggedInAs = ctx.session.username,
+                        prefill = mapper,
+                        error = errorMessage(result),
+                    ),
+                )
+        }
+    }
+
+    // ── Update (POST) ───────────────────────────────────────────────────
+    post("/settings/claim-mappers/{attributeKey}") {
+        val ctx = call.adminContext()
+        val attributeKey =
+            call.parameters["attributeKey"]
+                ?: return@post call.respond(HttpStatusCode.BadRequest)
+        val params = call.receiveParameters()
+        val mapper = parseMapperForm(ctx.workspace.id, params).copy(attributeKey = attributeKey)
+
+        when (val result = claimMapperService.upsert(mapper)) {
+            is AttributeResult.Success ->
+                call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/settings/claim-mappers?saved=updated",
+                )
+            else ->
+                call.respondHtml(
+                    HttpStatusCode.UnprocessableEntity,
+                    AdminView.claimMapperFormPage(
+                        workspace = ctx.workspace,
+                        allWorkspaces = ctx.wsPairs,
+                        loggedInAs = ctx.session.username,
+                        prefill = mapper,
+                        error = errorMessage(result),
+                    ),
+                )
+        }
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────────
+    post("/settings/claim-mappers/{attributeKey}/delete") {
+        val ctx = call.adminContext()
+        val attributeKey =
+            call.parameters["attributeKey"]
+                ?: return@post call.respond(HttpStatusCode.BadRequest)
+        claimMapperService.delete(ctx.workspace.id, attributeKey)
+        call.respondRedirect(
+            "/admin/workspaces/${ctx.slug}/settings/claim-mappers?saved=deleted",
+        )
+    }
+}
+
+private fun parseMapperForm(
+    tenantId: com.kauth.domain.model.TenantId,
+    params: io.ktor.http.Parameters,
+): TenantClaimMapper =
+    TenantClaimMapper(
+        tenantId = tenantId,
+        attributeKey = params["attributeKey"]?.trim().orEmpty(),
+        claimName = params["claimName"]?.trim().orEmpty(),
+        includeInAccess = params["includeInAccess"] == "true",
+        includeInId = params["includeInId"] == "true",
+    )
+
+private fun errorMessage(result: AttributeResult<*>): String =
+    when (result) {
+        is AttributeResult.Success<*> -> "Unexpected internal state."
+        is AttributeResult.ValidationError -> result.reason
+        is AttributeResult.NotFound -> "${result.resource} not found."
+        is AttributeResult.ReservedClaimName ->
+            "Claim name '${result.claimName}' is reserved by OIDC/KotAuth. " +
+                "Use a custom prefix, e.g. 'custom:${result.claimName}'."
+        is AttributeResult.DuplicateClaimName ->
+            "Another attribute in this tenant already maps to claim name '${result.claimName}'."
+        is AttributeResult.LimitReached ->
+            "This tenant has reached the maximum of ${result.max} claim mappers."
+    }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -68,6 +68,8 @@ fun Route.adminRoutes(
     roleRepository: RoleRepository? = null,
     keyRotationService: KeyRotationService? = null,
     tenantKeyRepository: TenantKeyRepository? = null,
+    userAttributeService: com.kauth.domain.service.UserAttributeService,
+    claimMapperService: com.kauth.infrastructure.CachingClaimMapperService,
     corsPort: CorsPort? = null,
     baseUrl: String = "",
 ) {
@@ -481,6 +483,8 @@ fun Route.adminRoutes(
                     adminService = adminService,
                     roleGroupService = roleGroupService,
                     sessionRepository = sessionRepository,
+                    userAttributeService = userAttributeService,
+                    claimMapperService = claimMapperService,
                 )
 
                 adminSessionAuditRoutes(
@@ -510,6 +514,10 @@ fun Route.adminRoutes(
                         tenantKeyRepository = tenantKeyRepository,
                     )
                 }
+
+                adminClaimMapperRoutes(
+                    claimMapperService = claimMapperService,
+                )
             }
         }
     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminShell.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminShell.kt
@@ -424,4 +424,5 @@ internal fun DIV.renderSettingsCtxPanel(
     div("sidebar__divider") {}
     ctxLink("$base/api-keys", "api-keys", activeSection, "API Keys")
     ctxLink("$base/webhooks", "webhooks", activeSection, "Webhooks")
+    ctxLink("$base/claim-mappers", "claim-mappers", activeSection, "Claim Mappers")
 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -5,10 +5,12 @@ import com.kauth.domain.model.UserId
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.AttributeResult
 import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserAttributeService
+import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
 import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respond
@@ -23,6 +25,8 @@ fun Route.adminUserRoutes(
     adminService: AdminService,
     roleGroupService: RoleGroupService,
     sessionRepository: SessionRepository,
+    userAttributeService: UserAttributeService,
+    claimMapperService: CachingClaimMapperService,
 ) {
     route("/users") {
         get {
@@ -119,6 +123,14 @@ fun Route.adminUserRoutes(
                 val sessions = sessionRepository.findActiveByUser(ctx.workspace.id, userId)
                 val userRoles = roleGroupService.getRolesForUser(userId)
                 val userGroups = roleGroupService.getGroupsForUser(userId)
+                val attributes =
+                    (userAttributeService.list(userId, ctx.workspace.id) as? AttributeResult.Success)
+                        ?.value
+                        ?: emptyMap()
+                val mappedKeys =
+                    claimMapperService
+                        .list(ctx.workspace.id)
+                        .associate { it.attributeKey to it.claimName }
                 val savedParam = call.request.queryParameters["saved"]
                 val successMsg =
                     when (savedParam) {
@@ -131,6 +143,8 @@ fun Route.adminUserRoutes(
                         "verification_sent" -> EnglishStrings.TOAST_VERIFICATION_SENT
                         "invite_sent" -> EnglishStrings.TOAST_INVITE_SENT
                         "invite_resent" -> EnglishStrings.TOAST_INVITE_RESENT
+                        "attribute_saved" -> "Attribute saved."
+                        "attribute_deleted" -> "Attribute deleted."
                         else -> null
                     }
                 val errorParam =
@@ -152,6 +166,8 @@ fun Route.adminUserRoutes(
                         editError = errorParam,
                         roles = userRoles,
                         groups = userGroups,
+                        userAttributes = attributes,
+                        mappedKeys = mappedKeys,
                     ),
                 )
             }
@@ -356,6 +372,168 @@ fun Route.adminUserRoutes(
                         )
                 }
             }
+
+            // ── Attributes: new form ────────────────────────────────────
+            get("/attributes/new") {
+                val ctx = call.adminContext()
+                val userId =
+                    call.parameters.typedId("userId", ::UserId)
+                        ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val user =
+                    when (val r = adminService.getUser(userId, ctx.workspace.id)) {
+                        is AdminResult.Success -> r.value
+                        is AdminResult.Failure -> return@get call.respond(HttpStatusCode.NotFound)
+                    }
+                call.respondHtml(
+                    HttpStatusCode.OK,
+                    AdminView.userAttributeFormPage(
+                        workspace = ctx.workspace,
+                        user = user,
+                        allWorkspaces = ctx.wsPairs,
+                        loggedInAs = ctx.session.username,
+                    ),
+                )
+            }
+
+            // ── Attributes: edit form ───────────────────────────────────
+            get("/attributes/{attrKey}/edit") {
+                val ctx = call.adminContext()
+                val userId =
+                    call.parameters.typedId("userId", ::UserId)
+                        ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val attrKey =
+                    call.parameters["attrKey"]
+                        ?: return@get call.respond(HttpStatusCode.BadRequest)
+                val user =
+                    when (val r = adminService.getUser(userId, ctx.workspace.id)) {
+                        is AdminResult.Success -> r.value
+                        is AdminResult.Failure -> return@get call.respond(HttpStatusCode.NotFound)
+                    }
+                val existing =
+                    (userAttributeService.list(userId, ctx.workspace.id) as? AttributeResult.Success)
+                        ?.value
+                        ?.get(attrKey)
+                        ?: return@get call.respondRedirect(
+                            "/admin/workspaces/${ctx.slug}/users/${userId.value}",
+                        )
+                call.respondHtml(
+                    HttpStatusCode.OK,
+                    AdminView.userAttributeFormPage(
+                        workspace = ctx.workspace,
+                        user = user,
+                        allWorkspaces = ctx.wsPairs,
+                        loggedInAs = ctx.session.username,
+                        existingKey = attrKey,
+                        prefillKey = attrKey,
+                        prefillValue = existing,
+                    ),
+                )
+            }
+
+            // ── Attributes: create (POST) ───────────────────────────────
+            post("/attributes") {
+                val ctx = call.adminContext()
+                val userId =
+                    call.parameters.typedId("userId", ::UserId)
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val params = call.receiveParameters()
+                val key = params["key"]?.trim().orEmpty()
+                val value = params["value"] ?: ""
+
+                when (val result = userAttributeService.upsert(userId, ctx.workspace.id, key, value)) {
+                    is AttributeResult.Success ->
+                        call.respondRedirect(
+                            "/admin/workspaces/${ctx.slug}/users/${userId.value}?saved=attribute_saved",
+                        )
+                    else -> {
+                        val user =
+                            when (val r = adminService.getUser(userId, ctx.workspace.id)) {
+                                is AdminResult.Success -> r.value
+                                is AdminResult.Failure -> return@post call.respond(HttpStatusCode.NotFound)
+                            }
+                        call.respondHtml(
+                            HttpStatusCode.UnprocessableEntity,
+                            AdminView.userAttributeFormPage(
+                                workspace = ctx.workspace,
+                                user = user,
+                                allWorkspaces = ctx.wsPairs,
+                                loggedInAs = ctx.session.username,
+                                prefillKey = key,
+                                prefillValue = value,
+                                error = attributeErrorMessage(result),
+                            ),
+                        )
+                    }
+                }
+            }
+
+            // ── Attributes: update (POST to existing key) ───────────────
+            post("/attributes/{attrKey}") {
+                val ctx = call.adminContext()
+                val userId =
+                    call.parameters.typedId("userId", ::UserId)
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val attrKey =
+                    call.parameters["attrKey"]
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val params = call.receiveParameters()
+                val value = params["value"] ?: ""
+
+                when (val result = userAttributeService.upsert(userId, ctx.workspace.id, attrKey, value)) {
+                    is AttributeResult.Success ->
+                        call.respondRedirect(
+                            "/admin/workspaces/${ctx.slug}/users/${userId.value}?saved=attribute_saved",
+                        )
+                    else -> {
+                        val user =
+                            when (val r = adminService.getUser(userId, ctx.workspace.id)) {
+                                is AdminResult.Success -> r.value
+                                is AdminResult.Failure -> return@post call.respond(HttpStatusCode.NotFound)
+                            }
+                        call.respondHtml(
+                            HttpStatusCode.UnprocessableEntity,
+                            AdminView.userAttributeFormPage(
+                                workspace = ctx.workspace,
+                                user = user,
+                                allWorkspaces = ctx.wsPairs,
+                                loggedInAs = ctx.session.username,
+                                existingKey = attrKey,
+                                prefillKey = attrKey,
+                                prefillValue = value,
+                                error = attributeErrorMessage(result),
+                            ),
+                        )
+                    }
+                }
+            }
+
+            // ── Attributes: delete ──────────────────────────────────────
+            post("/attributes/{attrKey}/delete") {
+                val ctx = call.adminContext()
+                val userId =
+                    call.parameters.typedId("userId", ::UserId)
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val attrKey =
+                    call.parameters["attrKey"]
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                userAttributeService.delete(userId, ctx.workspace.id, attrKey)
+                call.respondRedirect(
+                    "/admin/workspaces/${ctx.slug}/users/${userId.value}?saved=attribute_deleted",
+                )
+            }
         }
     }
 }
+
+private fun attributeErrorMessage(result: AttributeResult<*>): String =
+    when (result) {
+        is AttributeResult.Success<*> -> "Unexpected internal state."
+        is AttributeResult.ValidationError -> result.reason
+        is AttributeResult.NotFound -> "${result.resource} not found."
+        is AttributeResult.ReservedClaimName ->
+            "Reserved claim name '${result.claimName}'."
+        is AttributeResult.DuplicateClaimName ->
+            "Duplicate claim name '${result.claimName}'."
+        is AttributeResult.LimitReached ->
+            "Mapper limit of ${result.max} reached."
+    }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -159,7 +159,45 @@ object AdminView {
         editError: String? = null,
         roles: List<Role> = emptyList(),
         groups: List<Group> = emptyList(),
-    ): HTML.() -> Unit = userDetailPageImpl(workspace, user, sessions, allWorkspaces, loggedInAs, successMessage, editError, roles, groups)
+        userAttributes: Map<String, String> = emptyMap(),
+        mappedKeys: Map<String, String> = emptyMap(),
+        attributeError: String? = null,
+    ): HTML.() -> Unit =
+        userDetailPageImpl(
+            workspace,
+            user,
+            sessions,
+            allWorkspaces,
+            loggedInAs,
+            successMessage,
+            editError,
+            roles,
+            groups,
+            userAttributes,
+            mappedKeys,
+            attributeError,
+        )
+
+    fun userAttributeFormPage(
+        workspace: Tenant,
+        user: User,
+        allWorkspaces: List<WorkspaceStub>,
+        loggedInAs: String,
+        existingKey: String? = null,
+        prefillKey: String = "",
+        prefillValue: String = "",
+        error: String? = null,
+    ): HTML.() -> Unit =
+        userAttributeFormPageImpl(
+            workspace,
+            user,
+            allWorkspaces,
+            loggedInAs,
+            existingKey,
+            prefillKey,
+            prefillValue,
+            error,
+        )
 
     // ── User htmx fragments ──────────────────────────────────────────
 
@@ -347,4 +385,25 @@ object AdminView {
         error: String? = null,
         toastMessage: String? = null,
     ): HTML.() -> Unit = keyManagementPageImpl(workspace, allWorkspaces, loggedInAs, keys, error, toastMessage)
+
+    // ── Claim Mappers ───────────────────────────────────────────────────
+
+    fun claimMappersListPage(
+        workspace: Tenant,
+        allWorkspaces: List<WorkspaceStub>,
+        loggedInAs: String,
+        mappers: List<com.kauth.domain.model.TenantClaimMapper>,
+        error: String? = null,
+        toastMessage: String? = null,
+    ): HTML.() -> Unit =
+        claimMappersListPageImpl(workspace, allWorkspaces, loggedInAs, mappers, error, toastMessage)
+
+    fun claimMapperFormPage(
+        workspace: Tenant,
+        allWorkspaces: List<WorkspaceStub>,
+        loggedInAs: String,
+        prefill: com.kauth.domain.model.TenantClaimMapper? = null,
+        error: String? = null,
+    ): HTML.() -> Unit =
+        claimMapperFormPageImpl(workspace, allWorkspaces, loggedInAs, prefill, error)
 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
@@ -62,8 +62,8 @@ internal fun claimMappersListPageImpl(
                             title = "No claim mappers configured",
                             description =
                                 "Attributes won't appear in JWTs until you map them here. " +
-                                    "Example: map attribute key 'plan' to claim name 'custom:plan' " +
-                                    "to surface a billing tier in your access and ID tokens.",
+                                    "Example: map attribute key 'department' to claim name " +
+                                    "'custom:department' to surface org structure in your access and ID tokens.",
                         )
                     }
                 } else {
@@ -168,19 +168,21 @@ internal fun claimMapperFormPageImpl(
                     div("notice notice--error") { +error }
                 }
 
-                div("ov-card") {
-                    div("ov-card__section-label") { +"Mapper Details" }
-                    form(
-                        action =
-                            if (isEdit) {
-                                "/admin/workspaces/$slug/settings/claim-mappers/${prefill.attributeKey}"
-                            } else {
-                                "/admin/workspaces/$slug/settings/claim-mappers"
-                            },
-                        method = FormMethod.post,
-                        encType = FormEncType.applicationXWwwFormUrlEncoded,
-                    ) {
-                        id = "claim-mapper-form"
+                form(
+                    action =
+                        if (isEdit) {
+                            "/admin/workspaces/$slug/settings/claim-mappers/${prefill.attributeKey}"
+                        } else {
+                            "/admin/workspaces/$slug/settings/claim-mappers"
+                        },
+                    method = FormMethod.post,
+                    encType = FormEncType.applicationXWwwFormUrlEncoded,
+                ) {
+                    id = "claim-mapper-form"
+
+                    // ── Mapper details ──────────────────────────────────
+                    div("ov-card") {
+                        div("ov-card__section-label") { +"Mapper Details" }
 
                         div("edit-row") {
                             span("edit-row__label") { +"Attribute Key" }
@@ -189,7 +191,7 @@ internal fun claimMapperFormPageImpl(
                                     classes = setOf("edit-row__field")
                                     required = true
                                     maxLength = "64"
-                                    placeholder = "plan"
+                                    placeholder = "department"
                                     value = prefill?.attributeKey ?: ""
                                     if (isEdit) readonly = true
                                 }
@@ -206,7 +208,7 @@ internal fun claimMapperFormPageImpl(
                                     classes = setOf("edit-row__field")
                                     required = true
                                     maxLength = "128"
-                                    placeholder = "custom:plan"
+                                    placeholder = "custom:department"
                                     value = prefill?.claimName ?: ""
                                 }
                                 div("edit-row__hint") {
@@ -215,34 +217,41 @@ internal fun claimMapperFormPageImpl(
                                 }
                             }
                         }
+                    }
 
-                        div("edit-row") {
-                            span("edit-row__label") { +"Include in" }
-                            div {
-                                label("radio-row") {
-                                    input(type = InputType.checkBox, name = "includeInAccess") {
-                                        value = "true"
-                                        if (prefill?.includeInAccess != false) checked = true
-                                    }
-                                    span("radio-row__body") {
-                                        span("radio-row__label") { +"Access Token" }
-                                        span("radio-row__desc") {
-                                            +"Claim appears in the short-lived bearer token sent with API requests."
-                                        }
-                                    }
+                    // ── Token visibility (toggle-row for each) ──────────
+                    div("ov-card") {
+                        div("ov-card__section-label") { +"Token Visibility" }
+
+                        div("toggle-row") {
+                            div("toggle-row__body") {
+                                div("toggle-row__title") { +"Access Token" }
+                                div("toggle-row__desc") {
+                                    +"Include this claim in the short-lived bearer token sent with API requests."
                                 }
-                                label("radio-row") {
-                                    input(type = InputType.checkBox, name = "includeInId") {
-                                        value = "true"
-                                        if (prefill?.includeInId == true) checked = true
-                                    }
-                                    span("radio-row__body") {
-                                        span("radio-row__label") { +"ID Token" }
-                                        span("radio-row__desc") {
-                                            +"Claim appears in the OIDC id_token (consumed by clients to display user info)."
-                                        }
-                                    }
+                            }
+                            label("toggle") {
+                                input(type = InputType.checkBox, name = "includeInAccess") {
+                                    attributes["value"] = "true"
+                                    if (prefill?.includeInAccess != false) checked = true
                                 }
+                                span("toggle__track") { span("toggle__thumb") {} }
+                            }
+                        }
+
+                        div("toggle-row") {
+                            div("toggle-row__body") {
+                                div("toggle-row__title") { +"ID Token" }
+                                div("toggle-row__desc") {
+                                    +"Include this claim in the OIDC id_token consumed by clients to display user info."
+                                }
+                            }
+                            label("toggle") {
+                                input(type = InputType.checkBox, name = "includeInId") {
+                                    attributes["value"] = "true"
+                                    if (prefill?.includeInId == true) checked = true
+                                }
+                                span("toggle__track") { span("toggle__thumb") {} }
                             }
                         }
                     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
@@ -1,0 +1,263 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantClaimMapper
+import kotlinx.html.*
+
+// ─── Claim Mappers — list page ──────────────────────────────────────────────
+
+internal fun claimMappersListPageImpl(
+    workspace: Tenant,
+    allWorkspaces: List<WorkspaceStub>,
+    loggedInAs: String,
+    mappers: List<TenantClaimMapper>,
+    error: String? = null,
+    toastMessage: String? = null,
+): HTML.() -> Unit =
+    {
+        val slug = workspace.slug
+
+        adminShell(
+            pageTitle = "Claim Mappers — ${workspace.displayName}",
+            activeRail = "settings",
+            allWorkspaces = allWorkspaces,
+            workspaceName = workspace.displayName,
+            workspaceSlug = slug,
+            workspaceLogoUrl = workspace.theme.logoUrl,
+            loggedInAs = loggedInAs,
+            activeAppSection = "claim-mappers",
+            contentClass = "content-outer",
+            toastMessage = toastMessage,
+        ) {
+            div("content-inner") {
+                breadcrumb(
+                    "Workspaces" to "/admin",
+                    slug to "/admin/workspaces/$slug",
+                    "Settings" to "/admin/workspaces/$slug/settings",
+                    "Claim Mappers" to null,
+                )
+
+                pageHeader(
+                    title = "Claim Mappers",
+                    subtitle =
+                        "Control which user attributes appear as claims in access and ID tokens. " +
+                            "Changes take effect on the next token issuance.",
+                    actions = {
+                        primaryLink(
+                            "/admin/workspaces/$slug/settings/claim-mappers/new",
+                            "Add Mapper",
+                            "plus",
+                        )
+                    },
+                )
+
+                if (error != null) {
+                    div("notice notice--error") { +error }
+                }
+
+                if (mappers.isEmpty()) {
+                    div("ov-card") {
+                        emptyState(
+                            iconName = "key",
+                            title = "No claim mappers configured",
+                            description =
+                                "Attributes won't appear in JWTs until you map them here. " +
+                                    "Example: map attribute key 'plan' to claim name 'custom:plan' " +
+                                    "to surface a billing tier in your access and ID tokens.",
+                        )
+                    }
+                } else {
+                    div("ov-card") {
+                        div("ov-card__section-label") { +"Configured Mappers" }
+                        table("data-table") {
+                            thead {
+                                tr {
+                                    th { +"Attribute Key" }
+                                    th { +"Claim Name" }
+                                    th { style = "width:120px;"; +"Access Token" }
+                                    th { style = "width:120px;"; +"ID Token" }
+                                    th { style = "width:80px;" }
+                                }
+                            }
+                            tbody {
+                                mappers.forEach { mapper ->
+                                    tr {
+                                        td {
+                                            span("data-table__id") { +mapper.attributeKey }
+                                        }
+                                        td { +mapper.claimName }
+                                        td { yesNoBadge(mapper.includeInAccess) }
+                                        td { yesNoBadge(mapper.includeInId) }
+                                        td {
+                                            div {
+                                                postButton(
+                                                    action =
+                                                        "/admin/workspaces/$slug/settings/claim-mappers/" +
+                                                            "${mapper.attributeKey}/delete",
+                                                    label = "Delete",
+                                                    btnClass = "btn btn--danger btn--sm",
+                                                    confirmMessage =
+                                                        "Delete mapper for '${mapper.attributeKey}'? The " +
+                                                            "'${mapper.claimName}' claim will stop appearing in tokens.",
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+// ─── Claim Mappers — create/edit page ───────────────────────────────────────
+
+internal fun claimMapperFormPageImpl(
+    workspace: Tenant,
+    allWorkspaces: List<WorkspaceStub>,
+    loggedInAs: String,
+    prefill: TenantClaimMapper? = null,
+    error: String? = null,
+): HTML.() -> Unit =
+    {
+        val slug = workspace.slug
+        val isEdit = prefill != null
+
+        adminShell(
+            pageTitle = "${if (isEdit) "Edit Mapper" else "New Mapper"} — ${workspace.displayName}",
+            activeRail = "settings",
+            allWorkspaces = allWorkspaces,
+            workspaceName = workspace.displayName,
+            workspaceSlug = slug,
+            workspaceLogoUrl = workspace.theme.logoUrl,
+            loggedInAs = loggedInAs,
+            activeAppSection = "claim-mappers",
+            contentClass = "content-outer",
+        ) {
+            div("content-inner") {
+                breadcrumb(
+                    "Workspaces" to "/admin",
+                    slug to "/admin/workspaces/$slug",
+                    "Settings" to "/admin/workspaces/$slug/settings",
+                    "Claim Mappers" to "/admin/workspaces/$slug/settings/claim-mappers",
+                    (if (isEdit) "Edit Mapper" else "New Mapper") to null,
+                )
+
+                div("page-header") {
+                    div("page-header__left") {
+                        div("page-header__identity") {
+                            h1("page-header__title") {
+                                +(if (isEdit) "Edit Claim Mapper" else "Add Claim Mapper")
+                            }
+                            p("page-header__sub") {
+                                +"Project a user attribute into JWT claims under a custom name."
+                            }
+                        }
+                    }
+                    div("page-header__actions") {
+                        button(type = ButtonType.submit, classes = "btn btn--primary") {
+                            attributes["form"] = "claim-mapper-form"
+                            +(if (isEdit) "Save Changes" else "Create Mapper")
+                        }
+                    }
+                }
+
+                if (error != null) {
+                    div("notice notice--error") { +error }
+                }
+
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Mapper Details" }
+                    form(
+                        action =
+                            if (isEdit) {
+                                "/admin/workspaces/$slug/settings/claim-mappers/${prefill.attributeKey}"
+                            } else {
+                                "/admin/workspaces/$slug/settings/claim-mappers"
+                            },
+                        method = FormMethod.post,
+                        encType = FormEncType.applicationXWwwFormUrlEncoded,
+                    ) {
+                        id = "claim-mapper-form"
+
+                        div("edit-row") {
+                            span("edit-row__label") { +"Attribute Key" }
+                            div {
+                                input(type = InputType.text, name = "attributeKey") {
+                                    classes = setOf("edit-row__field")
+                                    required = true
+                                    maxLength = "64"
+                                    placeholder = "plan"
+                                    value = prefill?.attributeKey ?: ""
+                                    if (isEdit) readonly = true
+                                }
+                                div("edit-row__hint") {
+                                    +"Must match exactly the key set on users via the attributes API."
+                                }
+                            }
+                        }
+
+                        div("edit-row") {
+                            span("edit-row__label") { +"Claim Name" }
+                            div {
+                                input(type = InputType.text, name = "claimName") {
+                                    classes = setOf("edit-row__field")
+                                    required = true
+                                    maxLength = "128"
+                                    placeholder = "custom:plan"
+                                    value = prefill?.claimName ?: ""
+                                }
+                                div("edit-row__hint") {
+                                    +"Avoid reserved OIDC names (sub, iss, aud, exp, iat, email, etc.). "
+                                    +"Prefix with 'custom:' to prevent collisions."
+                                }
+                            }
+                        }
+
+                        div("edit-row") {
+                            span("edit-row__label") { +"Include in" }
+                            div {
+                                label("radio-row") {
+                                    input(type = InputType.checkBox, name = "includeInAccess") {
+                                        value = "true"
+                                        if (prefill?.includeInAccess != false) checked = true
+                                    }
+                                    span("radio-row__body") {
+                                        span("radio-row__label") { +"Access Token" }
+                                        span("radio-row__desc") {
+                                            +"Claim appears in the short-lived bearer token sent with API requests."
+                                        }
+                                    }
+                                }
+                                label("radio-row") {
+                                    input(type = InputType.checkBox, name = "includeInId") {
+                                        value = "true"
+                                        if (prefill?.includeInId == true) checked = true
+                                    }
+                                    span("radio-row__body") {
+                                        span("radio-row__label") { +"ID Token" }
+                                        span("radio-row__desc") {
+                                            +"Claim appears in the OIDC id_token (consumed by clients to display user info)."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+private fun TD.yesNoBadge(value: Boolean) {
+    if (value) {
+        span("badge badge--active") {
+            span("badge__dot") {}
+            +"Yes"
+        }
+    } else {
+        span("badge badge--inactive") { +"No" }
+    }
+}

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -945,12 +945,13 @@ internal fun userAttributeFormPageImpl(
                                     classes = setOf("edit-row__field")
                                     required = true
                                     maxLength = "64"
-                                    placeholder = "plan"
+                                    placeholder = "department"
                                     value = prefillKey
                                     if (isEdit) readonly = true
                                 }
                                 div("edit-row__hint") {
-                                    +"Example keys: plan, trial_ends, sifen_env. Keys are opaque to KotAuth."
+                                    +"Any string key. Common examples: department, tier, region, employee_id. "
+                                    +"Keys are opaque to KotAuth."
                                 }
                             }
                         }
@@ -963,7 +964,7 @@ internal fun userAttributeFormPageImpl(
                                     name = "value"
                                     rows = "3"
                                     attributes["maxlength"] = "1024"
-                                    placeholder = "e.g. trial, 2026-05-21, staging"
+                                    placeholder = "e.g. engineering, premium, us-east-1"
                                     +prefillValue
                                 }
                                 div("edit-row__hint") {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -22,6 +22,10 @@ internal fun userDetailPageImpl(
     editError: String? = null,
     roles: List<Role> = emptyList(),
     groups: List<Group> = emptyList(),
+    userAttributes: Map<String, String> = emptyMap(),
+    /** attribute_key -> claim_name for keys that have a mapper configured. */
+    mappedKeys: Map<String, String> = emptyMap(),
+    attributeError: String? = null,
 ): HTML.() -> Unit =
     {
         adminShell(
@@ -119,6 +123,15 @@ internal fun userDetailPageImpl(
 
             // ── Profile (read mode — swapped via htmx) ──────────────
             userProfileReadFragment(user, roles = roles, groups = groups)
+
+            // ── Custom Attributes ────────────────────────────────────
+            userAttributesSection(
+                workspace = workspace,
+                user = user,
+                attributes = userAttributes,
+                mappedKeys = mappedKeys,
+                error = attributeError,
+            )
 
             // ── Active Sessions ──────────────────────────────────────
             div("ov-card") {
@@ -755,3 +768,214 @@ internal fun createUserPageImpl(
                     }
 }
     }
+
+// ─── User Attributes section (rendered on user detail page) ─────────────────
+
+private fun FlowContent.userAttributesSection(
+    workspace: Tenant,
+    user: User,
+    attributes: Map<String, String>,
+    mappedKeys: Map<String, String>,
+    error: String?,
+) {
+    val slug = workspace.slug
+    val userIdValue = user.id?.value ?: return
+    val base = "/admin/workspaces/$slug/users/$userIdValue/attributes"
+
+    div("ov-card") {
+        div("ov-card__section-label") {
+            span { +"Custom Attributes" }
+            a(href = "$base/new", classes = "btn btn--ghost btn--sm") {
+                +"Add attribute"
+            }
+        }
+
+        if (error != null) {
+            div("notice notice--error") { +error }
+        }
+
+        if (attributes.isEmpty()) {
+            emptyState(
+                iconName = "key",
+                title = "No custom attributes",
+                description =
+                    "Add key-value pairs to this user. Configure how they appear in JWTs under " +
+                        "Settings → Claim Mappers.",
+            )
+        } else {
+            table("data-table") {
+                thead {
+                    tr {
+                        th { +"Key" }
+                        th { +"Value" }
+                        th { style = "width:120px;" }
+                    }
+                }
+                tbody {
+                    attributes.entries
+                        .sortedBy { it.key }
+                        .forEach { (key, value) ->
+                            tr {
+                                td {
+                                    span("data-table__id") { +key }
+                                    val claimName = mappedKeys[key]
+                                    if (claimName != null) {
+                                        div {
+                                            style = "margin-top:4px;"
+                                            span("badge badge--id-muted") { +"→ $claimName" }
+                                        }
+                                    } else {
+                                        div {
+                                            style = "margin-top:4px;font-size:11px;color:var(--color-subtle);"
+                                            a(
+                                                href =
+                                                    "/admin/workspaces/$slug/settings/claim-mappers/new" +
+                                                        "?attributeKey=$key",
+                                            ) { +"Configure mapping →" }
+                                        }
+                                    }
+                                }
+                                td { +value }
+                                td {
+                                    div("data-table__actions") {
+                                        a(
+                                            href = "$base/${encodeUriComponent(key)}/edit",
+                                            classes = "btn btn--ghost btn--sm",
+                                        ) { +"Edit" }
+                                        postButton(
+                                            action = "$base/${encodeUriComponent(key)}/delete",
+                                            label = "Delete",
+                                            btnClass = "btn btn--danger btn--sm",
+                                            confirmMessage =
+                                                if (mappedKeys.containsKey(key)) {
+                                                    "Delete attribute '$key'? The '${mappedKeys[key]}' claim " +
+                                                        "will stop appearing in tokens for this user."
+                                                } else {
+                                                    "Delete attribute '$key'?"
+                                                },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
+        }
+    }
+}
+
+internal fun userAttributeFormPageImpl(
+    workspace: Tenant,
+    user: User,
+    allWorkspaces: List<WorkspaceStub>,
+    loggedInAs: String,
+    existingKey: String? = null,
+    prefillKey: String = "",
+    prefillValue: String = "",
+    error: String? = null,
+): HTML.() -> Unit =
+    {
+        val slug = workspace.slug
+        val userIdValue = user.id?.value ?: 0
+        val isEdit = existingKey != null
+
+        adminShell(
+            pageTitle = "${if (isEdit) "Edit Attribute" else "Add Attribute"} — ${user.username}",
+            activeRail = "directory",
+            allWorkspaces = allWorkspaces,
+            workspaceName = workspace.displayName,
+            workspaceSlug = slug,
+            workspaceLogoUrl = workspace.theme.logoUrl,
+            loggedInAs = loggedInAs,
+            activeAppSection = "users",
+            contentClass = "content-outer",
+        ) {
+            div("content-inner") {
+                breadcrumb(
+                    "Workspaces" to "/admin",
+                    slug to "/admin/workspaces/$slug",
+                    "Users" to "/admin/workspaces/$slug/users",
+                    user.username to "/admin/workspaces/$slug/users/$userIdValue",
+                    (if (isEdit) "Edit Attribute" else "Add Attribute") to null,
+                )
+
+                div("page-header") {
+                    div("page-header__left") {
+                        div("page-header__identity") {
+                            h1("page-header__title") {
+                                +(if (isEdit) "Edit Attribute" else "Add Attribute")
+                            }
+                            p("page-header__sub") {
+                                +"Attribute values are stored as strings. They appear in JWTs only when a "
+                                +"claim mapper is configured for the key."
+                            }
+                        }
+                    }
+                    div("page-header__actions") {
+                        button(type = ButtonType.submit, classes = "btn btn--primary") {
+                            attributes["form"] = "attribute-form"
+                            +(if (isEdit) "Save" else "Add Attribute")
+                        }
+                    }
+                }
+
+                if (error != null) {
+                    div("notice notice--error") { +error }
+                }
+
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Attribute Details" }
+                    form(
+                        action =
+                            if (isEdit) {
+                                "/admin/workspaces/$slug/users/$userIdValue/attributes/" +
+                                    encodeUriComponent(existingKey)
+                            } else {
+                                "/admin/workspaces/$slug/users/$userIdValue/attributes"
+                            },
+                        method = FormMethod.post,
+                        encType = FormEncType.applicationXWwwFormUrlEncoded,
+                    ) {
+                        id = "attribute-form"
+
+                        div("edit-row") {
+                            span("edit-row__label") { +"Key" }
+                            div {
+                                input(type = InputType.text, name = "key") {
+                                    classes = setOf("edit-row__field")
+                                    required = true
+                                    maxLength = "64"
+                                    placeholder = "plan"
+                                    value = prefillKey
+                                    if (isEdit) readonly = true
+                                }
+                                div("edit-row__hint") {
+                                    +"Example keys: plan, trial_ends, sifen_env. Keys are opaque to KotAuth."
+                                }
+                            }
+                        }
+
+                        div("edit-row") {
+                            span("edit-row__label") { +"Value" }
+                            div {
+                                textArea {
+                                    classes = setOf("edit-row__field")
+                                    name = "value"
+                                    rows = "3"
+                                    attributes["maxlength"] = "1024"
+                                    placeholder = "e.g. trial, 2026-05-21, staging"
+                                    +prefillValue
+                                }
+                                div("edit-row__hint") {
+                                    +"Stored as plain text (max 1024 characters). Callers serialize their own types."
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+private fun encodeUriComponent(input: String): String =
+    java.net.URLEncoder.encode(input, "UTF-8").replace("+", "%20")

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutes.kt
@@ -1,0 +1,78 @@
+package com.kauth.adapter.web.api
+
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.service.AttributeResult
+import com.kauth.infrastructure.CachingClaimMapperService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+
+/**
+ * REST API — tenant-level claim mappers that project user attributes into JWTs.
+ *
+ * Mounted under `/t/{tenantSlug}/api/v1/claim-mappers` inside the authenticated/
+ * tenant-scoped route in [apiRoutes].
+ *
+ * Writes are serialized through the caching layer so the tenant's mapper cache
+ * is invalidated immediately — the next token issuance uses the fresh list.
+ */
+internal fun Route.apiClaimMapperRoutes(claimMapperService: CachingClaimMapperService) {
+    route("/claim-mappers") {
+        get {
+            requireScope(call, ApiScope.CLAIM_MAPPERS_READ) ?: return@get
+            val tenantId = call.attributes[TenantIdAttr]
+            val mappers = claimMapperService.list(tenantId).map { it.toApiDto() }
+            call.respond(HttpStatusCode.OK, ClaimMappersDto(mappers))
+        }
+
+        put("/{attributeKey}") {
+            requireScope(call, ApiScope.CLAIM_MAPPERS_WRITE) ?: return@put
+            val tenantId = call.attributes[TenantIdAttr]
+            val attributeKey =
+                call.parameters["attributeKey"]
+                    ?: return@put call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Missing attribute key",
+                        "The attributeKey path parameter is required.",
+                    )
+            val body = call.receive<UpsertClaimMapperRequest>()
+
+            val mapper =
+                TenantClaimMapper(
+                    tenantId = tenantId,
+                    attributeKey = attributeKey,
+                    claimName = body.claimName,
+                    includeInAccess = body.includeInAccess,
+                    includeInId = body.includeInId,
+                )
+
+            when (val result = claimMapperService.upsert(mapper)) {
+                is AttributeResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                else -> call.respondAttributeError(result)
+            }
+        }
+
+        delete("/{attributeKey}") {
+            requireScope(call, ApiScope.CLAIM_MAPPERS_WRITE) ?: return@delete
+            val tenantId = call.attributes[TenantIdAttr]
+            val attributeKey =
+                call.parameters["attributeKey"]
+                    ?: return@delete call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Missing attribute key",
+                        "The attributeKey path parameter is required.",
+                    )
+
+            when (val result = claimMapperService.delete(tenantId, attributeKey)) {
+                is AttributeResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                else -> call.respondAttributeError(result)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -2,6 +2,7 @@ package com.kauth.adapter.web.api
 
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.service.AdminError
+import com.kauth.domain.service.AttributeResult
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -63,6 +64,48 @@ internal suspend fun ApplicationCall.respondAdminError(error: AdminError): Unit 
                 HttpStatusCode.UnprocessableEntity,
                 "Validation Error",
                 error.message,
+            )
+    }
+
+/** Maps the terminal [AttributeResult] failure variants to Problem+JSON responses. */
+internal suspend fun ApplicationCall.respondAttributeError(result: AttributeResult<*>): Unit =
+    when (result) {
+        is AttributeResult.Success<*> ->
+            respondProblem(
+                HttpStatusCode.InternalServerError,
+                "Unexpected Success",
+                "Internal error: respondAttributeError called with Success.",
+            )
+        is AttributeResult.NotFound ->
+            respondProblem(
+                HttpStatusCode.NotFound,
+                "Not Found",
+                "No ${result.resource} matched the request.",
+            )
+        is AttributeResult.ValidationError ->
+            respondProblem(
+                HttpStatusCode.UnprocessableEntity,
+                "Validation Error",
+                result.reason,
+            )
+        is AttributeResult.ReservedClaimName ->
+            respondProblem(
+                HttpStatusCode.BadRequest,
+                "Reserved Claim Name",
+                "The claim name '${result.claimName}' is reserved by OIDC/KotAuth and cannot be used. " +
+                    "Use a custom prefix, e.g. 'custom:${result.claimName}'.",
+            )
+        is AttributeResult.DuplicateClaimName ->
+            respondProblem(
+                HttpStatusCode.Conflict,
+                "Duplicate Claim Name",
+                "Another attribute in this tenant already maps to claim name '${result.claimName}'.",
+            )
+        is AttributeResult.LimitReached ->
+            respondProblem(
+                HttpStatusCode.Conflict,
+                "Mapper Limit Reached",
+                "This tenant has reached the maximum of ${result.max} claim mappers.",
             )
     }
 
@@ -132,6 +175,16 @@ data class ProblemDetail(
     val redirectUris: List<String>? = null,
 )
 
+@Serializable data class UpsertUserAttributeRequest(
+    val value: String,
+)
+
+@Serializable data class UpsertClaimMapperRequest(
+    val claimName: String,
+    val includeInAccess: Boolean = true,
+    val includeInId: Boolean = false,
+)
+
 // -- Response DTOs ------------------------------------------------------------
 
 @Serializable data class UserDto(
@@ -187,6 +240,22 @@ data class ProblemDetail(
     val ipAddress: String?,
     val createdAt: String,
     val details: Map<String, String>,
+)
+
+@Serializable data class UserAttributesDto(
+    /** Flat key→value map. Empty if the user has no custom attributes. */
+    val attributes: Map<String, String>,
+)
+
+@Serializable data class ClaimMapperDto(
+    val attributeKey: String,
+    val claimName: String,
+    val includeInAccess: Boolean,
+    val includeInId: Boolean,
+)
+
+@Serializable data class ClaimMappersDto(
+    val mappers: List<ClaimMapperDto>,
 )
 
 // -- Domain → DTO mappers ----------------------------------------------------
@@ -250,4 +319,12 @@ internal fun com.kauth.domain.model.AuditEvent.toApiDto() =
         ipAddress = ipAddress,
         createdAt = isoFormatter.format(createdAt),
         details = details,
+    )
+
+internal fun com.kauth.domain.model.TenantClaimMapper.toApiDto() =
+    ClaimMapperDto(
+        attributeKey = attributeKey,
+        claimName = claimName,
+        includeInAccess = includeInAccess,
+        includeInId = includeInId,
     )

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
@@ -11,7 +11,9 @@ import com.kauth.domain.service.AdminService
 import com.kauth.domain.service.ApiKeyService
 import com.kauth.domain.service.CorsService
 import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserAttributeService
 import com.kauth.infrastructure.ApiKeyPrincipal
+import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.createRouteScopedPlugin
@@ -34,6 +36,8 @@ fun Route.apiRoutes(
     auditLogRepository: AuditLogRepository,
     roleGroupService: RoleGroupService,
     adminService: AdminService,
+    userAttributeService: UserAttributeService,
+    claimMapperService: CachingClaimMapperService,
     corsService: CorsService? = null,
 ) {
     get("/api/docs") {
@@ -107,6 +111,8 @@ fun Route.apiRoutes(
             apiRbacRoutes(roleRepository, groupRepository, roleGroupService)
             apiApplicationRoutes(applicationRepository, adminService)
             apiSessionAuditRoutes(sessionRepository, auditLogRepository)
+            apiUserAttributeRoutes(userAttributeService)
+            apiClaimMapperRoutes(claimMapperService)
         }
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutes.kt
@@ -1,0 +1,94 @@
+package com.kauth.adapter.web.api
+
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AttributeResult
+import com.kauth.domain.service.UserAttributeService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+
+/**
+ * REST API — per-user custom attributes (key/value strings).
+ *
+ * Mounted under `/t/{tenantSlug}/api/v1/users/{userId}/attributes` inside the
+ * authenticated/tenant-scoped route in [apiRoutes].
+ *
+ * Attributes are opaque to KotAuth: callers serialize structured data as strings.
+ * Values are NOT validated for type. Attribute changes propagate to issued JWTs
+ * on the next token issuance (worst case bounded by the claim-mapper cache TTL).
+ */
+internal fun Route.apiUserAttributeRoutes(userAttributeService: UserAttributeService) {
+    route("/users/{userId}/attributes") {
+        get {
+            requireScope(call, ApiScope.USER_ATTRIBUTES_READ) ?: return@get
+            val tenantId = call.attributes[TenantIdAttr]
+            val userId =
+                call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
+                    ?: return@get call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Invalid user ID",
+                        "userId must be an integer.",
+                    )
+
+            when (val result = userAttributeService.list(userId, tenantId)) {
+                is AttributeResult.Success -> call.respond(HttpStatusCode.OK, UserAttributesDto(result.value))
+                else -> call.respondAttributeError(result)
+            }
+        }
+
+        put("/{key}") {
+            requireScope(call, ApiScope.USER_ATTRIBUTES_WRITE) ?: return@put
+            val tenantId = call.attributes[TenantIdAttr]
+            val userId =
+                call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
+                    ?: return@put call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Invalid user ID",
+                        "userId must be an integer.",
+                    )
+            val key =
+                call.parameters["key"]
+                    ?: return@put call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Missing attribute key",
+                        "The attribute key path parameter is required.",
+                    )
+            val body = call.receive<UpsertUserAttributeRequest>()
+
+            when (val result = userAttributeService.upsert(userId, tenantId, key, body.value)) {
+                is AttributeResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                else -> call.respondAttributeError(result)
+            }
+        }
+
+        delete("/{key}") {
+            requireScope(call, ApiScope.USER_ATTRIBUTES_WRITE) ?: return@delete
+            val tenantId = call.attributes[TenantIdAttr]
+            val userId =
+                call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
+                    ?: return@delete call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Invalid user ID",
+                        "userId must be an integer.",
+                    )
+            val key =
+                call.parameters["key"]
+                    ?: return@delete call.respondProblem(
+                        HttpStatusCode.BadRequest,
+                        "Missing attribute key",
+                        "The attribute key path parameter is required.",
+                    )
+
+            when (val result = userAttributeService.delete(userId, tenantId, key)) {
+                is AttributeResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                else -> call.respondAttributeError(result)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -70,7 +70,12 @@ import kotlinx.coroutines.SupervisorJob
 /**
  * Holds every service and repository needed by the Ktor module.
  * Built once at startup by [create], then passed into the server.
+ *
+ * ArrayInDataClass is suppressed: ByteArray session keys would use
+ * reference equality in the auto-generated equals/hashCode, but this
+ * container is never compared — it is a DI singleton.
  */
+@Suppress("ArrayInDataClass")
 data class ServiceGraph(
     val authService: AuthService,
     val oauthService: OAuthService,
@@ -210,6 +215,17 @@ data class ServiceGraph(
                     selfServiceService = selfServiceService,
                     passwordPolicy = passwordPolicyAdapter,
                 )
+            // -- User attributes + claim mapping ------------------------------
+            val userAttributeService =
+                UserAttributeService(
+                    userAttributeRepository = userAttributeRepository,
+                    userRepository = userRepository,
+                )
+            val claimMapperService =
+                CachingClaimMapperService(
+                    mapperRepository = tenantClaimMapperRepository,
+                )
+
             val oauthService =
                 OAuthService(
                     tenantRepository = tenantRepository,
@@ -221,6 +237,8 @@ data class ServiceGraph(
                     passwordHasher = passwordHasher,
                     auditLog = auditLogAdapter,
                     roleRepository = roleRepository,
+                    userAttributeRepository = userAttributeRepository,
+                    claimMappersFor = claimMapperService::list,
                 )
             val adminService =
                 AdminService(
@@ -283,17 +301,6 @@ data class ServiceGraph(
                     tenantRepository = tenantRepository,
                     tokenPort = tokenAdapter,
                     auditLog = auditLogAdapter,
-                )
-
-            // -- User attributes + claim mapping ------------------------------
-            val userAttributeService =
-                UserAttributeService(
-                    userAttributeRepository = userAttributeRepository,
-                    userRepository = userRepository,
-                )
-            val claimMapperService =
-                CachingClaimMapperService(
-                    mapperRepository = tenantClaimMapperRepository,
                 )
 
             // -- Demo seed ----------------------------------------------------

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -17,9 +17,11 @@ import com.kauth.adapter.persistence.PostgresPortalConfigRepository
 import com.kauth.adapter.persistence.PostgresRoleRepository
 import com.kauth.adapter.persistence.PostgresSessionRepository
 import com.kauth.adapter.persistence.PostgresSocialAccountRepository
+import com.kauth.adapter.persistence.PostgresTenantClaimMapperRepository
 import com.kauth.adapter.persistence.PostgresTenantKeyRepository
 import com.kauth.adapter.persistence.PostgresTenantRepository
 import com.kauth.adapter.persistence.PostgresThemeRepository
+import com.kauth.adapter.persistence.PostgresUserAttributeRepository
 import com.kauth.adapter.persistence.PostgresUserRepository
 import com.kauth.adapter.persistence.PostgresWebhookDeliveryRepository
 import com.kauth.adapter.persistence.PostgresWebhookEndpointRepository
@@ -50,9 +52,11 @@ import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.RoleGroupService
 import com.kauth.domain.service.SocialLoginService
+import com.kauth.domain.service.UserAttributeService
 import com.kauth.domain.service.UserSelfServiceService
 import com.kauth.domain.service.WebhookService
 import com.kauth.infrastructure.AdminClientProvisioning
+import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.DemoSeedService
 import com.kauth.infrastructure.EncryptionService
 import com.kauth.infrastructure.InMemoryRateLimiter
@@ -103,6 +107,8 @@ data class ServiceGraph(
     val socialAccountRepository: PostgresSocialAccountRepository,
     val keyRotationService: KeyRotationService,
     val tenantKeyRepository: PostgresTenantKeyRepository,
+    val userAttributeService: UserAttributeService,
+    val claimMapperService: CachingClaimMapperService,
     val applicationScope: CoroutineScope,
 ) {
     companion object {
@@ -133,6 +139,8 @@ data class ServiceGraph(
             val webhookEndpointRepository = PostgresWebhookEndpointRepository()
             val webhookDeliveryRepository = PostgresWebhookDeliveryRepository()
             val mfaRepository = PostgresMfaRepository(encryptionService)
+            val userAttributeRepository = PostgresUserAttributeRepository()
+            val tenantClaimMapperRepository = PostgresTenantClaimMapperRepository()
             val corsOriginCache = CorsOriginCache(PostgresCorsAdapter())
             val corsService = CorsService(corsOriginCache)
 
@@ -277,6 +285,17 @@ data class ServiceGraph(
                     auditLog = auditLogAdapter,
                 )
 
+            // -- User attributes + claim mapping ------------------------------
+            val userAttributeService =
+                UserAttributeService(
+                    userAttributeRepository = userAttributeRepository,
+                    userRepository = userRepository,
+                )
+            val claimMapperService =
+                CachingClaimMapperService(
+                    mapperRepository = tenantClaimMapperRepository,
+                )
+
             // -- Demo seed ----------------------------------------------------
             if (config.isDemoMode) {
                 DemoSeedService(
@@ -364,6 +383,8 @@ data class ServiceGraph(
                 socialAccountRepository = socialAccountRepository,
                 keyRotationService = keyRotationService,
                 tenantKeyRepository = tenantKeyRepository,
+                userAttributeService = userAttributeService,
+                claimMapperService = claimMapperService,
                 applicationScope = applicationScope,
             )
         }

--- a/src/main/kotlin/com/kauth/domain/model/ApiKey.kt
+++ b/src/main/kotlin/com/kauth/domain/model/ApiKey.kt
@@ -6,8 +6,8 @@ import java.time.Instant
  * Represents a machine-to-machine API key for REST API access.
  *
  * The raw key value is NEVER stored here — only the prefix (for display) and the
- * SHA-256 hash (for verification). The plaintext is generated once by [ApiKeyService]
- * and returned to the caller; subsequent calls can only verify or revoke.
+ * SHA-256 hash (for verification). The plaintext is generated once by ApiKeyService
+ * (domain/service/) and returned to the caller; subsequent calls can only verify or revoke.
  *
  * Scopes follow the pattern `resource:action` (e.g. `users:read`, `roles:write`).
  * An empty scope list means no access — valid scopes are defined in [ApiScope].
@@ -44,6 +44,10 @@ object ApiScope {
     const val SESSIONS_READ = "sessions:read"
     const val SESSIONS_WRITE = "sessions:write"
     const val AUDIT_LOGS_READ = "audit_logs:read"
+    const val USER_ATTRIBUTES_READ = "user_attributes:read"
+    const val USER_ATTRIBUTES_WRITE = "user_attributes:write"
+    const val CLAIM_MAPPERS_READ = "claim_mappers:read"
+    const val CLAIM_MAPPERS_WRITE = "claim_mappers:write"
 
     val ALL =
         listOf(
@@ -58,5 +62,9 @@ object ApiScope {
             SESSIONS_READ,
             SESSIONS_WRITE,
             AUDIT_LOGS_READ,
+            USER_ATTRIBUTES_READ,
+            USER_ATTRIBUTES_WRITE,
+            CLAIM_MAPPERS_READ,
+            CLAIM_MAPPERS_WRITE,
         )
 }

--- a/src/main/kotlin/com/kauth/domain/model/TenantClaimMapper.kt
+++ b/src/main/kotlin/com/kauth/domain/model/TenantClaimMapper.kt
@@ -1,0 +1,26 @@
+package com.kauth.domain.model
+
+/**
+ * Tenant-level rule that projects a user attribute into issued JWTs.
+ * Identity is the composite (tenantId, attributeKey).
+ *
+ * Claim name collision with standard OIDC claims (sub, iss, aud, etc.) is
+ * rejected at the service layer — see [com.kauth.domain.service.ClaimMapperService].
+ */
+data class TenantClaimMapper(
+    val tenantId: TenantId,
+    val attributeKey: String,
+    val claimName: String,
+    val includeInAccess: Boolean = true,
+    val includeInId: Boolean = false,
+) {
+    companion object {
+        const val MAX_CLAIM_NAME_LENGTH = 128
+
+        /** Soft cap to keep JWTs from bloating. Enforced at write time. */
+        const val MAX_MAPPERS_PER_TENANT = 20
+    }
+}
+
+/** Which token type a claim projection is being built for. */
+enum class ClaimTokenType { ACCESS, ID }

--- a/src/main/kotlin/com/kauth/domain/model/UserAttribute.kt
+++ b/src/main/kotlin/com/kauth/domain/model/UserAttribute.kt
@@ -1,0 +1,23 @@
+package com.kauth.domain.model
+
+import java.time.Instant
+
+/**
+ * Per-user key/value metadata. Values are always strings — callers serialize
+ * structured data themselves. Attributes are opaque to KotAuth; there is no
+ * reserved-key list or type validation.
+ *
+ * See [TenantClaimMapper] for projecting attributes into JWT claims.
+ */
+data class UserAttribute(
+    val userId: UserId,
+    val tenantId: TenantId,
+    val key: String,
+    val value: String,
+    val updatedAt: Instant,
+) {
+    companion object {
+        const val MAX_KEY_LENGTH = 64
+        const val MAX_VALUE_LENGTH = 1024
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/port/TenantClaimMapperRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TenantClaimMapperRepository.kt
@@ -1,0 +1,39 @@
+package com.kauth.domain.port
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+
+/**
+ * Port (outbound) — tenant-level claim mapping configuration.
+ *
+ * Mappers project user attributes into issued JWTs. The list is small
+ * (bounded by [TenantClaimMapper.MAX_MAPPERS_PER_TENANT]) and read on every
+ * token issuance, so [findAll] is cached at a higher layer.
+ */
+interface TenantClaimMapperRepository {
+    /** Returns every mapper configured for the tenant. Empty if none. */
+    fun findAll(tenantId: TenantId): List<TenantClaimMapper>
+
+    /** Upserts a single mapper. Creates on new attribute key, overwrites on match. */
+    fun upsert(mapper: TenantClaimMapper)
+
+    /** Deletes a mapper by its natural key. Returns true if a row was removed. */
+    fun delete(
+        tenantId: TenantId,
+        attributeKey: String,
+    ): Boolean
+}
+
+/**
+ * Signals cache invalidation for a tenant's mappers. Implemented by the
+ * caching decorator in the infrastructure layer; invoked by the write path
+ * ([com.kauth.domain.service.ClaimMapperService]) after every mutating call.
+ */
+fun interface ClaimMapperCacheInvalidator {
+    fun invalidate(tenantId: TenantId)
+
+    companion object {
+        /** No-op invalidator for contexts without a cache (tests, startup). */
+        val NOOP = ClaimMapperCacheInvalidator { _ -> }
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
@@ -14,7 +14,7 @@ import com.kauth.domain.model.User
  * Implementations handle the cryptographic details (RS256 signing, JWKS,
  * key loading). The domain services work exclusively with this abstraction.
  *
- * Implemented by [JwtTokenAdapter].
+ * Implemented by JwtTokenAdapter (in the adapter/token/ package).
  */
 interface TokenPort {
     /**
@@ -25,6 +25,11 @@ interface TokenPort {
      * They are embedded in the token as:
      *   - `realm_access.roles` for tenant-scoped roles
      *   - `resource_access.{clientId}.roles` for client-scoped roles
+     *
+     * [customAccessClaims] and [customIdClaims] are already-projected maps of
+     * claim-name → value from [com.kauth.domain.service.ClaimMapperService].
+     * The adapter stamps each entry onto the corresponding JWT builder without
+     * further logic. Default empty maps preserve pre-feature token shape.
      */
     fun issueUserTokens(
         user: User,
@@ -33,6 +38,8 @@ interface TokenPort {
         scopes: List<String>,
         nonce: String? = null,
         roles: List<Role> = emptyList(),
+        customAccessClaims: Map<String, String> = emptyMap(),
+        customIdClaims: Map<String, String> = emptyMap(),
     ): TokenResponse
 
     /**

--- a/src/main/kotlin/com/kauth/domain/port/UserAttributeRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/UserAttributeRepository.kt
@@ -1,0 +1,35 @@
+package com.kauth.domain.port
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+
+/**
+ * Port (outbound) — per-user key/value attribute storage.
+ *
+ * All operations are tenant-scoped. Attribute deletion cascades from users
+ * at the DB level, but [deleteAllForUser] is provided for explicit cleanup.
+ */
+interface UserAttributeRepository {
+    /** Returns all attributes for a user as a flat key→value map. Empty if none. */
+    fun findAll(
+        userId: UserId,
+        tenantId: TenantId,
+    ): Map<String, String>
+
+    /** Upserts a single attribute. Creates on conflict, overwrites on match. */
+    fun upsert(attribute: UserAttribute)
+
+    /** Deletes a single attribute. Returns true if a row was removed. */
+    fun delete(
+        userId: UserId,
+        tenantId: TenantId,
+        key: String,
+    ): Boolean
+
+    /** Removes every attribute for a user. Used when the user is deleted. */
+    fun deleteAllForUser(
+        userId: UserId,
+        tenantId: TenantId,
+    )
+}

--- a/src/main/kotlin/com/kauth/domain/service/ClaimMapperService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ClaimMapperService.kt
@@ -1,0 +1,139 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.ClaimTokenType
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.ClaimMapperCacheInvalidator
+import com.kauth.domain.port.TenantClaimMapperRepository
+
+/**
+ * Domain service — tenant-level claim-mapper configuration and projection.
+ *
+ * Reserved claim names are blocked at write time to prevent admins from
+ * stomping on standard OIDC claims or KotAuth-proprietary claims.
+ *
+ * [projectClaims] is a pure function: given a mapper list, an attribute map,
+ * and a token type, it returns the claims to inject into that token. It
+ * contains no I/O and is safe to call on the hot token-issuance path.
+ *
+ * Write operations invalidate the tenant's cache entry via the injected
+ * [ClaimMapperCacheInvalidator]. Reads go through the caching layer
+ * ([com.kauth.infrastructure.CachingClaimMapperService]) in production.
+ */
+class ClaimMapperService(
+    private val mapperRepository: TenantClaimMapperRepository,
+    private val cacheInvalidator: ClaimMapperCacheInvalidator = ClaimMapperCacheInvalidator.NOOP,
+) {
+    fun list(tenantId: TenantId): List<TenantClaimMapper> = mapperRepository.findAll(tenantId)
+
+    fun upsert(mapper: TenantClaimMapper): AttributeResult<TenantClaimMapper> {
+        if (mapper.attributeKey.isBlank()) {
+            return AttributeResult.ValidationError("Attribute key must not be blank.")
+        }
+        if (mapper.claimName.isBlank()) {
+            return AttributeResult.ValidationError("Claim name must not be blank.")
+        }
+        if (mapper.claimName.length > TenantClaimMapper.MAX_CLAIM_NAME_LENGTH) {
+            return AttributeResult.ValidationError(
+                "Claim name must be at most ${TenantClaimMapper.MAX_CLAIM_NAME_LENGTH} characters.",
+            )
+        }
+        if (mapper.claimName in RESERVED_CLAIMS) {
+            return AttributeResult.ReservedClaimName(mapper.claimName)
+        }
+
+        val existing = mapperRepository.findAll(mapper.tenantId)
+
+        // Enforce per-tenant cap, but only for new mappers (edits don't count).
+        val isNew = existing.none { it.attributeKey == mapper.attributeKey }
+        if (isNew && existing.size >= TenantClaimMapper.MAX_MAPPERS_PER_TENANT) {
+            return AttributeResult.LimitReached(TenantClaimMapper.MAX_MAPPERS_PER_TENANT)
+        }
+
+        // Reject two attribute keys projecting to the same claim name.
+        val claimNameClash =
+            existing.any { it.claimName == mapper.claimName && it.attributeKey != mapper.attributeKey }
+        if (claimNameClash) {
+            return AttributeResult.DuplicateClaimName(mapper.claimName)
+        }
+
+        mapperRepository.upsert(mapper)
+        cacheInvalidator.invalidate(mapper.tenantId)
+        return AttributeResult.Success(mapper)
+    }
+
+    fun delete(
+        tenantId: TenantId,
+        attributeKey: String,
+    ): AttributeResult<Unit> {
+        mapperRepository.delete(tenantId, attributeKey)
+        cacheInvalidator.invalidate(tenantId)
+        return AttributeResult.Success(Unit)
+    }
+
+    companion object {
+        /**
+         * Claim names that callers may not use as custom claim targets.
+         * Covers standard OIDC/JWT claims and KotAuth-proprietary claims
+         * that downstream consumers rely on.
+         */
+        val RESERVED_CLAIMS =
+            setOf(
+                // RFC 7519 + OIDC core
+                "sub",
+                "iss",
+                "aud",
+                "exp",
+                "iat",
+                "nbf",
+                "jti",
+                "nonce",
+                "auth_time",
+                "acr",
+                "amr",
+                "azp",
+                // OIDC standard profile
+                "email",
+                "email_verified",
+                "name",
+                "preferred_username",
+                "given_name",
+                "family_name",
+                "middle_name",
+                "nickname",
+                "profile",
+                "picture",
+                "website",
+                "gender",
+                "birthdate",
+                "zoneinfo",
+                "locale",
+                "phone_number",
+                "phone_number_verified",
+                "address",
+                "updated_at",
+                // KotAuth proprietary (tokens consumers parse)
+                "tenant_id",
+                "username",
+                "scope",
+                "client_id",
+                "realm_access",
+                "resource_access",
+            )
+
+        /**
+         * Pure projection: for a given mapper list and attribute map, returns
+         * the claim-name→value entries to add to a token of [tokenType].
+         * Attributes missing from the user's set are silently skipped.
+         */
+        fun projectClaims(
+            mappers: List<TenantClaimMapper>,
+            attributes: Map<String, String>,
+            tokenType: ClaimTokenType,
+        ): Map<String, String> =
+            mappers
+                .filter { if (tokenType == ClaimTokenType.ACCESS) it.includeInAccess else it.includeInId }
+                .mapNotNull { mapper -> attributes[mapper.attributeKey]?.let { mapper.claimName to it } }
+                .toMap()
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -4,7 +4,9 @@ import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.AuditEvent
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.AuthorizationCode
+import com.kauth.domain.model.ClaimTokenType
 import com.kauth.domain.model.Session
+import com.kauth.domain.model.TenantClaimMapper
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TokenResponse
 import com.kauth.domain.model.UserId
@@ -16,6 +18,7 @@ import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.TokenPort
+import com.kauth.domain.port.UserAttributeRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.util.SecureTokens
 import com.kauth.domain.util.sha256Hex
@@ -50,7 +53,33 @@ class OAuthService(
     private val passwordHasher: PasswordHasher,
     private val auditLog: AuditLogPort,
     private val roleRepository: RoleRepository? = null,
+    private val userAttributeRepository: UserAttributeRepository? = null,
+    /**
+     * Reader for tenant claim mappers. A lambda (instead of a port interface)
+     * keeps the domain contract trivial while letting the composition root
+     * inject the cached [com.kauth.infrastructure.CachingClaimMapperService].
+     * Default returns empty — preserves pre-feature token shape.
+     */
+    private val claimMappersFor: (TenantId) -> List<TenantClaimMapper> = { _ -> emptyList() },
 ) {
+    /**
+     * Resolves the custom claim maps (access + id) for a user's issued token.
+     * Returns (emptyMap, emptyMap) when either dependency is not wired —
+     * the default adopted by existing tests via the nullable constructor params.
+     */
+    private fun buildCustomClaims(
+        userId: UserId,
+        tenantId: TenantId,
+    ): Pair<Map<String, String>, Map<String, String>> {
+        val repo = userAttributeRepository ?: return emptyMap<String, String>() to emptyMap()
+        val mappers = claimMappersFor(tenantId)
+        if (mappers.isEmpty()) return emptyMap<String, String>() to emptyMap()
+        val attributes = repo.findAll(userId, tenantId)
+        if (attributes.isEmpty()) return emptyMap<String, String>() to emptyMap()
+        val access = ClaimMapperService.projectClaims(mappers, attributes, ClaimTokenType.ACCESS)
+        val id = ClaimMapperService.projectClaims(mappers, attributes, ClaimTokenType.ID)
+        return access to id
+    }
     // -------------------------------------------------------------------------
     // Authorization Code Flow — Step 1: validate request, issue code
     // -------------------------------------------------------------------------
@@ -229,6 +258,7 @@ class OAuthService(
 
         // Resolve effective roles for the user
         val effectiveRoles = roleRepository?.resolveEffectiveRoles(user.id!!, tenant.id) ?: emptyList()
+        val (customAccessClaims, customIdClaims) = buildCustomClaims(user.id!!, tenant.id)
 
         val tokenResponse =
             tokenPort.issueUserTokens(
@@ -238,6 +268,8 @@ class OAuthService(
                 scopes = scopes,
                 nonce = authCode.nonce,
                 roles = effectiveRoles,
+                customAccessClaims = customAccessClaims,
+                customIdClaims = customIdClaims,
             )
 
         // Persist session
@@ -415,6 +447,7 @@ class OAuthService(
 
         // Resolve effective roles for refresh
         val effectiveRoles = roleRepository?.resolveEffectiveRoles(user.id!!, tenant.id) ?: emptyList()
+        val (customAccessClaims, customIdClaims) = buildCustomClaims(user.id!!, tenant.id)
 
         val newTokens =
             tokenPort.issueUserTokens(
@@ -423,6 +456,8 @@ class OAuthService(
                 client = client,
                 scopes = scopes,
                 roles = effectiveRoles,
+                customAccessClaims = customAccessClaims,
+                customIdClaims = customIdClaims,
             )
 
         // Revoke old session, create new (rotation)

--- a/src/main/kotlin/com/kauth/domain/service/UserAttributeService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserAttributeService.kt
@@ -1,0 +1,110 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.UserAttributeRepository
+import com.kauth.domain.port.UserRepository
+import java.time.Instant
+
+/**
+ * Domain service — per-user key/value attribute management.
+ *
+ * Values are opaque strings; keys are opaque to KotAuth. The only validation
+ * is length enforcement. Tenant isolation is verified by loading the user and
+ * comparing tenant IDs before every write.
+ *
+ * Attribute changes are eventually consistent for token consumers — bounded by
+ * the access-token TTL. Callers that need immediate enforcement must validate
+ * server-side on each request.
+ */
+class UserAttributeService(
+    private val userAttributeRepository: UserAttributeRepository,
+    private val userRepository: UserRepository,
+) {
+    fun list(
+        userId: UserId,
+        tenantId: TenantId,
+    ): AttributeResult<Map<String, String>> {
+        if (userRepository.findById(userId, tenantId) == null) {
+            return AttributeResult.NotFound("user")
+        }
+        return AttributeResult.Success(userAttributeRepository.findAll(userId, tenantId))
+    }
+
+    fun upsert(
+        userId: UserId,
+        tenantId: TenantId,
+        key: String,
+        value: String,
+    ): AttributeResult<UserAttribute> {
+        if (key.isBlank()) {
+            return AttributeResult.ValidationError("Attribute key must not be blank.")
+        }
+        if (key.length > UserAttribute.MAX_KEY_LENGTH) {
+            return AttributeResult.ValidationError(
+                "Attribute key must be at most ${UserAttribute.MAX_KEY_LENGTH} characters.",
+            )
+        }
+        if (value.length > UserAttribute.MAX_VALUE_LENGTH) {
+            return AttributeResult.ValidationError(
+                "Attribute value must be at most ${UserAttribute.MAX_VALUE_LENGTH} characters.",
+            )
+        }
+        if (userRepository.findById(userId, tenantId) == null) {
+            return AttributeResult.NotFound("user")
+        }
+        val attribute =
+            UserAttribute(
+                userId = userId,
+                tenantId = tenantId,
+                key = key,
+                value = value,
+                updatedAt = Instant.now(),
+            )
+        userAttributeRepository.upsert(attribute)
+        return AttributeResult.Success(attribute)
+    }
+
+    fun delete(
+        userId: UserId,
+        tenantId: TenantId,
+        key: String,
+    ): AttributeResult<Unit> {
+        if (userRepository.findById(userId, tenantId) == null) {
+            return AttributeResult.NotFound("user")
+        }
+        userAttributeRepository.delete(userId, tenantId, key)
+        return AttributeResult.Success(Unit)
+    }
+}
+
+/**
+ * Sealed result type for user-attribute and claim-mapper operations.
+ * Services never throw for business errors — callers pattern-match on this.
+ */
+sealed class AttributeResult<out T> {
+    data class Success<T>(
+        val value: T,
+    ) : AttributeResult<T>()
+
+    data class NotFound(
+        val resource: String,
+    ) : AttributeResult<Nothing>()
+
+    data class ValidationError(
+        val reason: String,
+    ) : AttributeResult<Nothing>()
+
+    data class ReservedClaimName(
+        val claimName: String,
+    ) : AttributeResult<Nothing>()
+
+    data class DuplicateClaimName(
+        val claimName: String,
+    ) : AttributeResult<Nothing>()
+
+    data class LimitReached(
+        val max: Int,
+    ) : AttributeResult<Nothing>()
+}

--- a/src/main/kotlin/com/kauth/infrastructure/CachingClaimMapperService.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/CachingClaimMapperService.kt
@@ -1,0 +1,59 @@
+package com.kauth.infrastructure
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.ClaimMapperCacheInvalidator
+import com.kauth.domain.port.TenantClaimMapperRepository
+import com.kauth.domain.service.AttributeResult
+import com.kauth.domain.service.ClaimMapperService
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Caching decorator around [ClaimMapperService] for the hot token-issuance path.
+ *
+ * Reads ([list]) are served from an in-memory cache with a [ttlMillis] TTL.
+ * Writes go through the wrapped [ClaimMapperService], which invokes this class's
+ * invalidator to drop the cached entry. The wiring is self-referential: the
+ * underlying service is constructed with `this::invalidate` as its invalidator.
+ */
+class CachingClaimMapperService(
+    mapperRepository: TenantClaimMapperRepository,
+    private val ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    private val clock: () -> Instant = Instant::now,
+) : ClaimMapperCacheInvalidator {
+    private data class CachedMappers(
+        val mappers: List<TenantClaimMapper>,
+        val expireAt: Instant,
+    )
+
+    private val cache = ConcurrentHashMap<Int, CachedMappers>()
+
+    private val delegate: ClaimMapperService = ClaimMapperService(mapperRepository, this)
+
+    fun list(tenantId: TenantId): List<TenantClaimMapper> {
+        val now = clock()
+        val cached = cache[tenantId.value]
+        if (cached != null && cached.expireAt.isAfter(now)) {
+            return cached.mappers
+        }
+        val fresh = delegate.list(tenantId)
+        cache[tenantId.value] = CachedMappers(fresh, now.plusMillis(ttlMillis))
+        return fresh
+    }
+
+    fun upsert(mapper: TenantClaimMapper): AttributeResult<TenantClaimMapper> = delegate.upsert(mapper)
+
+    fun delete(
+        tenantId: TenantId,
+        attributeKey: String,
+    ): AttributeResult<Unit> = delegate.delete(tenantId, attributeKey)
+
+    override fun invalidate(tenantId: TenantId) {
+        cache.remove(tenantId.value)
+    }
+
+    companion object {
+        const val DEFAULT_TTL_MILLIS: Long = 60_000L
+    }
+}

--- a/src/main/resources/db/migration/V33__user_attributes.sql
+++ b/src/main/resources/db/migration/V33__user_attributes.sql
@@ -1,0 +1,15 @@
+-- V33: Per-user key/value metadata.
+-- Values are always string-encoded — callers serialize structured data themselves.
+-- Projected into JWT claims via tenant_claim_mappers (V34).
+
+CREATE TABLE user_attributes (
+    user_id    INTEGER     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tenant_id  INTEGER     NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    key        VARCHAR(64) NOT NULL,
+    value      TEXT        NOT NULL CHECK (char_length(value) <= 1024),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, key)
+);
+
+-- Covers the hot-path query: "all attributes for user X in tenant Y".
+CREATE INDEX idx_user_attributes_tenant_user ON user_attributes (tenant_id, user_id);

--- a/src/main/resources/db/migration/V34__tenant_claim_mappers.sql
+++ b/src/main/resources/db/migration/V34__tenant_claim_mappers.sql
@@ -1,0 +1,15 @@
+-- V34: Tenant-level rules that project user attributes into issued JWTs.
+-- (tenant_id, attribute_key) is the natural PK — one mapping per attribute per tenant.
+-- (tenant_id, claim_name) is UNIQUE — two attributes cannot collide on the same claim name.
+
+CREATE TABLE tenant_claim_mappers (
+    tenant_id         INTEGER      NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    attribute_key     VARCHAR(64)  NOT NULL,
+    claim_name        VARCHAR(128) NOT NULL,
+    include_in_access BOOLEAN      NOT NULL DEFAULT TRUE,
+    include_in_id     BOOLEAN      NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (tenant_id, attribute_key)
+);
+
+-- Enforces no two attributes in the same tenant projecting to the same claim name.
+CREATE UNIQUE INDEX idx_claim_mappers_claim_name ON tenant_claim_mappers (tenant_id, claim_name);

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -274,7 +274,7 @@ components:
           description: |
             The JWT claim name. Cannot be a reserved OIDC claim name
             (`sub`, `iss`, `aud`, `exp`, `iat`, `email`, `tenant_id`, etc.).
-            Use a prefix like `custom:plan` to avoid collisions.
+            Use a prefix like `custom:department` to avoid collisions.
         includeInAccess: { type: boolean, default: true }
         includeInId:     { type: boolean, default: false }
 

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -33,6 +33,20 @@ info:
     | `sessions:read`      | List active sessions                         |
     | `sessions:write`     | Revoke sessions                              |
     | `audit_logs:read`    | Read audit log events                        |
+    | `user_attributes:read`  | Read custom per-user attributes           |
+    | `user_attributes:write` | Create, update, delete per-user attributes |
+    | `claim_mappers:read`    | List tenant claim mappers                 |
+    | `claim_mappers:write`   | Create, update, delete claim mappers      |
+
+    ## Custom attributes and JWT claims
+
+    You can attach arbitrary key/value string attributes to users and project them
+    into issued JWTs via tenant-level **claim mappers**. Changes take effect on the
+    next access-token issuance (no live-session mutation).
+
+    > **Security note:** attribute values flow unencrypted into JWTs, which are
+    > base64-decodable by anyone in possession of the token. Do not store PII or
+    > secrets as user attributes unless the token consumers are fully trusted.
 
     ## Errors
 
@@ -54,10 +68,8 @@ servers:
     variables:
       baseUrl:
         default: "http://localhost:8080"
-        description: Base URL of your KotAuth instance (e.g. https://auth.yourdomain.com)
       tenantSlug:
         default: "master"
-        description: The slug of the workspace (tenant) to operate on
 
 security:
   - bearerAuth: []
@@ -215,6 +227,56 @@ components:
         details:
           type: object
           additionalProperties: { type: string }
+
+    # ---- User attributes + claim mappers ----
+    UserAttributesDto:
+      type: object
+      required: [attributes]
+      properties:
+        attributes:
+          type: object
+          description: Flat key→value map. Empty object if the user has no attributes.
+          additionalProperties: { type: string }
+
+    UpsertUserAttributeRequest:
+      type: object
+      required: [value]
+      properties:
+        value:
+          type: string
+          maxLength: 1024
+          description: The attribute value. Always stored as a string — callers serialize their own types.
+
+    ClaimMapperDto:
+      type: object
+      required: [attributeKey, claimName, includeInAccess, includeInId]
+      properties:
+        attributeKey:    { type: string, maxLength: 64 }
+        claimName:       { type: string, maxLength: 128 }
+        includeInAccess: { type: boolean }
+        includeInId:     { type: boolean }
+
+    ClaimMappersDto:
+      type: object
+      required: [mappers]
+      properties:
+        mappers:
+          type: array
+          items: { $ref: "#/components/schemas/ClaimMapperDto" }
+
+    UpsertClaimMapperRequest:
+      type: object
+      required: [claimName]
+      properties:
+        claimName:
+          type: string
+          maxLength: 128
+          description: |
+            The JWT claim name. Cannot be a reserved OIDC claim name
+            (`sub`, `iss`, `aud`, `exp`, `iat`, `email`, `tenant_id`, etc.).
+            Use a prefix like `custom:plan` to avoid collisions.
+        includeInAccess: { type: boolean, default: true }
+        includeInId:     { type: boolean, default: false }
 
   responses:
     Unauthorized:
@@ -739,6 +801,152 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
 
+  # ==========================================================================
+  # User Attributes
+  # ==========================================================================
+  /users/{userId}/attributes:
+    get:
+      summary: List all attributes for a user
+      tags: [User Attributes]
+      security: [{ bearerAuth: [user_attributes:read] }]
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema: { type: integer }
+      responses:
+        "200":
+          description: User attributes
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/UserAttributesDto" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /users/{userId}/attributes/{key}:
+    put:
+      summary: Create or update a user attribute
+      description: |
+        Upserts the attribute. Values are strings — callers serialize structured
+        data themselves. Changes propagate to issued JWTs on the next token issuance.
+      tags: [User Attributes]
+      security: [{ bearerAuth: [user_attributes:write] }]
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema: { type: integer }
+        - in: path
+          name: key
+          required: true
+          schema: { type: string, maxLength: 64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpsertUserAttributeRequest" }
+      responses:
+        "204": { description: Attribute saved }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+
+    delete:
+      summary: Delete a user attribute
+      description: |
+        Removes the attribute entirely. Different from setting it to an empty
+        string — the claim will not be projected into tokens at all.
+      tags: [User Attributes]
+      security: [{ bearerAuth: [user_attributes:write] }]
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema: { type: integer }
+        - in: path
+          name: key
+          required: true
+          schema: { type: string, maxLength: 64 }
+      responses:
+        "204": { description: Attribute deleted (idempotent — 204 even if the key was missing) }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  # ==========================================================================
+  # Claim Mappers
+  # ==========================================================================
+  /claim-mappers:
+    get:
+      summary: List all claim mappers for the tenant
+      tags: [Claim Mappers]
+      security: [{ bearerAuth: [claim_mappers:read] }]
+      responses:
+        "200":
+          description: Configured claim mappers
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ClaimMappersDto" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
+  /claim-mappers/{attributeKey}:
+    put:
+      summary: Create or update a claim mapper
+      description: |
+        Upserts the mapping from `attributeKey` to `claimName`.
+
+        - Reserved OIDC claim names (`sub`, `iss`, `aud`, etc.) return **400**.
+        - Two attribute keys mapping to the same claim name in one tenant
+          return **409 Conflict**.
+        - A tenant may configure at most 20 claim mappers — further writes
+          return **409**.
+      tags: [Claim Mappers]
+      security: [{ bearerAuth: [claim_mappers:write] }]
+      parameters:
+        - in: path
+          name: attributeKey
+          required: true
+          schema: { type: string, maxLength: 64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpsertClaimMapperRequest" }
+      responses:
+        "204": { description: Mapper saved }
+        "400":
+          description: Reserved claim name
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "409":
+          description: Duplicate claim name or mapper limit reached
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+
+    delete:
+      summary: Delete a claim mapper
+      description: |
+        Deleting a mapper immediately stops the claim from appearing in tokens
+        on the next issuance, even if user attributes for that key still exist.
+      tags: [Claim Mappers]
+      security: [{ bearerAuth: [claim_mappers:write] }]
+      parameters:
+        - in: path
+          name: attributeKey
+          required: true
+          schema: { type: string, maxLength: 64 }
+      responses:
+        "204": { description: Mapper deleted (idempotent) }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
 tags:
   - name: Users
     description: User lifecycle management
@@ -752,3 +960,7 @@ tags:
     description: Active user sessions
   - name: Audit Logs
     description: Security event audit trail
+  - name: User Attributes
+    description: Per-user custom key/value metadata (projected into JWTs via claim mappers)
+  - name: Claim Mappers
+    description: Tenant-level configuration that projects user attributes into issued JWTs

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -34,7 +34,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
@@ -156,16 +155,13 @@ class AdminApiKeysTest {
         val adminRole =
             roleRepo.add(
                 com.kauth.domain.model.Role(
-                    tenantId =
-                        com.kauth.domain.model
-                            .TenantId(1),
+                    tenantId = TenantId(1),
                     name = "admin",
                     scope = com.kauth.domain.model.RoleScope.TENANT,
                 ),
             )
         roleRepo.assignRoleToUser(
-            com.kauth.domain.model
-                .UserId(1),
+            UserId(1),
             adminRole.id!!,
         )
     }
@@ -284,7 +280,7 @@ class AdminApiKeysTest {
                         username = "admin",
                     ),
                 )
-                call.respond(io.ktor.http.HttpStatusCode.OK, "session set")
+                call.respond(HttpStatusCode.OK, "session set")
             }
             adminRoutes(
                 adminService = buildAdminService(),
@@ -299,6 +295,15 @@ class AdminApiKeysTest {
                 apiKeyService = apiKeyService,
                 encryptionService = encryptionService,
                 roleRepository = roleRepo,
+                userAttributeService =
+                    com.kauth.domain.service.UserAttributeService(
+                        userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                        userRepository = userRepo,
+                    ),
+                claimMapperService =
+                    com.kauth.infrastructure.CachingClaimMapperService(
+                        mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                    ),
             )
         }
     }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
@@ -140,10 +140,10 @@ class AdminRoutesTest {
         // Seed admin role and assign to admin user (required for OAuth callback role check)
         val adminRole =
             roleRepo.add(
-                com.kauth.domain.model.Role(
+                Role(
                     tenantId = TenantId(1),
                     name = "admin",
-                    scope = com.kauth.domain.model.RoleScope.TENANT,
+                    scope = RoleScope.TENANT,
                 ),
             )
         roleRepo.assignRoleToUser(UserId(1), adminRole.id!!)
@@ -617,6 +617,15 @@ class AdminRoutesTest {
                 keyProvisioningService = keyProvisioningService,
                 encryptionService = encryptionService,
                 oauthService = null,
+                userAttributeService =
+                    com.kauth.domain.service.UserAttributeService(
+                        userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                        userRepository = userRepo,
+                    ),
+                claimMapperService =
+                    com.kauth.infrastructure.CachingClaimMapperService(
+                        mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                    ),
             )
         }
     }
@@ -624,9 +633,9 @@ class AdminRoutesTest {
     /**
      * Test app with a mockk OAuthService stub.
      *
-     * The stub returns an [OAuthResult.Success] whose access_token equals whatever
+     * The stub returns an `OAuthResult.Success` whose access_token equals whatever
      * code was passed in — this lets the test craft a fake JWT as the "code" so that
-     * [decodeJwtPayload] inside the route can parse `sub` and `preferred_username`.
+     * `decodeJwtPayload` inside the route can parse `sub` and `preferred_username`.
      *
      * When [adminRole] is true the admin user is given the "admin" role on the master
      * tenant so the role-check branch succeeds. When false the role check fails → 403.
@@ -691,6 +700,15 @@ class AdminRoutesTest {
                 oauthService = oauthSvcMock,
                 selfServiceService = buildSelfService(),
                 roleRepository = roleRepo,
+                userAttributeService =
+                    com.kauth.domain.service.UserAttributeService(
+                        userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                        userRepository = userRepo,
+                    ),
+                claimMapperService =
+                    com.kauth.infrastructure.CachingClaimMapperService(
+                        mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                    ),
             )
         }
     }
@@ -713,12 +731,16 @@ class AdminRoutesTest {
     }
 
     /**
-     * Builds a minimal fake JWT whose payload encodes [userId] and [username]
-     * in the format that [decodeJwtPayload] inside AdminRoutes.kt can parse.
+     * Builds a minimal fake JWT whose payload encodes the userId and username
+     * in the format that `decodeJwtPayload` inside AdminRoutes.kt can parse.
      *
      * Format: "header.payload.sig" where payload is base64url-encoded JSON.
      * The regex inside decodeJwtPayload matches: "key": "value" or "key": 123
+     *
+     * Note: the helper only has one caller inside this file that always passes
+     * (1, "admin") — the param values are locked in by that single use, not a bug.
      */
+    @Suppress("SameParameterValue")
     private fun buildFakeJwt(
         userId: Int,
         username: String,

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -30,7 +30,6 @@ import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
@@ -148,16 +147,13 @@ class AdminSettingsTest {
         val adminRole =
             roleRepo.add(
                 com.kauth.domain.model.Role(
-                    tenantId =
-                        com.kauth.domain.model
-                            .TenantId(1),
+                    tenantId = TenantId(1),
                     name = "admin",
                     scope = com.kauth.domain.model.RoleScope.TENANT,
                 ),
             )
         roleRepo.assignRoleToUser(
-            com.kauth.domain.model
-                .UserId(1),
+            UserId(1),
             adminRole.id!!,
         )
     }
@@ -349,7 +345,7 @@ class AdminSettingsTest {
                         username = "admin",
                     ),
                 )
-                call.respond(io.ktor.http.HttpStatusCode.OK, "session set")
+                call.respond(HttpStatusCode.OK, "session set")
             }
             adminRoutes(
                 adminService = buildAdminService(),
@@ -363,6 +359,15 @@ class AdminSettingsTest {
                 keyProvisioningService = keyProvisioningService,
                 encryptionService = encryptionService,
                 roleRepository = roleRepo,
+                userAttributeService =
+                    com.kauth.domain.service.UserAttributeService(
+                        userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                        userRepository = userRepo,
+                    ),
+                claimMapperService =
+                    com.kauth.infrastructure.CachingClaimMapperService(
+                        mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                    ),
             )
         }
     }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
@@ -1,0 +1,420 @@
+package com.kauth.adapter.web.admin
+
+import com.kauth.adapter.web.AppInfo
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.RoleGroupService
+import com.kauth.domain.service.UserAttributeService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuditLogRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.CachingClaimMapperService
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.KeyProvisioningService
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the admin console routes that manage user attributes
+ * and tenant claim mappers.
+ */
+class AdminUserAttributesAndClaimMappersTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val roleRepo = FakeRoleRepository()
+    private val groupRepo = FakeGroupRepository()
+    private val auditLogRepo = FakeAuditLogRepository()
+    private val auditLogPort = FakeAuditLogPort()
+    private val userAttributeRepo = FakeUserAttributeRepository()
+    private val claimMapperRepo = FakeTenantClaimMapperRepository()
+    private val hasher = FakePasswordHasher()
+
+    private val keyProvisioningService = mockk<KeyProvisioningService>(relaxed = true)
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-plus-more")
+
+    private val userAttributeService =
+        UserAttributeService(
+            userAttributeRepository = userAttributeRepo,
+            userRepository = userRepo,
+        )
+    private val claimMapperService =
+        CachingClaimMapperService(mapperRepository = claimMapperRepo)
+
+    private val masterTenant =
+        Tenant(id = TenantId(1), slug = "master", displayName = "Master", issuerUrl = null, theme = TenantTheme.DEFAULT)
+    private val acme =
+        Tenant(id = TenantId(2), slug = "acme", displayName = "Acme", issuerUrl = null, theme = TenantTheme.DEFAULT)
+
+    private val adminUser =
+        User(
+            id = UserId(1),
+            tenantId = TenantId(1),
+            username = "admin",
+            email = "admin@kauth",
+            fullName = "Admin",
+            passwordHash = hasher.hash("admin"),
+        )
+    private val alice =
+        User(
+            id = UserId(10),
+            tenantId = TenantId(2),
+            username = "alice",
+            email = "alice@acme",
+            fullName = "Alice",
+            passwordHash = hasher.hash("pw"),
+        )
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        sessionRepo.clear()
+        roleRepo.clear()
+        groupRepo.clear()
+        auditLogRepo.clear()
+        auditLogPort.clear()
+        userAttributeRepo.clear()
+        claimMapperRepo.clear()
+
+        tenantRepo.add(masterTenant)
+        tenantRepo.add(acme)
+        userRepo.add(adminUser)
+        userRepo.add(alice)
+
+        val adminRole =
+            roleRepo.save(
+                com.kauth.domain.model.Role(
+                    id = null,
+                    tenantId = TenantId(1),
+                    name = "admin",
+                    scope = com.kauth.domain.model.RoleScope.TENANT,
+                ),
+            )
+        roleRepo.assignRoleToUser(UserId(1), adminRole.id!!)
+    }
+
+    // =========================================================================
+    // User attributes admin UI
+    // =========================================================================
+
+    @Test
+    fun `GET user detail renders attributes section`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(2), "plan", "trial", Instant.now()))
+
+            val response = authed.get("/admin/workspaces/acme/users/10")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Custom Attributes"))
+            assertTrue(body.contains("plan"))
+            assertTrue(body.contains("trial"))
+        }
+
+    @Test
+    fun `GET user detail shows 'Configure mapping' link for unmapped attributes`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(2), "plan", "trial", Instant.now()))
+
+            val response = authed.get("/admin/workspaces/acme/users/10")
+            assertTrue(response.bodyAsText().contains("Configure mapping"))
+        }
+
+    @Test
+    fun `GET user detail shows claim badge for mapped attributes`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(2), "plan", "trial", Instant.now()))
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(2), "plan", "custom:plan"))
+
+            val response = authed.get("/admin/workspaces/acme/users/10")
+            assertTrue(response.bodyAsText().contains("→ custom:plan"))
+        }
+
+    @Test
+    fun `POST attributes creates a new attribute and redirects back`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/users/10/attributes",
+                    formParameters =
+                        Parameters.build {
+                            append("key", "plan")
+                            append("value", "trial")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(location.contains("/admin/workspaces/acme/users/10"))
+            assertEquals("trial", userAttributeRepo.findAll(UserId(10), TenantId(2))["plan"])
+        }
+
+    @Test
+    fun `POST attribute delete removes it`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(2), "plan", "trial", Instant.now()))
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/users/10/attributes/plan/delete",
+                    formParameters = Parameters.build {},
+                )
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(userAttributeRepo.findAll(UserId(10), TenantId(2)).isEmpty())
+        }
+
+    // =========================================================================
+    // Claim mappers admin UI
+    // =========================================================================
+
+    @Test
+    fun `GET claim-mappers list renders empty state`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            val response = authed.get("/admin/workspaces/acme/settings/claim-mappers")
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("No claim mappers configured"))
+        }
+
+    @Test
+    fun `GET claim-mappers list renders configured mappers`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(2), "plan", "custom:plan"))
+
+            val response = authed.get("/admin/workspaces/acme/settings/claim-mappers")
+            val body = response.bodyAsText()
+            assertTrue(body.contains("plan"))
+            assertTrue(body.contains("custom:plan"))
+        }
+
+    @Test
+    fun `POST claim-mappers creates a new mapper`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/claim-mappers",
+                    formParameters =
+                        Parameters.build {
+                            append("attributeKey", "plan")
+                            append("claimName", "custom:plan")
+                            append("includeInAccess", "true")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val stored = claimMapperRepo.findAll(TenantId(2)).single()
+            assertEquals("plan", stored.attributeKey)
+            assertEquals("custom:plan", stored.claimName)
+            assertTrue(stored.includeInAccess)
+        }
+
+    @Test
+    fun `POST claim-mappers returns 422 for reserved claim name`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/claim-mappers",
+                    formParameters =
+                        Parameters.build {
+                            append("attributeKey", "my_sub")
+                            append("claimName", "sub")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            assertTrue(response.bodyAsText().contains("reserved"))
+        }
+
+    @Test
+    fun `POST claim-mapper delete removes it`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(2), "plan", "custom:plan"))
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/claim-mappers/plan/delete",
+                    formParameters = Parameters.build {},
+                )
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(claimMapperRepo.findAll(TenantId(2)).isEmpty())
+        }
+
+    // -------------------------------------------------------------------------
+    // Shared wiring
+    // -------------------------------------------------------------------------
+
+    private fun buildAdminService() =
+        AdminService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            passwordHasher = hasher,
+            auditLog = auditLogPort,
+            sessionRepository = sessionRepo,
+            selfServiceService =
+                UserSelfServiceService(
+                    userRepository = userRepo,
+                    tenantRepository = tenantRepo,
+                    sessionRepository = sessionRepo,
+                    passwordHasher = hasher,
+                    auditLog = auditLogPort,
+                    evTokenRepo = FakeEmailVerificationTokenRepository(),
+                    prTokenRepo = FakePasswordResetTokenRepository(),
+                    emailPort = FakeEmailPort(),
+                    emailScope = CoroutineScope(Dispatchers.Unconfined),
+                ),
+        )
+
+    private fun buildRoleGroupService() =
+        RoleGroupService(
+            roleRepository = roleRepo,
+            groupRepository = groupRepo,
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            auditLog = auditLogPort,
+        )
+
+    private suspend fun login(client: io.ktor.client.HttpClient) {
+        client.submitForm(
+            url = "/test-admin-login",
+            formParameters = Parameters.build {},
+        )
+    }
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<AdminSession>("KOTAUTH_ADMIN") {
+                transform(SessionTransportTransformerMessageAuthentication(ByteArray(32)))
+            }
+        }
+        routing {
+            post("/test-admin-login") {
+                call.sessions.set(
+                    AdminSession(
+                        userId = 1,
+                        tenantId = 1,
+                        username = "admin",
+                        accessToken = "",
+                        idToken = "",
+                        adminSessionId = null,
+                    ),
+                )
+                call.respond(HttpStatusCode.OK, "session set")
+            }
+            adminRoutes(
+                adminService = buildAdminService(),
+                roleGroupService = buildRoleGroupService(),
+                appInfo = AppInfo(),
+                tenantRepository = tenantRepo,
+                applicationRepository = appRepo,
+                userRepository = userRepo,
+                sessionRepository = sessionRepo,
+                auditLogRepository = auditLogRepo,
+                keyProvisioningService = keyProvisioningService,
+                encryptionService = encryptionService,
+                roleRepository = roleRepo,
+                userAttributeService = userAttributeService,
+                claimMapperService = claimMapperService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -37,7 +37,6 @@ import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
@@ -299,6 +298,15 @@ class AdminWebhooksTest {
                 webhookService = webhookService,
                 encryptionService = encryptionService,
                 roleRepository = roleRepo,
+                userAttributeService =
+                    com.kauth.domain.service.UserAttributeService(
+                        userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                        userRepository = userRepo,
+                    ),
+                claimMapperService =
+                    com.kauth.infrastructure.CachingClaimMapperService(
+                        mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+                    ),
             )
         }
     }

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
@@ -1,0 +1,361 @@
+package com.kauth.adapter.web.api
+
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.ApiKeyResult
+import com.kauth.domain.service.ApiKeyService
+import com.kauth.fakes.FakeApiKeyRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.ApiKeyPrincipal
+import com.kauth.infrastructure.CachingClaimMapperService
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.bearer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the claim-mapper REST API.
+ */
+class ApiClaimMapperRoutesTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val apiKeyRepo = FakeApiKeyRepository()
+    private val claimMapperRepo = FakeTenantClaimMapperRepository()
+    private val hasher = FakePasswordHasher()
+
+    private val apiKeyService =
+        ApiKeyService(apiKeyRepository = apiKeyRepo, tenantRepository = tenantRepo)
+    private val claimMapperService =
+        CachingClaimMapperService(mapperRepository = claimMapperRepo)
+
+    private val tenant =
+        Tenant(id = TenantId(1), slug = "acme", displayName = "Acme", issuerUrl = null, theme = TenantTheme.DEFAULT)
+
+    private var readKey: String = ""
+    private var writeKey: String = ""
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        apiKeyRepo.clear()
+        claimMapperRepo.clear()
+
+        tenantRepo.add(tenant)
+        // Dummy user needed to spin up the shared dependencies inside installTestApp().
+        userRepo.add(
+            User(
+                id = UserId(1),
+                tenantId = TenantId(1),
+                username = "admin",
+                email = "admin@acme.com",
+                fullName = "Admin",
+                passwordHash = hasher.hash("pw"),
+            ),
+        )
+
+        readKey =
+            (
+                apiKeyService.create(
+                    tenantId = TenantId(1),
+                    name = "Read",
+                    scopes = listOf(ApiScope.CLAIM_MAPPERS_READ),
+                ) as ApiKeyResult.Success
+            ).value.rawKey
+        writeKey =
+            (
+                apiKeyService.create(
+                    tenantId = TenantId(1),
+                    name = "Write",
+                    scopes = listOf(ApiScope.CLAIM_MAPPERS_READ, ApiScope.CLAIM_MAPPERS_WRITE),
+                ) as ApiKeyResult.Success
+            ).value.rawKey
+    }
+
+    // =========================================================================
+    // GET /claim-mappers
+    // =========================================================================
+
+    @Test
+    fun `GET mappers returns empty list when none configured`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.get("/t/acme/api/v1/claim-mappers") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"mappers\":[]"))
+        }
+
+    @Test
+    fun `GET mappers returns configured mappers`() =
+        testApplication {
+            application { installTestApp() }
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "plan", "custom:plan"))
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "trial_ends", "custom:trial_ends"))
+
+            val response =
+                client.get("/t/acme/api/v1/claim-mappers") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"attributeKey\":\"plan\""))
+            assertTrue(body.contains("\"claimName\":\"custom:plan\""))
+            assertTrue(body.contains("\"attributeKey\":\"trial_ends\""))
+        }
+
+    @Test
+    fun `GET mappers returns 403 when scope missing`() =
+        testApplication {
+            application { installTestApp() }
+            val noScopeKey =
+                (
+                    apiKeyService.create(
+                        tenantId = TenantId(1),
+                        name = "No Scope",
+                        scopes = listOf(ApiScope.USERS_READ),
+                    ) as ApiKeyResult.Success
+                ).value.rawKey
+
+            val response =
+                client.get("/t/acme/api/v1/claim-mappers") { bearerAuth(noScopeKey) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    // =========================================================================
+    // PUT /claim-mappers/{attributeKey}
+    // =========================================================================
+
+    @Test
+    fun `PUT mapper creates new mapping`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"custom:plan","includeInAccess":true,"includeInId":true}""")
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            val stored = claimMapperRepo.findAll(TenantId(1)).single()
+            assertEquals("plan", stored.attributeKey)
+            assertEquals("custom:plan", stored.claimName)
+            assertEquals(true, stored.includeInAccess)
+            assertEquals(true, stored.includeInId)
+        }
+
+    @Test
+    fun `PUT mapper overwrites existing mapping`() =
+        testApplication {
+            application { installTestApp() }
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "plan", "custom:plan"))
+
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"custom:tier","includeInAccess":false,"includeInId":true}""")
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            val stored = claimMapperRepo.findAll(TenantId(1)).single { it.attributeKey == "plan" }
+            assertEquals("custom:tier", stored.claimName)
+        }
+
+    @Test
+    fun `PUT mapper returns 400 for reserved OIDC claim name`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/my_sub") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"sub"}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertTrue(response.bodyAsText().contains("Reserved"))
+            assertTrue(response.bodyAsText().contains("'sub'"))
+        }
+
+    @Test
+    fun `PUT mapper returns 409 for duplicate claim name`() =
+        testApplication {
+            application { installTestApp() }
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "plan", "custom:tier"))
+
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/subscription") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"custom:tier"}""")
+                }
+
+            assertEquals(HttpStatusCode.Conflict, response.status)
+        }
+
+    @Test
+    fun `PUT mapper returns 403 when scope missing`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/plan") {
+                    bearerAuth(readKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"custom:plan"}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `PUT mapper returns 409 when tenant cap reached`() =
+        testApplication {
+            application { installTestApp() }
+            repeat(TenantClaimMapper.MAX_MAPPERS_PER_TENANT) { i ->
+                claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "attr_$i", "custom:$i"))
+            }
+
+            val response =
+                client.put("/t/acme/api/v1/claim-mappers/attr_overflow") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"claimName":"custom:overflow"}""")
+                }
+
+            assertEquals(HttpStatusCode.Conflict, response.status)
+            assertTrue(response.bodyAsText().contains("Mapper Limit Reached"))
+        }
+
+    // =========================================================================
+    // DELETE /claim-mappers/{attributeKey}
+    // =========================================================================
+
+    @Test
+    fun `DELETE mapper removes it and returns 204`() =
+        testApplication {
+            application { installTestApp() }
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "plan", "custom:plan"))
+
+            val response =
+                client.delete("/t/acme/api/v1/claim-mappers/plan") { bearerAuth(writeKey) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            assertTrue(claimMapperRepo.findAll(TenantId(1)).isEmpty())
+        }
+
+    @Test
+    fun `DELETE missing mapper still returns 204`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.delete("/t/acme/api/v1/claim-mappers/nonexistent") { bearerAuth(writeKey) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+        }
+
+    @Test
+    fun `DELETE mapper returns 403 when scope missing`() =
+        testApplication {
+            application { installTestApp() }
+            claimMapperRepo.upsert(TenantClaimMapper(TenantId(1), "plan", "custom:plan"))
+
+            val response =
+                client.delete("/t/acme/api/v1/claim-mappers/plan") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    // -------------------------------------------------------------------------
+    // Test application wiring
+    // -------------------------------------------------------------------------
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Authentication) {
+            bearer("api-key") {
+                realm = "KotAuth REST API"
+                authenticate { creds ->
+                    if (creds.token.startsWith("kauth_")) ApiKeyPrincipal(rawToken = creds.token) else null
+                }
+            }
+        }
+
+        val userAttributeService =
+            com.kauth.domain.service.UserAttributeService(
+                userAttributeRepository = com.kauth.fakes.FakeUserAttributeRepository(),
+                userRepository = userRepo,
+            )
+
+        routing {
+            apiRoutes(
+                apiKeyService = apiKeyService,
+                tenantRepository = tenantRepo,
+                roleRepository = com.kauth.fakes.FakeRoleRepository(),
+                groupRepository = com.kauth.fakes.FakeGroupRepository(),
+                applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                auditLogRepository = com.kauth.fakes.FakeAuditLogRepository(),
+                roleGroupService =
+                    com.kauth.domain.service.RoleGroupService(
+                        roleRepository = com.kauth.fakes.FakeRoleRepository(),
+                        groupRepository = com.kauth.fakes.FakeGroupRepository(),
+                        tenantRepository = tenantRepo,
+                        userRepository = userRepo,
+                        applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                        auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                    ),
+                adminService =
+                    com.kauth.domain.service.AdminService(
+                        tenantRepository = tenantRepo,
+                        userRepository = userRepo,
+                        applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                        passwordHasher = hasher,
+                        auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                        sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                        selfServiceService =
+                            com.kauth.domain.service.UserSelfServiceService(
+                                userRepository = userRepo,
+                                tenantRepository = tenantRepo,
+                                sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                                passwordHasher = hasher,
+                                auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                                evTokenRepo = com.kauth.fakes.FakeEmailVerificationTokenRepository(),
+                                prTokenRepo = com.kauth.fakes.FakePasswordResetTokenRepository(),
+                                emailPort = com.kauth.fakes.FakeEmailPort(),
+                                emailScope =
+                                    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+                            ),
+                    ),
+                userAttributeService = userAttributeService,
+                claimMapperService = claimMapperService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -154,6 +154,20 @@ class ApiRoutesTest {
             auditLog = auditLogPort,
         )
 
+    private val userAttributeRepo = com.kauth.fakes.FakeUserAttributeRepository()
+    private val claimMapperRepo = com.kauth.fakes.FakeTenantClaimMapperRepository()
+
+    private val userAttributeService =
+        com.kauth.domain.service.UserAttributeService(
+            userAttributeRepository = userAttributeRepo,
+            userRepository = userRepo,
+        )
+
+    private val claimMapperService =
+        com.kauth.infrastructure.CachingClaimMapperService(
+            mapperRepository = claimMapperRepo,
+        )
+
     private var rawApiKey: String = ""
 
     @BeforeTest
@@ -170,6 +184,8 @@ class ApiRoutesTest {
         evTokenRepo.clear()
         prTokenRepo.clear()
         emailPort.clear()
+        userAttributeRepo.clear()
+        claimMapperRepo.clear()
 
         tenantRepo.add(tenant)
         tenantRepo.add(otherTenant)
@@ -823,6 +839,8 @@ class ApiRoutesTest {
                 auditLogRepository = auditLogRepo,
                 roleGroupService = roleGroupService,
                 adminService = adminService,
+                userAttributeService = userAttributeService,
+                claimMapperService = claimMapperService,
             )
         }
     }

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
@@ -1,0 +1,375 @@
+package com.kauth.adapter.web.api
+
+import com.kauth.domain.model.ApiScope
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.ApiKeyResult
+import com.kauth.domain.service.ApiKeyService
+import com.kauth.domain.service.UserAttributeService
+import com.kauth.fakes.FakeApiKeyRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.ApiKeyPrincipal
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.bearer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the user-attributes REST API.
+ * Uses a stripped-down wiring with only the deps these routes need.
+ */
+class ApiUserAttributeRoutesTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val apiKeyRepo = FakeApiKeyRepository()
+    private val userAttributeRepo = FakeUserAttributeRepository()
+    private val hasher = FakePasswordHasher()
+
+    private val apiKeyService =
+        ApiKeyService(apiKeyRepository = apiKeyRepo, tenantRepository = tenantRepo)
+    private val userAttributeService =
+        UserAttributeService(userAttributeRepository = userAttributeRepo, userRepository = userRepo)
+
+    private val tenant =
+        Tenant(id = TenantId(1), slug = "acme", displayName = "Acme", issuerUrl = null, theme = TenantTheme.DEFAULT)
+    private val user =
+        User(
+            id = UserId(10),
+            tenantId = TenantId(1),
+            username = "alice",
+            email = "alice@example.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("pw"),
+        )
+
+    private var readKey: String = ""
+    private var writeKey: String = ""
+
+    @BeforeTest
+    fun setup() {
+        tenantRepo.clear()
+        userRepo.clear()
+        apiKeyRepo.clear()
+        userAttributeRepo.clear()
+
+        tenantRepo.add(tenant)
+        userRepo.add(user)
+
+        readKey =
+            (
+                apiKeyService.create(
+                    tenantId = TenantId(1),
+                    name = "Read Key",
+                    scopes = listOf(ApiScope.USER_ATTRIBUTES_READ),
+                ) as ApiKeyResult.Success
+            ).value.rawKey
+        writeKey =
+            (
+                apiKeyService.create(
+                    tenantId = TenantId(1),
+                    name = "Write Key",
+                    scopes = listOf(ApiScope.USER_ATTRIBUTES_READ, ApiScope.USER_ATTRIBUTES_WRITE),
+                ) as ApiKeyResult.Success
+            ).value.rawKey
+    }
+
+    // =========================================================================
+    // GET /users/{id}/attributes
+    // =========================================================================
+
+    @Test
+    fun `GET attributes returns empty map for user with no attributes`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.get("/t/acme/api/v1/users/10/attributes") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"attributes\""))
+        }
+
+    @Test
+    fun `GET attributes returns all stored attributes`() =
+        testApplication {
+            application { installTestApp() }
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(1), "plan", "trial", Instant.now()))
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(1), "trial_ends", "2026-05-21", Instant.now()))
+
+            val response =
+                client.get("/t/acme/api/v1/users/10/attributes") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"plan\":\"trial\""))
+            assertTrue(body.contains("\"trial_ends\":\"2026-05-21\""))
+        }
+
+    @Test
+    fun `GET attributes returns 404 for unknown user`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.get("/t/acme/api/v1/users/999/attributes") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `GET attributes returns 403 when API key lacks read scope`() =
+        testApplication {
+            application { installTestApp() }
+            val noScopeKey =
+                (
+                    apiKeyService.create(
+                        tenantId = TenantId(1),
+                        name = "No Scope",
+                        scopes = listOf(ApiScope.USERS_READ),
+                    ) as ApiKeyResult.Success
+                ).value.rawKey
+
+            val response =
+                client.get("/t/acme/api/v1/users/10/attributes") { bearerAuth(noScopeKey) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `GET attributes returns 400 for non-integer user id`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.get("/t/acme/api/v1/users/abc/attributes") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    // =========================================================================
+    // PUT /users/{id}/attributes/{key}
+    // =========================================================================
+
+    @Test
+    fun `PUT attribute creates new attribute`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/users/10/attributes/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"value":"trial"}""")
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            assertEquals("trial", userAttributeRepo.findAll(UserId(10), TenantId(1))["plan"])
+        }
+
+    @Test
+    fun `PUT attribute overwrites existing value`() =
+        testApplication {
+            application { installTestApp() }
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(1), "plan", "trial", Instant.now()))
+
+            val response =
+                client.put("/t/acme/api/v1/users/10/attributes/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"value":"pro"}""")
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            assertEquals("pro", userAttributeRepo.findAll(UserId(10), TenantId(1))["plan"])
+        }
+
+    @Test
+    fun `PUT attribute returns 403 when API key lacks write scope`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/users/10/attributes/plan") {
+                    bearerAuth(readKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"value":"trial"}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `PUT attribute returns 404 for unknown user`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.put("/t/acme/api/v1/users/999/attributes/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"value":"trial"}""")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `PUT attribute returns 422 when value too long`() =
+        testApplication {
+            application { installTestApp() }
+            val tooLongValue = "v".repeat(UserAttribute.MAX_VALUE_LENGTH + 1)
+            val response =
+                client.put("/t/acme/api/v1/users/10/attributes/plan") {
+                    bearerAuth(writeKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"value":"$tooLongValue"}""")
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    // =========================================================================
+    // DELETE /users/{id}/attributes/{key}
+    // =========================================================================
+
+    @Test
+    fun `DELETE attribute removes it and returns 204`() =
+        testApplication {
+            application { installTestApp() }
+            userAttributeRepo.upsert(UserAttribute(UserId(10), TenantId(1), "plan", "trial", Instant.now()))
+
+            val response =
+                client.delete("/t/acme/api/v1/users/10/attributes/plan") { bearerAuth(writeKey) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            assertTrue(userAttributeRepo.findAll(UserId(10), TenantId(1)).isEmpty())
+        }
+
+    @Test
+    fun `DELETE non-existent attribute still returns 204`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.delete("/t/acme/api/v1/users/10/attributes/nonexistent") { bearerAuth(writeKey) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+        }
+
+    @Test
+    fun `DELETE attribute returns 403 when API key lacks write scope`() =
+        testApplication {
+            application { installTestApp() }
+            val response =
+                client.delete("/t/acme/api/v1/users/10/attributes/plan") { bearerAuth(readKey) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    // =========================================================================
+    // Cross-tenant isolation
+    // =========================================================================
+
+    @Test
+    fun `API key from tenant A cannot read attributes in tenant B`() =
+        testApplication {
+            application { installTestApp() }
+            // Add a second tenant and user.
+            val otherTenant = tenant.copy(id = TenantId(2), slug = "other", displayName = "Other")
+            tenantRepo.add(otherTenant)
+            userRepo.add(user.copy(id = UserId(20), tenantId = TenantId(2), username = "bob"))
+
+            // Attribute belongs to tenant B.
+            userAttributeRepo.upsert(UserAttribute(UserId(20), TenantId(2), "plan", "secret", Instant.now()))
+
+            // Request the tenant-B attribute using the tenant-A key.
+            val response =
+                client.get("/t/acme/api/v1/users/20/attributes") { bearerAuth(readKey) }
+
+            // User 20 doesn't exist in tenant 1 (acme), so 404.
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    // -------------------------------------------------------------------------
+    // Test application wiring
+    // -------------------------------------------------------------------------
+
+    private fun io.ktor.server.application.Application.installTestApp() {
+        install(ContentNegotiation) { json() }
+        install(Authentication) {
+            bearer("api-key") {
+                realm = "KotAuth REST API"
+                authenticate { creds ->
+                    if (creds.token.startsWith("kauth_")) ApiKeyPrincipal(rawToken = creds.token) else null
+                }
+            }
+        }
+        // Required by apiRoutes signature — the attribute endpoint tests don't exercise it.
+        val claimMapperService =
+            com.kauth.infrastructure.CachingClaimMapperService(
+                mapperRepository = com.kauth.fakes.FakeTenantClaimMapperRepository(),
+            )
+
+        routing {
+            apiRoutes(
+                apiKeyService = apiKeyService,
+                tenantRepository = tenantRepo,
+                roleRepository = com.kauth.fakes.FakeRoleRepository(),
+                groupRepository = com.kauth.fakes.FakeGroupRepository(),
+                applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                auditLogRepository = com.kauth.fakes.FakeAuditLogRepository(),
+                roleGroupService =
+                    com.kauth.domain.service.RoleGroupService(
+                        roleRepository = com.kauth.fakes.FakeRoleRepository(),
+                        groupRepository = com.kauth.fakes.FakeGroupRepository(),
+                        tenantRepository = tenantRepo,
+                        userRepository = userRepo,
+                        applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                        auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                    ),
+                adminService =
+                    com.kauth.domain.service.AdminService(
+                        tenantRepository = tenantRepo,
+                        userRepository = userRepo,
+                        applicationRepository = com.kauth.fakes.FakeApplicationRepository(),
+                        passwordHasher = hasher,
+                        auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                        sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                        selfServiceService =
+                            com.kauth.domain.service.UserSelfServiceService(
+                                userRepository = userRepo,
+                                tenantRepository = tenantRepo,
+                                sessionRepository = com.kauth.fakes.FakeSessionRepository(),
+                                passwordHasher = hasher,
+                                auditLog = com.kauth.fakes.FakeAuditLogPort(),
+                                evTokenRepo = com.kauth.fakes.FakeEmailVerificationTokenRepository(),
+                                prTokenRepo = com.kauth.fakes.FakePasswordResetTokenRepository(),
+                                emailPort = com.kauth.fakes.FakeEmailPort(),
+                                emailScope =
+                                    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+                            ),
+                    ),
+                userAttributeService = userAttributeService,
+                claimMapperService = claimMapperService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/ClaimMapperServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ClaimMapperServiceTest.kt
@@ -1,0 +1,231 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.ClaimTokenType
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.ClaimMapperCacheInvalidator
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ClaimMapperServiceTest {
+    private val mappers = FakeTenantClaimMapperRepository()
+
+    private val invalidations = mutableListOf<TenantId>()
+    private val invalidator = ClaimMapperCacheInvalidator { tid -> invalidations.add(tid) }
+
+    private val svc = ClaimMapperService(mapperRepository = mappers, cacheInvalidator = invalidator)
+
+    private val tenantId = TenantId(1)
+
+    @BeforeTest
+    fun setup() {
+        mappers.clear()
+        invalidations.clear()
+    }
+
+    // =========================================================================
+    // upsert
+    // =========================================================================
+
+    @Test
+    fun `upsert - creates new mapper`() {
+        val mapper =
+            TenantClaimMapper(
+                tenantId = tenantId,
+                attributeKey = "plan",
+                claimName = "custom:plan",
+            )
+        val result = svc.upsert(mapper)
+        assertIs<AttributeResult.Success<TenantClaimMapper>>(result)
+        assertEquals(listOf(mapper), mappers.findAll(tenantId))
+    }
+
+    @Test
+    fun `upsert - overwrites existing mapper`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:tier", includeInId = true))
+
+        val stored = mappers.findAll(tenantId).single { it.attributeKey == "plan" }
+        assertEquals("custom:tier", stored.claimName)
+        assertTrue(stored.includeInId)
+    }
+
+    @Test
+    fun `upsert - blank attribute key rejected`() {
+        val result = svc.upsert(TenantClaimMapper(tenantId, "  ", "custom:plan"))
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - blank claim name rejected`() {
+        val result = svc.upsert(TenantClaimMapper(tenantId, "plan", "  "))
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - claim name too long rejected`() {
+        val tooLong = "c".repeat(TenantClaimMapper.MAX_CLAIM_NAME_LENGTH + 1)
+        val result = svc.upsert(TenantClaimMapper(tenantId, "plan", tooLong))
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - reserved OIDC claim names are blocked`() {
+        val reserved = listOf("sub", "iss", "aud", "exp", "iat", "nonce", "email", "tenant_id", "scope")
+        reserved.forEach { claimName ->
+            val result = svc.upsert(TenantClaimMapper(tenantId, "attr_$claimName", claimName))
+            assertIs<AttributeResult.ReservedClaimName>(result)
+            assertEquals(claimName, result.claimName)
+        }
+    }
+
+    @Test
+    fun `upsert - duplicate claim name across attribute keys rejected`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:tier"))
+        val result = svc.upsert(TenantClaimMapper(tenantId, "subscription", "custom:tier"))
+        assertIs<AttributeResult.DuplicateClaimName>(result)
+    }
+
+    @Test
+    fun `upsert - same attribute key rewriting same claim name allowed`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        val result = svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan", includeInId = true))
+        assertIs<AttributeResult.Success<TenantClaimMapper>>(result)
+    }
+
+    @Test
+    fun `upsert - enforces MAX_MAPPERS_PER_TENANT`() {
+        repeat(TenantClaimMapper.MAX_MAPPERS_PER_TENANT) { i ->
+            svc.upsert(TenantClaimMapper(tenantId, "attr_$i", "custom:$i"))
+        }
+        val result = svc.upsert(TenantClaimMapper(tenantId, "attr_overflow", "custom:overflow"))
+        assertIs<AttributeResult.LimitReached>(result)
+        assertEquals(TenantClaimMapper.MAX_MAPPERS_PER_TENANT, result.max)
+    }
+
+    @Test
+    fun `upsert - editing existing mapper does not count against cap`() {
+        repeat(TenantClaimMapper.MAX_MAPPERS_PER_TENANT) { i ->
+            svc.upsert(TenantClaimMapper(tenantId, "attr_$i", "custom:$i"))
+        }
+        val result = svc.upsert(TenantClaimMapper(tenantId, "attr_0", "custom:0", includeInId = true))
+        assertIs<AttributeResult.Success<TenantClaimMapper>>(result)
+    }
+
+    @Test
+    fun `upsert - triggers cache invalidation`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        assertEquals(listOf(tenantId), invalidations)
+    }
+
+    // =========================================================================
+    // delete
+    // =========================================================================
+
+    @Test
+    fun `delete - removes existing mapper`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        invalidations.clear()
+
+        val result = svc.delete(tenantId, "plan")
+        assertIs<AttributeResult.Success<Unit>>(result)
+        assertTrue(mappers.findAll(tenantId).isEmpty())
+        assertEquals(listOf(tenantId), invalidations)
+    }
+
+    @Test
+    fun `delete - missing mapper returns Success`() {
+        val result = svc.delete(tenantId, "nonexistent")
+        assertIs<AttributeResult.Success<Unit>>(result)
+    }
+
+    // =========================================================================
+    // list
+    // =========================================================================
+
+    @Test
+    fun `list - returns mappers for tenant`() {
+        svc.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        svc.upsert(TenantClaimMapper(tenantId, "trial_ends", "custom:trial_ends"))
+        svc.upsert(TenantClaimMapper(TenantId(2), "plan", "custom:plan"))
+
+        val result = svc.list(tenantId)
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.tenantId == tenantId })
+    }
+
+    // =========================================================================
+    // projectClaims — pure function
+    // =========================================================================
+
+    @Test
+    fun `projectClaims - injects matching attributes for access token`() {
+        val mapperList =
+            listOf(
+                TenantClaimMapper(tenantId, "plan", "custom:plan", includeInAccess = true, includeInId = true),
+                TenantClaimMapper(
+                    tenantId,
+                    "trial_ends",
+                    "custom:trial_ends",
+                    includeInAccess = true,
+                    includeInId = false,
+                ),
+            )
+        val attrs = mapOf("plan" to "trial", "trial_ends" to "2026-05-21")
+
+        val result = ClaimMapperService.projectClaims(mapperList, attrs, ClaimTokenType.ACCESS)
+        assertEquals(
+            mapOf("custom:plan" to "trial", "custom:trial_ends" to "2026-05-21"),
+            result,
+        )
+    }
+
+    @Test
+    fun `projectClaims - filters by includeInId flag for id token`() {
+        val mapperList =
+            listOf(
+                TenantClaimMapper(tenantId, "plan", "custom:plan", includeInAccess = true, includeInId = true),
+                TenantClaimMapper(
+                    tenantId,
+                    "trial_ends",
+                    "custom:trial_ends",
+                    includeInAccess = true,
+                    includeInId = false,
+                ),
+            )
+        val attrs = mapOf("plan" to "trial", "trial_ends" to "2026-05-21")
+
+        val result = ClaimMapperService.projectClaims(mapperList, attrs, ClaimTokenType.ID)
+        assertEquals(mapOf("custom:plan" to "trial"), result)
+    }
+
+    @Test
+    fun `projectClaims - attribute missing skips the claim`() {
+        val mapperList =
+            listOf(
+                TenantClaimMapper(tenantId, "plan", "custom:plan"),
+                TenantClaimMapper(tenantId, "missing", "custom:missing"),
+            )
+        val attrs = mapOf("plan" to "trial")
+
+        val result = ClaimMapperService.projectClaims(mapperList, attrs, ClaimTokenType.ACCESS)
+        assertEquals(mapOf("custom:plan" to "trial"), result)
+    }
+
+    @Test
+    fun `projectClaims - no mappers returns empty map`() {
+        val result = ClaimMapperService.projectClaims(emptyList(), mapOf("plan" to "trial"), ClaimTokenType.ACCESS)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `projectClaims - no attributes returns empty map`() {
+        val mapperList = listOf(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        val result = ClaimMapperService.projectClaims(mapperList, emptyMap(), ClaimTokenType.ACCESS)
+        assertTrue(result.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/TokenClaimMappingTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/TokenClaimMappingTest.kt
@@ -1,0 +1,405 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.AuthorizationCode
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.Base64
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for claim mapping on token issuance paths.
+ *
+ * Covers the acceptance criteria from the user-attributes feature spec:
+ *  - attribute + mapper present → claim injected into access and id tokens
+ *  - mapper includeInId=false → claim absent from id token
+ *  - DELETE attribute → claim absent from subsequent tokens
+ *  - DELETE mapper → claim absent even when attribute still set
+ *  - zero mappers → token payload identical to pre-feature
+ *  - refresh_token flow picks up attribute changes within next issuance
+ */
+class TokenClaimMappingTest {
+    // -------------------------------------------------------------------------
+    // Fakes
+    // -------------------------------------------------------------------------
+
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val apps = FakeApplicationRepository()
+    private val authCodes = FakeAuthorizationCodeRepository()
+    private val sessions = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val tokens = FakeTokenPort()
+    private val auditLog = FakeAuditLogPort()
+    private val userAttributes = FakeUserAttributeRepository()
+    private val claimMappers = FakeTenantClaimMapperRepository()
+
+    private val userAttributeService =
+        UserAttributeService(
+            userAttributeRepository = userAttributes,
+            userRepository = users,
+        )
+
+    private val claimMapperService =
+        ClaimMapperService(
+            mapperRepository = claimMappers,
+        )
+
+    private val svc =
+        OAuthService(
+            tenantRepository = tenants,
+            userRepository = users,
+            applicationRepository = apps,
+            sessionRepository = sessions,
+            authCodeRepository = authCodes,
+            tokenPort = tokens,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            userAttributeRepository = userAttributes,
+            claimMappersFor = claimMapperService::list,
+        )
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private val tenantId = TenantId(1)
+    private val userId = UserId(10)
+
+    private val testTenant = Tenant(id = tenantId, slug = "acme", displayName = "Acme", issuerUrl = null)
+
+    private val testUser =
+        User(
+            id = userId,
+            tenantId = tenantId,
+            username = "alice",
+            email = "alice@example.com",
+            fullName = "Alice",
+            passwordHash = "hashed:pw",
+        )
+
+    private val publicClient =
+        Application(
+            id = ApplicationId(1),
+            tenantId = tenantId,
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    private val pkceVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    private val pkceChallenge =
+        Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(
+                MessageDigest.getInstance("SHA-256").digest(pkceVerifier.toByteArray()),
+            )
+
+    @BeforeTest
+    fun setup() {
+        tenants.clear()
+        users.clear()
+        apps.clear()
+        authCodes.clear()
+        sessions.clear()
+        auditLog.clear()
+        tokens.reset()
+        userAttributes.clear()
+        claimMappers.clear()
+
+        tenants.add(testTenant)
+        users.add(testUser)
+        apps.add(publicClient)
+    }
+
+    // =========================================================================
+    // Happy path — authorization_code flow
+    // =========================================================================
+
+    @Test
+    fun `access token includes custom claim when attribute and mapper are both configured`() {
+        userAttributes.upsert(
+            UserAttribute(userId, tenantId, "plan", "trial", Instant.now()),
+        )
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+
+        exchangeAuthCode()
+
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+    }
+
+    @Test
+    fun `id token includes custom claim when mapper has includeInId=true`() {
+        userAttributes.upsert(
+            UserAttribute(userId, tenantId, "plan", "trial", Instant.now()),
+        )
+        claimMapperService.upsert(
+            TenantClaimMapper(tenantId, "plan", "custom:plan", includeInAccess = true, includeInId = true),
+        )
+
+        exchangeAuthCode()
+
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+        assertEquals("trial", tokens.lastCustomIdClaims["custom:plan"])
+    }
+
+    @Test
+    fun `id token does NOT include custom claim when includeInId=false`() {
+        userAttributes.upsert(
+            UserAttribute(userId, tenantId, "plan", "trial", Instant.now()),
+        )
+        claimMapperService.upsert(
+            TenantClaimMapper(tenantId, "plan", "custom:plan", includeInAccess = true, includeInId = false),
+        )
+
+        exchangeAuthCode()
+
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+        assertTrue("custom:plan" !in tokens.lastCustomIdClaims)
+    }
+
+    @Test
+    fun `multiple mappers project multiple claims in a single issuance`() {
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+        userAttributes.upsert(UserAttribute(userId, tenantId, "trial_ends", "2026-05-21", Instant.now()))
+        userAttributes.upsert(UserAttribute(userId, tenantId, "sifen_env", "staging", Instant.now()))
+
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "trial_ends", "custom:trial_ends"))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "sifen_env", "custom:sifen_env"))
+
+        exchangeAuthCode()
+
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+        assertEquals("2026-05-21", tokens.lastCustomAccessClaims["custom:trial_ends"])
+        assertEquals("staging", tokens.lastCustomAccessClaims["custom:sifen_env"])
+    }
+
+    // =========================================================================
+    // Missing attribute / missing mapper → claim absent
+    // =========================================================================
+
+    @Test
+    fun `attribute deleted via service no longer appears in subsequent tokens`() {
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+
+        exchangeAuthCode()
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+
+        userAttributeService.delete(userId, tenantId, "plan")
+        exchangeAuthCode()
+
+        assertTrue("custom:plan" !in tokens.lastCustomAccessClaims)
+    }
+
+    @Test
+    fun `mapper deleted removes the claim even if attribute still set`() {
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+
+        exchangeAuthCode()
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+
+        claimMapperService.delete(tenantId, "plan")
+        exchangeAuthCode()
+
+        assertTrue("custom:plan" !in tokens.lastCustomAccessClaims)
+        // Attribute itself is untouched.
+        assertEquals("trial", userAttributes.findAll(userId, tenantId)["plan"])
+    }
+
+    @Test
+    fun `mapper without matching attribute silently omits the claim`() {
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+        // No attribute set.
+
+        exchangeAuthCode()
+
+        assertTrue("custom:plan" !in tokens.lastCustomAccessClaims)
+    }
+
+    // =========================================================================
+    // Zero regression — no mappers configured
+    // =========================================================================
+
+    @Test
+    fun `zero mappers configured yields empty custom claim maps`() {
+        // No mappers, no attributes — baseline.
+        exchangeAuthCode()
+
+        assertTrue(tokens.lastCustomAccessClaims.isEmpty())
+        assertTrue(tokens.lastCustomIdClaims.isEmpty())
+    }
+
+    @Test
+    fun `OAuthService without user-attribute wiring yields empty claims`() {
+        val svcWithoutAttributes =
+            OAuthService(
+                tenantRepository = tenants,
+                userRepository = users,
+                applicationRepository = apps,
+                sessionRepository = sessions,
+                authCodeRepository = authCodes,
+                tokenPort = tokens,
+                passwordHasher = hasher,
+                auditLog = auditLog,
+                // No userAttributeRepository, no claimMappersFor.
+            )
+
+        val code =
+            (
+                svcWithoutAttributes.issueAuthorizationCode(
+                    tenantSlug = "acme",
+                    userId = userId,
+                    clientId = "spa-app",
+                    redirectUri = "https://app.example.com/callback",
+                    scopes = "openid",
+                    codeChallenge = pkceChallenge,
+                    codeChallengeMethod = "S256",
+                    nonce = null,
+                    state = null,
+                ) as OAuthResult.Success<AuthorizationCode>
+            ).value.code
+
+        svcWithoutAttributes.exchangeAuthorizationCode(
+            tenantSlug = "acme",
+            code = code,
+            clientId = "spa-app",
+            redirectUri = "https://app.example.com/callback",
+            codeVerifier = pkceVerifier,
+            clientSecret = null,
+        )
+
+        assertTrue(tokens.lastCustomAccessClaims.isEmpty())
+        assertTrue(tokens.lastCustomIdClaims.isEmpty())
+    }
+
+    // =========================================================================
+    // Refresh token flow — eventually consistent
+    // =========================================================================
+
+    @Test
+    fun `refresh token flow re-projects claims from current attribute state`() {
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+
+        // First issuance — initial access + refresh token.
+        val initial = exchangeAuthCode()
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+
+        // Billing flips the plan while the refresh token is still valid.
+        userAttributeService.upsert(userId, tenantId, "plan", "pro")
+
+        // Refresh request — must pick up the new value.
+        val result =
+            svc.refreshTokens(
+                tenantSlug = "acme",
+                refreshToken = initial.refresh_token!!,
+                clientId = "spa-app",
+            )
+        assertIs<OAuthResult.Success<*>>(result)
+
+        assertEquals("pro", tokens.lastCustomAccessClaims["custom:plan"])
+    }
+
+    @Test
+    fun `refresh token flow drops claim when mapper is deleted between issuances`() {
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+        claimMapperService.upsert(TenantClaimMapper(tenantId, "plan", "custom:plan"))
+
+        val initial = exchangeAuthCode()
+        assertEquals("trial", tokens.lastCustomAccessClaims["custom:plan"])
+
+        claimMapperService.delete(tenantId, "plan")
+
+        val result =
+            svc.refreshTokens(
+                tenantSlug = "acme",
+                refreshToken = initial.refresh_token!!,
+                clientId = "spa-app",
+            )
+        assertIs<OAuthResult.Success<*>>(result)
+
+        assertTrue("custom:plan" !in tokens.lastCustomAccessClaims)
+    }
+
+    // =========================================================================
+    // Tenant isolation — attributes from other tenants never bleed
+    // =========================================================================
+
+    @Test
+    fun `mappers from a different tenant are ignored during issuance`() {
+        val otherTenantId = TenantId(99)
+        userAttributes.upsert(UserAttribute(userId, tenantId, "plan", "trial", Instant.now()))
+
+        // Mapper registered in the WRONG tenant.
+        claimMapperService.upsert(TenantClaimMapper(otherTenantId, "plan", "custom:plan"))
+
+        exchangeAuthCode()
+
+        assertTrue("custom:plan" !in tokens.lastCustomAccessClaims)
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Runs a full authorization_code exchange with the openid scope and returns the token response. */
+    private fun exchangeAuthCode() =
+        run {
+            val code =
+                (
+                    svc.issueAuthorizationCode(
+                        tenantSlug = "acme",
+                        userId = userId,
+                        clientId = "spa-app",
+                        redirectUri = "https://app.example.com/callback",
+                        scopes = "openid",
+                        codeChallenge = pkceChallenge,
+                        codeChallengeMethod = "S256",
+                        nonce = null,
+                        state = null,
+                    ) as OAuthResult.Success<AuthorizationCode>
+                ).value.code
+
+            val result =
+                svc.exchangeAuthorizationCode(
+                    tenantSlug = "acme",
+                    code = code,
+                    clientId = "spa-app",
+                    redirectUri = "https://app.example.com/callback",
+                    codeVerifier = pkceVerifier,
+                    clientSecret = null,
+                )
+            assertIs<OAuthResult.Success<*>>(result)
+            @Suppress("UNCHECKED_CAST")
+            (result as OAuthResult.Success<com.kauth.domain.model.TokenResponse>).value
+        }
+}

--- a/src/test/kotlin/com/kauth/domain/service/UserAttributeServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserAttributeServiceTest.kt
@@ -1,0 +1,191 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class UserAttributeServiceTest {
+    private val attributes = FakeUserAttributeRepository()
+    private val users = FakeUserRepository()
+
+    private val svc =
+        UserAttributeService(
+            userAttributeRepository = attributes,
+            userRepository = users,
+        )
+
+    private val tenantId = TenantId(1)
+    private val otherTenantId = TenantId(2)
+
+    private val alice =
+        User(
+            id = UserId(10),
+            tenantId = tenantId,
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = "hash",
+        )
+
+    @BeforeTest
+    fun setup() {
+        attributes.clear()
+        users.clear()
+        users.add(alice)
+    }
+
+    // =========================================================================
+    // list
+    // =========================================================================
+
+    @Test
+    fun `list - returns empty map when no attributes`() {
+        val result = svc.list(alice.id!!, tenantId)
+        assertIs<AttributeResult.Success<Map<String, String>>>(result)
+        assertTrue(result.value.isEmpty())
+    }
+
+    @Test
+    fun `list - returns stored attributes`() {
+        svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        svc.upsert(alice.id!!, tenantId, "trial_ends", "2026-05-21")
+
+        val result = svc.list(alice.id!!, tenantId)
+        assertIs<AttributeResult.Success<Map<String, String>>>(result)
+        assertEquals(mapOf("plan" to "trial", "trial_ends" to "2026-05-21"), result.value)
+    }
+
+    @Test
+    fun `list - missing user returns NotFound`() {
+        val result = svc.list(UserId(999), tenantId)
+        assertIs<AttributeResult.NotFound>(result)
+    }
+
+    @Test
+    fun `list - wrong tenant returns NotFound`() {
+        val result = svc.list(alice.id!!, otherTenantId)
+        assertIs<AttributeResult.NotFound>(result)
+    }
+
+    // =========================================================================
+    // upsert
+    // =========================================================================
+
+    @Test
+    fun `upsert - creates new attribute`() {
+        val result = svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        assertIs<AttributeResult.Success<UserAttribute>>(result)
+        assertEquals("plan", result.value.key)
+        assertEquals("trial", result.value.value)
+    }
+
+    @Test
+    fun `upsert - overwrites existing attribute`() {
+        svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        svc.upsert(alice.id!!, tenantId, "plan", "pro")
+
+        val stored = attributes.all().single { it.key == "plan" }
+        assertEquals("pro", stored.value)
+    }
+
+    @Test
+    fun `upsert - blank key is rejected`() {
+        val result = svc.upsert(alice.id!!, tenantId, "  ", "value")
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - key too long is rejected`() {
+        val key = "k".repeat(UserAttribute.MAX_KEY_LENGTH + 1)
+        val result = svc.upsert(alice.id!!, tenantId, key, "v")
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - value too long is rejected`() {
+        val value = "v".repeat(UserAttribute.MAX_VALUE_LENGTH + 1)
+        val result = svc.upsert(alice.id!!, tenantId, "k", value)
+        assertIs<AttributeResult.ValidationError>(result)
+    }
+
+    @Test
+    fun `upsert - exactly at value limit is accepted`() {
+        val value = "v".repeat(UserAttribute.MAX_VALUE_LENGTH)
+        val result = svc.upsert(alice.id!!, tenantId, "k", value)
+        assertIs<AttributeResult.Success<UserAttribute>>(result)
+    }
+
+    @Test
+    fun `upsert - missing user returns NotFound without writing`() {
+        val result = svc.upsert(UserId(999), tenantId, "plan", "trial")
+        assertIs<AttributeResult.NotFound>(result)
+        assertTrue(attributes.all().isEmpty())
+    }
+
+    @Test
+    fun `upsert - empty value is allowed`() {
+        val result = svc.upsert(alice.id!!, tenantId, "plan", "")
+        assertIs<AttributeResult.Success<UserAttribute>>(result)
+    }
+
+    // =========================================================================
+    // delete
+    // =========================================================================
+
+    @Test
+    fun `delete - removes existing attribute`() {
+        svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        val result = svc.delete(alice.id!!, tenantId, "plan")
+        assertIs<AttributeResult.Success<Unit>>(result)
+        assertTrue(attributes.all().isEmpty())
+    }
+
+    @Test
+    fun `delete - missing key succeeds silently`() {
+        val result = svc.delete(alice.id!!, tenantId, "nonexistent")
+        assertIs<AttributeResult.Success<Unit>>(result)
+    }
+
+    @Test
+    fun `delete - missing user returns NotFound`() {
+        val result = svc.delete(UserId(999), tenantId, "plan")
+        assertIs<AttributeResult.NotFound>(result)
+    }
+
+    // =========================================================================
+    // tenant isolation
+    // =========================================================================
+
+    @Test
+    fun `attributes from different tenants do not bleed`() {
+        val bob =
+            User(
+                id = UserId(20),
+                tenantId = otherTenantId,
+                username = "bob",
+                email = "bob@other.com",
+                fullName = "Bob",
+                passwordHash = "hash",
+            )
+        users.add(bob)
+
+        svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        svc.upsert(bob.id!!, otherTenantId, "plan", "pro")
+
+        val aliceAttrs = svc.list(alice.id!!, tenantId)
+        val bobAttrs = svc.list(bob.id!!, otherTenantId)
+
+        assertIs<AttributeResult.Success<Map<String, String>>>(aliceAttrs)
+        assertIs<AttributeResult.Success<Map<String, String>>>(bobAttrs)
+        assertEquals("trial", aliceAttrs.value["plan"])
+        assertEquals("pro", bobAttrs.value["plan"])
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/UserAttributeServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserAttributeServiceTest.kt
@@ -24,10 +24,11 @@ class UserAttributeServiceTest {
 
     private val tenantId = TenantId(1)
     private val otherTenantId = TenantId(2)
+    private val aliceId = UserId(10)
 
     private val alice =
         User(
-            id = UserId(10),
+            id = aliceId,
             tenantId = tenantId,
             username = "alice",
             email = "alice@acme.com",
@@ -48,17 +49,17 @@ class UserAttributeServiceTest {
 
     @Test
     fun `list - returns empty map when no attributes`() {
-        val result = svc.list(alice.id!!, tenantId)
+        val result = svc.list(aliceId, tenantId)
         assertIs<AttributeResult.Success<Map<String, String>>>(result)
         assertTrue(result.value.isEmpty())
     }
 
     @Test
     fun `list - returns stored attributes`() {
-        svc.upsert(alice.id!!, tenantId, "plan", "trial")
-        svc.upsert(alice.id!!, tenantId, "trial_ends", "2026-05-21")
+        svc.upsert(aliceId, tenantId, "plan", "trial")
+        svc.upsert(aliceId, tenantId, "trial_ends", "2026-05-21")
 
-        val result = svc.list(alice.id!!, tenantId)
+        val result = svc.list(aliceId, tenantId)
         assertIs<AttributeResult.Success<Map<String, String>>>(result)
         assertEquals(mapOf("plan" to "trial", "trial_ends" to "2026-05-21"), result.value)
     }
@@ -71,7 +72,7 @@ class UserAttributeServiceTest {
 
     @Test
     fun `list - wrong tenant returns NotFound`() {
-        val result = svc.list(alice.id!!, otherTenantId)
+        val result = svc.list(aliceId, otherTenantId)
         assertIs<AttributeResult.NotFound>(result)
     }
 
@@ -81,7 +82,7 @@ class UserAttributeServiceTest {
 
     @Test
     fun `upsert - creates new attribute`() {
-        val result = svc.upsert(alice.id!!, tenantId, "plan", "trial")
+        val result = svc.upsert(aliceId, tenantId, "plan", "trial")
         assertIs<AttributeResult.Success<UserAttribute>>(result)
         assertEquals("plan", result.value.key)
         assertEquals("trial", result.value.value)
@@ -89,8 +90,8 @@ class UserAttributeServiceTest {
 
     @Test
     fun `upsert - overwrites existing attribute`() {
-        svc.upsert(alice.id!!, tenantId, "plan", "trial")
-        svc.upsert(alice.id!!, tenantId, "plan", "pro")
+        svc.upsert(aliceId, tenantId, "plan", "trial")
+        svc.upsert(aliceId, tenantId, "plan", "pro")
 
         val stored = attributes.all().single { it.key == "plan" }
         assertEquals("pro", stored.value)
@@ -98,28 +99,28 @@ class UserAttributeServiceTest {
 
     @Test
     fun `upsert - blank key is rejected`() {
-        val result = svc.upsert(alice.id!!, tenantId, "  ", "value")
+        val result = svc.upsert(aliceId, tenantId, "  ", "value")
         assertIs<AttributeResult.ValidationError>(result)
     }
 
     @Test
     fun `upsert - key too long is rejected`() {
         val key = "k".repeat(UserAttribute.MAX_KEY_LENGTH + 1)
-        val result = svc.upsert(alice.id!!, tenantId, key, "v")
+        val result = svc.upsert(aliceId, tenantId, key, "v")
         assertIs<AttributeResult.ValidationError>(result)
     }
 
     @Test
     fun `upsert - value too long is rejected`() {
         val value = "v".repeat(UserAttribute.MAX_VALUE_LENGTH + 1)
-        val result = svc.upsert(alice.id!!, tenantId, "k", value)
+        val result = svc.upsert(aliceId, tenantId, "k", value)
         assertIs<AttributeResult.ValidationError>(result)
     }
 
     @Test
     fun `upsert - exactly at value limit is accepted`() {
         val value = "v".repeat(UserAttribute.MAX_VALUE_LENGTH)
-        val result = svc.upsert(alice.id!!, tenantId, "k", value)
+        val result = svc.upsert(aliceId, tenantId, "k", value)
         assertIs<AttributeResult.Success<UserAttribute>>(result)
     }
 
@@ -132,7 +133,7 @@ class UserAttributeServiceTest {
 
     @Test
     fun `upsert - empty value is allowed`() {
-        val result = svc.upsert(alice.id!!, tenantId, "plan", "")
+        val result = svc.upsert(aliceId, tenantId, "plan", "")
         assertIs<AttributeResult.Success<UserAttribute>>(result)
     }
 
@@ -142,15 +143,15 @@ class UserAttributeServiceTest {
 
     @Test
     fun `delete - removes existing attribute`() {
-        svc.upsert(alice.id!!, tenantId, "plan", "trial")
-        val result = svc.delete(alice.id!!, tenantId, "plan")
+        svc.upsert(aliceId, tenantId, "plan", "trial")
+        val result = svc.delete(aliceId, tenantId, "plan")
         assertIs<AttributeResult.Success<Unit>>(result)
         assertTrue(attributes.all().isEmpty())
     }
 
     @Test
     fun `delete - missing key succeeds silently`() {
-        val result = svc.delete(alice.id!!, tenantId, "nonexistent")
+        val result = svc.delete(aliceId, tenantId, "nonexistent")
         assertIs<AttributeResult.Success<Unit>>(result)
     }
 
@@ -166,9 +167,10 @@ class UserAttributeServiceTest {
 
     @Test
     fun `attributes from different tenants do not bleed`() {
+        val bobId = UserId(20)
         val bob =
             User(
-                id = UserId(20),
+                id = bobId,
                 tenantId = otherTenantId,
                 username = "bob",
                 email = "bob@other.com",
@@ -177,11 +179,11 @@ class UserAttributeServiceTest {
             )
         users.add(bob)
 
-        svc.upsert(alice.id!!, tenantId, "plan", "trial")
-        svc.upsert(bob.id!!, otherTenantId, "plan", "pro")
+        svc.upsert(aliceId, tenantId, "plan", "trial")
+        svc.upsert(bobId, otherTenantId, "plan", "pro")
 
-        val aliceAttrs = svc.list(alice.id!!, tenantId)
-        val bobAttrs = svc.list(bob.id!!, otherTenantId)
+        val aliceAttrs = svc.list(aliceId, tenantId)
+        val bobAttrs = svc.list(bobId, otherTenantId)
 
         assertIs<AttributeResult.Success<Map<String, String>>>(aliceAttrs)
         assertIs<AttributeResult.Success<Map<String, String>>>(bobAttrs)

--- a/src/test/kotlin/com/kauth/fakes/FakeTenantClaimMapperRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTenantClaimMapperRepository.kt
@@ -1,0 +1,34 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.TenantClaimMapperRepository
+
+/**
+ * In-memory TenantClaimMapperRepository for unit tests.
+ * Keyed by (tenantId, attributeKey) to mirror the PK of the real table.
+ */
+class FakeTenantClaimMapperRepository : TenantClaimMapperRepository {
+    private val store = mutableMapOf<Pair<Int, String>, TenantClaimMapper>()
+
+    fun clear() {
+        store.clear()
+    }
+
+    override fun findAll(tenantId: TenantId): List<TenantClaimMapper> =
+        store.values
+            .filter { it.tenantId == tenantId }
+            .sortedBy { it.attributeKey }
+
+    override fun upsert(mapper: TenantClaimMapper) {
+        store[mapper.tenantId.value to mapper.attributeKey] = mapper
+    }
+
+    override fun delete(
+        tenantId: TenantId,
+        attributeKey: String,
+    ): Boolean {
+        val key = tenantId.value to attributeKey
+        return store.remove(key) != null
+    }
+}

--- a/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
@@ -25,10 +25,18 @@ class FakeTokenPort : TokenPort {
     var claimsToReturn: AccessTokenClaims? = null
     var jwksToReturn: List<Map<String, Any>> = emptyList()
 
+    /** Captured on every issueUserTokens call — tests can assert on projected claims. */
+    var lastCustomAccessClaims: Map<String, String> = emptyMap()
+        private set
+    var lastCustomIdClaims: Map<String, String> = emptyMap()
+        private set
+
     fun reset() {
         callCount = 0
         claimsToReturn = null
         jwksToReturn = emptyList()
+        lastCustomAccessClaims = emptyMap()
+        lastCustomIdClaims = emptyMap()
     }
 
     override fun issueUserTokens(
@@ -38,8 +46,12 @@ class FakeTokenPort : TokenPort {
         scopes: List<String>,
         nonce: String?,
         roles: List<Role>,
+        customAccessClaims: Map<String, String>,
+        customIdClaims: Map<String, String>,
     ): TokenResponse {
         val n = ++callCount
+        lastCustomAccessClaims = customAccessClaims
+        lastCustomIdClaims = customIdClaims
         return TokenResponse(
             access_token = "fake.access.${user.username}.$n",
             token_type = "Bearer",

--- a/src/test/kotlin/com/kauth/fakes/FakeUserAttributeRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserAttributeRepository.kt
@@ -1,0 +1,50 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.UserAttribute
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.UserAttributeRepository
+
+/**
+ * In-memory UserAttributeRepository for unit tests.
+ * Keyed by (userId, key) to mirror the PK of the real table.
+ */
+class FakeUserAttributeRepository : UserAttributeRepository {
+    private val store = mutableMapOf<Pair<Int, String>, UserAttribute>()
+
+    fun clear() {
+        store.clear()
+    }
+
+    fun all(): List<UserAttribute> = store.values.toList()
+
+    override fun findAll(
+        userId: UserId,
+        tenantId: TenantId,
+    ): Map<String, String> =
+        store.values
+            .filter { it.userId == userId && it.tenantId == tenantId }
+            .associate { it.key to it.value }
+
+    override fun upsert(attribute: UserAttribute) {
+        store[attribute.userId.value to attribute.key] = attribute
+    }
+
+    override fun delete(
+        userId: UserId,
+        tenantId: TenantId,
+        key: String,
+    ): Boolean {
+        val existing = store[userId.value to key] ?: return false
+        if (existing.tenantId != tenantId) return false
+        store.remove(userId.value to key)
+        return true
+    }
+
+    override fun deleteAllForUser(
+        userId: UserId,
+        tenantId: TenantId,
+    ) {
+        store.entries.removeIf { (_, attr) -> attr.userId == userId && attr.tenantId == tenantId }
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/CachingClaimMapperServiceTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/CachingClaimMapperServiceTest.kt
@@ -1,0 +1,134 @@
+package com.kauth.infrastructure
+
+import com.kauth.domain.model.TenantClaimMapper
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.service.AttributeResult
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Unit tests for [CachingClaimMapperService].
+ *
+ * Covers: read caching, TTL expiry, self-invalidation on write, cross-tenant isolation.
+ */
+class CachingClaimMapperServiceTest {
+    private val repo = FakeTenantClaimMapperRepository()
+    private var now = Instant.parse("2026-05-01T12:00:00Z")
+    private lateinit var svc: CachingClaimMapperService
+
+    private val tenantA = TenantId(1)
+    private val tenantB = TenantId(2)
+
+    @BeforeTest
+    fun setup() {
+        repo.clear()
+        now = Instant.parse("2026-05-01T12:00:00Z")
+        svc =
+            CachingClaimMapperService(
+                mapperRepository = repo,
+                ttlMillis = 60_000L,
+                clock = { now },
+            )
+    }
+
+    // =========================================================================
+    // caching behavior
+    // =========================================================================
+
+    @Test
+    fun `first list call populates cache from repository`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        val first = svc.list(tenantA)
+        assertEquals(1, first.size)
+    }
+
+    @Test
+    fun `second list call within TTL does not hit repository`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        svc.list(tenantA) // prime cache
+
+        // Modify the repository directly — bypassing the cache. The cached
+        // value should still be returned because TTL has not expired.
+        repo.upsert(TenantClaimMapper(tenantA, "trial_ends", "custom:trial_ends"))
+
+        val cached = svc.list(tenantA)
+        assertEquals(1, cached.size)
+    }
+
+    @Test
+    fun `list after TTL expiry refetches from repository`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        svc.list(tenantA) // prime cache
+
+        repo.upsert(TenantClaimMapper(tenantA, "trial_ends", "custom:trial_ends"))
+        now = now.plusMillis(60_001L) // advance past TTL
+
+        val refreshed = svc.list(tenantA)
+        assertEquals(2, refreshed.size)
+    }
+
+    // =========================================================================
+    // self-invalidation on write
+    // =========================================================================
+
+    @Test
+    fun `upsert invalidates the tenant's cache entry`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        svc.list(tenantA) // prime cache
+
+        val result = svc.upsert(TenantClaimMapper(tenantA, "trial_ends", "custom:trial_ends"))
+        assertIs<AttributeResult.Success<TenantClaimMapper>>(result)
+
+        // Cache should be invalidated — next read reflects the write immediately.
+        val refreshed = svc.list(tenantA)
+        assertEquals(2, refreshed.size)
+    }
+
+    @Test
+    fun `delete invalidates the tenant's cache entry`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        svc.list(tenantA) // prime cache
+
+        val result = svc.delete(tenantA, "plan")
+        assertIs<AttributeResult.Success<Unit>>(result)
+
+        val refreshed = svc.list(tenantA)
+        assertEquals(0, refreshed.size)
+    }
+
+    // =========================================================================
+    // cross-tenant isolation
+    // =========================================================================
+
+    @Test
+    fun `invalidating one tenant does not affect another`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        repo.upsert(TenantClaimMapper(tenantB, "role", "custom:role"))
+
+        svc.list(tenantA)
+        svc.list(tenantB)
+
+        // Modify repo for B, then write to A (which invalidates only A).
+        repo.upsert(TenantClaimMapper(tenantB, "level", "custom:level"))
+        svc.upsert(TenantClaimMapper(tenantA, "tier", "custom:tier"))
+
+        // B should still return cached size (1), A should reflect new write (2).
+        assertEquals(1, svc.list(tenantB).size)
+        assertEquals(2, svc.list(tenantA).size)
+    }
+
+    @Test
+    fun `invalidate method clears cache directly`() {
+        repo.upsert(TenantClaimMapper(tenantA, "plan", "custom:plan"))
+        svc.list(tenantA)
+
+        repo.upsert(TenantClaimMapper(tenantA, "direct", "custom:direct"))
+        svc.invalidate(tenantA)
+
+        assertEquals(2, svc.list(tenantA).size)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a comprehensive system for custom user attributes and JWT claim mapping, enabling per-user key/value metadata to be projected into issued JWTs with configurable claim names. The changes span new database tables, domain models, service layers, REST API endpoints, admin UI features, and supporting infrastructure, with a strong emphasis on security and extensibility.

**Custom User Attributes & Claim Mapping:**

- Added support for per-user custom attributes and tenant-level claim mappers, allowing admins to declaratively project user metadata into JWTs with configurable claim names. This includes new domain models (`UserAttribute`, `TenantClaimMapper`), repositories, and services with validation, reserved-claim enforcement, and a soft cap to prevent JWT bloat.
- Introduced new persistence layers: `PostgresUserAttributeRepository` and `PostgresTenantClaimMapperRepository`, each with associated Exposed table mappings (`UserAttributesTable`, `TenantClaimMappersTable`). These support efficient querying, upserting, and deletion of user attributes and claim mappers. [[1]](diffhunk://#diff-ebeee580924ff4a2a8a5bc0817034e6eb479edb2eb4147e8c042df9bce22df5aR1-R98) [[2]](diffhunk://#diff-fa3a7ee1068784997a5f61286d2c1f55fef2283f8202a45f5b93e1c817e3e74fR1-R18) [[3]](diffhunk://#diff-8dfd78b68b947b045dad65a6d479a14a517483ff70917af04af14b73413092a3R1-R76) [[4]](diffhunk://#diff-1671f036456f1bce0324ea235deec34eb24a26d6ddf07a6f7543280491597518R1-R17)

**JWT Token Issuance & Claim Projection:**

- Extended the `JwtTokenAdapter.issueUserTokens` method to accept `customAccessClaims` and `customIdClaims`, stamping these into the respective tokens. This ensures that mapped claims flow into JWTs at issuance and on token refresh. [[1]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R68-R69) [[2]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183R133-R137) [[3]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L146-R157)
- Updated the OAuth and admin route wiring to inject the new services and repositories, preserving backward compatibility for existing call sites. [[1]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R373-R374) [[2]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R399-R400) [[3]](diffhunk://#diff-a1cd1a0d8a1c0255e8ea6c238f22836a6b092c55142f1b9fac522dadd8fd9b1cR208-R216)

**REST API & Admin UI:**

- Added six new REST API endpoints for managing user attributes and claim mappers, with appropriate authorization scopes and RFC 7807-compliant error responses. The OpenAPI spec and admin UI have been updated to expose these features, including warnings about PII in JWTs.

**Security & Infrastructure:**

- Enforced a reserved-claim-name blocklist and unique claim name constraints at both the service and database levels to prevent misuse and race conditions. Added a 20-mapper-per-tenant soft cap and prominent warnings about PII exposure.
- Implemented a caching decorator for claim mappers with a 60-second TTL and tenant-scoped invalidation, ensuring efficient and isolated updates.

These changes collectively provide a robust, extensible foundation for custom claims in JWTs, with strong validation, security, and admin tooling.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
- [x] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
