### PR TITLE
feature/magic-link-token-burn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.7.0-rc1] - 2026-04-28
+## [1.7.1] - 2026-04-28
+
+### Fixed
+
+- **Magic-link token-burn race on cross-device tap.** In v1.7.0, `GET /t/{slug}/magic-link/consume` called `consumeMagicLink(token)` **before** checking the `KOTAUTH_AUTH_CONTEXT` cookie. A user who requested the link on their laptop and tapped it on their phone (the modal mobile-email case — iOS opens links in system Safari, not the originating in-app browser) saw the friendly "open this link in the same browser" error, but the token had already been marked consumed. The user's same-device retry on their laptop then failed with "this link has already been used" — turning the friendly error into a hostile dead end. The fix in `MagicLinkRoutes.kt` reorders the consume route to check `getAuthContext` first; if the cookie is absent, the route renders the cross-device error **without** touching the token, leaving it valid for the same-device retry. Caught during cross-device priority analysis (deferred to v1.8.x — see [ADR-10](docs/adr/ADR-10-magic-link-passwordless-signin.md))
+
+### Added
+
+- **`MagicLinkRoutesTest.kt`** — 5 HTTP integration tests covering the regression: cross-device tap preserves the token, same-device flow consumes correctly, the canonical "tap on phone, then retry on laptop" sequence succeeds on the same token, feature toggle off behavior, and `POST /magic-link/send` enumeration safety (always redirects to `?sent=true` regardless of email known/unknown)
+
+### Documentation
+
+- **ADR-04 audit closed.** Re-audit of `AdminRbacRoutes.kt` confirmed all mutations correctly route through `RoleGroupService`/`AdminService`. Three remaining direct repository calls are reads (role-create dropdown population, user-search autocomplete) and are deliberately out of scope per ADR-04, which scopes to **write operations** only. No code change needed; memory note updated to reflect closed status
+
+---
+
+## [1.7.0] - 2026-04-28
 
 ### Added
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.7.0"
+version = "1.7.1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/main/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutes.kt
@@ -24,11 +24,12 @@ import io.ktor.server.routing.post
  *   4. `GET /magic-link/consume?token=…` — token verified, OAuth context from
  *      the cookie used to complete the authorization_code flow
  *
- * Cross-device / expired-cookie flow (v1.7.0):
+ * Cross-device / expired-cookie flow:
  *   Consumption requires the `KOTAUTH_AUTH_CONTEXT` cookie set by the original
  *   `/authorize` request. If absent (different browser, cookie expired after
  *   5 minutes), the user sees a friendly error asking them to open the link in
- *   the same browser or request a new one.
+ *   the same browser. The OAuth-context check runs **before** `consumeMagicLink`,
+ *   so the token is preserved and a same-device retry still works.
  *
  * Gated on `tenant.securityConfig.magicLinkEnabled` — off by default per tenant.
  */
@@ -102,6 +103,27 @@ internal fun Route.magicLinkRoutes(
             return@get call.respondRedirect("/t/${ctx.slug}/magic-link")
         }
 
+        // Check OAuth context BEFORE consuming the token. If absent, the user
+        // is on the wrong device/browser; bailing out here keeps the token
+        // alive so a same-device retry still works. Consuming first would
+        // burn the token on every cross-device tap and turn the friendly
+        // error into a dead end.
+        val oauthParams = call.getAuthContext(encryptionService)
+        if (oauthParams == null) {
+            call.respondHtml(
+                HttpStatusCode.Unauthorized,
+                AuthView.magicLinkErrorPage(
+                    tenantSlug = ctx.slug,
+                    theme = ctx.theme,
+                    workspaceName = ctx.workspaceName,
+                    error =
+                        "To finish signing in, open this link in the same browser where you " +
+                            "requested it — or go back to the sign-in page and request a new link.",
+                ),
+            )
+            return@get
+        }
+
         when (val result = selfServiceService.consumeMagicLink(token)) {
             is SelfServiceResult.Failure -> {
                 call.respondHtml(
@@ -116,26 +138,6 @@ internal fun Route.magicLinkRoutes(
             }
             is SelfServiceResult.Success -> {
                 val user = result.value
-                val oauthParams = call.getAuthContext(encryptionService)
-                if (oauthParams == null) {
-                    // No OAuth context → either cross-device or expired cookie.
-                    // v1.7.0: direct the user to the login page to start a fresh
-                    // session. Their account is verified; they just need to
-                    // re-initiate the flow in this browser.
-                    call.respondHtml(
-                        HttpStatusCode.Unauthorized,
-                        AuthView.magicLinkErrorPage(
-                            tenantSlug = ctx.slug,
-                            theme = ctx.theme,
-                            workspaceName = ctx.workspaceName,
-                            error =
-                                "To finish signing in, open this link in the same browser where you " +
-                                    "requested it — or go back to the sign-in page and request a new link.",
-                        ),
-                    )
-                    return@get
-                }
-
                 val ipAddress = call.request.local.remoteAddress
                 call.completeAuthorizationCodeFlow(
                     slug = ctx.slug,

--- a/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
@@ -1,0 +1,344 @@
+package com.kauth.adapter.web.auth
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.TokenPurpose
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordPolicyPort
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.InMemoryRateLimiter
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * HTTP integration tests for [magicLinkRoutes].
+ *
+ * Regression coverage for the v1.7.1 token-burn race fix: a cross-device tap
+ * (no `KOTAUTH_AUTH_CONTEXT` cookie) must NOT consume the token, so a
+ * same-device retry continues to work.
+ */
+class MagicLinkRoutesTest {
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val apps = FakeApplicationRepository()
+    private val authCodes = FakeAuthorizationCodeRepository()
+    private val sessions = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val emails = FakeEmailPort()
+    private val tokenPort = FakeTokenPort()
+    private val evTokens = FakeEmailVerificationTokenRepository()
+    private val prTokens = FakePasswordResetTokenRepository()
+    private val passwordPolicy = FakePasswordPolicyPort()
+
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-minimum-len")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(1),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+            smtpEnabled = true,
+            smtpHost = "smtp.example.com",
+            smtpPort = 587,
+            smtpUsername = "noreply@acme.com",
+            smtpPassword = "secret",
+            smtpFromAddress = "noreply@acme.com",
+            smtpFromName = "Acme",
+            securityConfig = SecurityConfig(magicLinkEnabled = true),
+        )
+
+    private val alice =
+        User(
+            id = UserId(10),
+            tenantId = TenantId(1),
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("doesnt-matter"),
+            enabled = true,
+            emailVerified = false,
+        )
+
+    private val spaApp =
+        Application(
+            id = ApplicationId(1),
+            tenantId = TenantId(1),
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    private val limiter = InMemoryRateLimiter(maxRequests = 1000, windowSeconds = 60)
+
+    private fun selfService() =
+        UserSelfServiceService(
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = evTokens,
+            prTokenRepo = prTokens,
+            emailPort = emails,
+            passwordPolicy = passwordPolicy,
+            emailScope = CoroutineScope(Dispatchers.Unconfined),
+        )
+
+    private fun authService() =
+        AuthService(
+            userRepository = users,
+            tenantRepository = tenants,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessions,
+        )
+
+    private fun oauthService() =
+        OAuthService(
+            tenantRepository = tenants,
+            userRepository = users,
+            applicationRepository = apps,
+            sessionRepository = sessions,
+            authCodeRepository = authCodes,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+        )
+
+    private fun buildAuthContextCookie(): String {
+        // Public clients require PKCE — use a deterministic challenge so the
+        // test exercises a realistic /authorize-style cookie payload.
+        val payload =
+            listOf(
+                "code",
+                "spa-app",
+                "https://app.example.com/callback",
+                "openid",
+                "",
+                "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "S256",
+                "",
+                System.currentTimeMillis().toString(),
+            ).joinToString("|")
+        return encryptionService.signCookie(payload)
+    }
+
+    @BeforeTest
+    fun reset() {
+        tenants.clear()
+        users.clear()
+        apps.clear()
+        authCodes.clear()
+        sessions.clear()
+        prTokens.clear()
+        evTokens.clear()
+        emails.clear()
+        auditLog.clear()
+        tokenPort.reset()
+        passwordPolicy.clear()
+
+        tenants.add(tenant)
+        users.add(alice)
+        apps.add(spaApp)
+    }
+
+    private fun extractToken(url: String): String = url.substringAfter("?token=").substringBefore("&")
+
+    private fun appBlock(): io.ktor.server.application.Application.() -> Unit =
+        {
+            install(ContentNegotiation) { json() }
+            routing {
+                authRoutes(
+                    authService = authService(),
+                    oauthService = oauthService(),
+                    tenantRepository = tenants,
+                    loginRateLimiter = limiter,
+                    registerRateLimiter = limiter,
+                    tokenRateLimiter = limiter,
+                    selfServiceService = selfService(),
+                    encryptionService = encryptionService,
+                )
+            }
+        }
+
+    // =========================================================================
+    // Regression — cross-device tap must NOT consume the token
+    // =========================================================================
+
+    @Test
+    fun `consume without auth-context cookie preserves the token for same-device retry`() =
+        testApplication {
+            application(appBlock())
+
+            // Issue the magic link
+            selfService().initiateMagicLink(
+                email = "alice@acme.com",
+                tenantSlug = "acme",
+                baseUrl = "http://localhost",
+                ipAddress = null,
+            )
+            val rawToken = extractToken(emails.sent.single { it.type == "magic_link" }.url)
+
+            // Cross-device tap: NO KOTAUTH_AUTH_CONTEXT cookie
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/magic-link/consume?token=$rawToken")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+
+            // The token MUST still be alive — not marked used, not deleted
+            val token = prTokens.all().single { it.purpose == TokenPurpose.MAGIC_LINK }
+            assertTrue(token.isValid, "Token must remain valid after a cross-device tap")
+            assertEquals(null, token.usedAt, "Token must not be marked used")
+        }
+
+    @Test
+    fun `consume with auth-context cookie completes OAuth flow and burns the token`() =
+        testApplication {
+            application(appBlock())
+
+            selfService().initiateMagicLink(
+                email = "alice@acme.com",
+                tenantSlug = "acme",
+                baseUrl = "http://localhost",
+                ipAddress = null,
+            )
+            val rawToken = extractToken(emails.sent.single { it.type == "magic_link" }.url)
+            val cookie = buildAuthContextCookie()
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("/t/acme/magic-link/consume?token=$rawToken") {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=$cookie")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"]
+            assertNotNull(location)
+            assertTrue(
+                location.startsWith("https://app.example.com/callback?code="),
+                "Same-device consume must redirect to the OAuth client callback with a code, was: $location",
+            )
+
+            val token = prTokens.all().single { it.purpose == TokenPurpose.MAGIC_LINK }
+            assertEquals(true, token.isUsed, "Token must be consumed on successful same-device sign-in")
+        }
+
+    @Test
+    fun `cross-device tap then same-device retry succeeds on the same token`() =
+        testApplication {
+            application(appBlock())
+
+            selfService().initiateMagicLink(
+                email = "alice@acme.com",
+                tenantSlug = "acme",
+                baseUrl = "http://localhost",
+                ipAddress = null,
+            )
+            val rawToken = extractToken(emails.sent.single { it.type == "magic_link" }.url)
+
+            val noFollow = createClient { followRedirects = false }
+
+            // 1. User taps the link on a different device — no cookie
+            val crossDeviceResponse = noFollow.get("/t/acme/magic-link/consume?token=$rawToken")
+            assertEquals(HttpStatusCode.Unauthorized, crossDeviceResponse.status)
+
+            // 2. User goes back to the original device, clicks again — cookie present
+            val cookie = buildAuthContextCookie()
+            val sameDeviceResponse =
+                noFollow.get("/t/acme/magic-link/consume?token=$rawToken") {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=$cookie")
+                }
+            assertEquals(
+                HttpStatusCode.Found,
+                sameDeviceResponse.status,
+                "Same-device retry must succeed because the cross-device tap did not burn the token",
+            )
+        }
+
+    // =========================================================================
+    // Sanity — feature toggle off
+    // =========================================================================
+
+    @Test
+    fun `consume returns redirect to login when magic-link disabled on tenant`() =
+        testApplication {
+            tenants.clear()
+            tenants.add(tenant.copy(securityConfig = SecurityConfig(magicLinkEnabled = false)))
+            application(appBlock())
+
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/magic-link/consume?token=anything")
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]?.contains("/account/login") == true)
+        }
+
+    // =========================================================================
+    // POST /magic-link/send — always redirects to ?sent=true (enumeration safe)
+    // =========================================================================
+
+    @Test
+    fun `send always redirects to sent=true regardless of email`() =
+        testApplication {
+            application(appBlock())
+
+            val noFollow = createClient { followRedirects = false }
+
+            val knownResponse =
+                noFollow.submitForm(
+                    url = "/t/acme/magic-link/send",
+                    formParameters = Parameters.build { append("email", "alice@acme.com") },
+                )
+            val unknownResponse =
+                noFollow.submitForm(
+                    url = "/t/acme/magic-link/send",
+                    formParameters = Parameters.build { append("email", "nobody@nowhere.com") },
+                )
+
+            assertEquals(HttpStatusCode.Found, knownResponse.status)
+            assertEquals(HttpStatusCode.Found, unknownResponse.status)
+            assertTrue(knownResponse.headers["Location"]?.contains("?sent=true") == true)
+            assertTrue(unknownResponse.headers["Location"]?.contains("?sent=true") == true)
+        }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request addresses a critical bug in the magic-link authentication flow, where a cross-device tap could prematurely consume the token, blocking legitimate same-device retries. The fix ensures the token is only consumed after confirming the correct OAuth context, and adds comprehensive integration tests to prevent regressions. Documentation has also been updated to reflect the changes and close out an audit.

**Bug fix: Magic-link token consumption logic**
- The `GET /t/{slug}/magic-link/consume` route in `MagicLinkRoutes.kt` now checks for the `KOTAUTH_AUTH_CONTEXT` cookie before consuming the magic-link token. If the cookie is missing (e.g., user opens the link on a different device/browser), the route returns a friendly error without consuming the token, preserving it for a valid same-device retry. This prevents the token-burn race that previously led to dead ends for users attempting to sign in across devices. [[1]](diffhunk://#diff-60121b0006f6a41e2181a9dd776290d7917fdfe88a4c8aa1936c867b023a2b6cL105-R140) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R26)

**Testing and regression coverage**
- Added a new test suite, `MagicLinkRoutesTest.kt`, with five integration tests covering: (1) cross-device tap preserves the token, (2) same-device flow consumes the token, (3) the canonical cross-device-then-same-device sequence succeeds, (4) feature toggle off behavior, and (5) enumeration safety of `POST /magic-link/send`.

**Documentation and audit**
- Updated documentation in `MagicLinkRoutes.kt` to clarify the new flow and the order of operations for token consumption and OAuth-context checking.
- Closed out ADR-04 audit in the changelog, confirming all mutations in `AdminRbacRoutes.kt` are routed through the correct services and that remaining direct repository calls are read-only and out of scope.

**Changelog**
- Updated `CHANGELOG.md` for version 1.7.1 to document the bug fix, new tests, and audit completion.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
