### PR TITLE
feature/OIDC-sso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.1] - 2026-04-29
+
+### Added
+
+- **OIDC silent SSO across clients on the same tenant** — every successful interactive login now drops a signed `KOTAUTH_SSO` witness cookie path-scoped to `/t/{slug}` (HttpOnly, signed via `EncryptionService.signCookie`, payload `v1|userId|tenantId|authTime|mfaCompleted|expiresAt`). Subsequent visits to `/t/{slug}/authorize` silent-auth by issuing an authorization code without rendering UI. Closes the gap that previously made users land on the portal login screen after signing into a SaaS app. See [ADR-13](docs/adr/ADR-13-oidc-sso-witness-cookie.md)
+- **OIDC `prompt` parameter — full §3.1.2.1 support** — `prompt=none` silent-auths or returns `error=login_required`; `prompt=login`/`consent`/`select_account` clear the SSO cookie and force re-auth. Unknown values and the invalid `none + other` combination return `invalid_request`. Discovery doc advertises `prompt_values_supported`
+- **`auth_time` claim on every ID token** — `JwtTokenAdapter.issueUserTokens` now writes the OIDC `auth_time` claim (epoch seconds) on the ID token. For MFA logins the value is the moment the **second factor was verified** (Keycloak convention), not the first-factor time. Threaded end-to-end: login → `setSsoCookie` → `AuthorizationCode.auth_time` (V38 migration) → ID token. Discovery doc adds `auth_time` to `claims_supported`
+- **OIDC `max_age` parameter** — silent auth refuses to issue when `(now - cookie.authTime) > max_age`. `max_age=0` is treated as the OIDC sentinel meaning "force fresh credential proof now" and always falls through to interactive
+- **OIDC `id_token_hint` parameter** — best-effort `sub` extraction from the hint payload; mismatch with the cookie's `userId` blocks silent auth and falls through to interactive. Signature verification of the hint is a v1.9.x follow-up
+- **Portal silent SSO via `prompt=none`** — `GET /t/{slug}/account/login` builds the OAuth authUrl with `&prompt=none` on first attempt. `/callback` handles the `error=login_required` response by redirecting to `/login?prompt_failed=true` to break the loop and render the form. Two server hops worst case for first-time visitors; zero form pages for users with a valid SSO cookie
+- **`OAuthService.validateRedirectUri(tenantSlug, clientId, redirectUri)`** — new domain method used by GET `/authorize` to validate the redirect_uri against the client's registered list **before** constructing any redirect string. Open-redirect protection for the `prompt=none` failure path
+- **Two new env vars** — `KAUTH_SSO_SESSION_TTL_SECONDS` (default 86400 / 24h) and `KAUTH_SSO_SESSION_MAX_TTL_SECONDS` (default 2592000 / 30d). Validated at startup (`60s ≤ ttl ≤ maxTtl`). Documented in [ENV_REFERENCE.md](docs/ENV_REFERENCE.md)
+- **V38 migration** — `auth_time TIMESTAMPTZ NULL` column on `authorization_codes`. Nullable for backwards compatibility with codes minted before this column existed; new issuance always populates it
+- **Phase 1–5 integration tests** — 4 SSO cookie tests (`SsoCookieTest`), 7 prompt parameter tests (`PromptParamTest`), 13 silent auth tests (`SilentAuthTest`), 2 OIDC end-session tests (`SsoLogoutTest`), 4 portal silent SSO tests (additions to `PortalRoutesTest`). All in default `make test`, no Docker required
+
+### Changed
+
+- **`completeAuthorizationCodeFlow` signature extended** — now accepts `tenantId`, `authTime`, `mfaCompleted`, `ssoTtlSeconds`, `secure`, `encryptionService`. Every call site (password login, MFA challenge, magic-link consume, social login) was updated; `SocialLoginRoutes` was refactored from two inline `issueAuthorizationCode` blocks into a single use of the helper, removing the divergence in code-issuance behavior across credential types
+- **`OAuthService.issueAuthorizationCode` accepts `authTime: Instant = Instant.now()`** — silent auth passes the cookie's `authTime`; interactive paths pass the moment of credential verification. The auth code persists this value for the token-exchange path to read
+- **`TokenPort.issueUserTokens` accepts `authTime: Instant?`** — null preserves pre-feature token shape (refresh-token paths). When set, `JwtTokenAdapter` writes the `auth_time` claim onto the ID token
+- **All three logout paths clear `KOTAUTH_SSO`** — `GET /t/{slug}/protocol/openid-connect/logout`, the corresponding `POST`, and portal `POST /t/{slug}/account/logout`. Without this, logging out then visiting `/account/login` would silent-auth the user straight back in
+
+### Documentation
+
+- **ADR-13 — OIDC silent SSO via path-scoped witness cookie.** Captures the cookie design (path-scope, HMAC-not-JWT, version prefix), `auth_time` plumbing through three layers, the Keycloak-style MFA-completion-time decision, the `mfaCompleted` policy enforcement model, prompt/max_age/id_token_hint semantics, the open-redirect mitigation, threat model, and known limitations (signature-verification of `id_token_hint`, role-aware `required_admins` silent auth, session-bound revocation — all tracked for v1.9.x / v1.10.0)
+
+---
+
 ## [1.8.0] - 2026-04-29
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.8.0"
+version = "1.8.1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/ENV_REFERENCE.md
+++ b/docs/ENV_REFERENCE.md
@@ -212,6 +212,36 @@ Timeout (ms) for the `PING` probe at startup. Higher in slow networks; lower if 
 
 ---
 
+## OIDC SSO
+
+The two knobs below tune the witness cookie that drives silent SSO across clients on the same tenant. See [ADR-13](adr/ADR-13-oidc-sso-witness-cookie.md) for the design and threat model.
+
+### `KAUTH_SSO_SESSION_TTL_SECONDS`
+**Optional.** Default: `86400` (24 hours)
+
+How long the `KOTAUTH_SSO` cookie lives. Determines the maximum interval over which a user can silent-auth across clients without re-proving credentials. Auth0's default is 24h; Keycloak defaults to 36000s (10h). Lower values trade SSO convenience for tighter session-freshness guarantees.
+
+```
+KAUTH_SSO_SESSION_TTL_SECONDS=86400
+```
+
+The cookie carries its own `expiresAt` timestamp in the signed payload, so this TTL cannot be silently exceeded by a stale cookie minted before the operator tightened the value.
+
+---
+
+### `KAUTH_SSO_SESSION_MAX_TTL_SECONDS`
+**Optional.** Default: `2592000` (30 days)
+
+Operator-side ceiling. `KAUTH_SSO_SESSION_TTL_SECONDS` must be `≤` this value or the server refuses to start (fail-fast at `EnvironmentConfig.load`). Use it to enforce a policy "no SSO session may live longer than X" without trusting individual deployments to keep the per-instance TTL under control.
+
+```
+KAUTH_SSO_SESSION_MAX_TTL_SECONDS=2592000
+```
+
+Validation: both values must be `≥ 60` and `ttl ≤ maxTtl`. Misconfiguration prints a `FATAL` banner and exits.
+
+---
+
 ## Demo Mode
 
 ### `KAUTH_DEMO_MODE`

--- a/docs/adr/ADR-13-oidc-sso-witness-cookie.md
+++ b/docs/adr/ADR-13-oidc-sso-witness-cookie.md
@@ -1,0 +1,317 @@
+# ADR-13: OIDC silent SSO via path-scoped witness cookie
+
+**Status:** Accepted (v1.8.1)
+**Date:** 2026-04-29
+**Supersedes:** —
+**Related:** ADR-01 (hexagonal architecture), `docs/guides/react-spa-tanstack-router.md`
+
+## Context
+
+Through v1.8.0, every visit to `/t/{slug}/authorize` rendered the login
+form even when the user had successfully authenticated minutes earlier
+in the same browser. A user who logged into the SaaS SPA via Kotauth and
+then clicked "Manage Account" landed on the portal login screen instead
+of being silently authenticated — generating "why am I logged out?"
+support tickets and badly under-performing the bar set by Auth0,
+Keycloak, and Clerk.
+
+Three things made the original sketch insufficient and forced this ADR:
+
+1. **The first proposal — "append `&prompt=none` to the portal authUrl"
+   — was a one-line change that doesn't actually do anything.** Kotauth's
+   `/authorize` GET handler had no awareness of `prompt`; even if it had,
+   `completeAuthorizationCodeFlow` did not set any auth-server-domain
+   cookie on successful login. After OAuth completes, the browser holds
+   zero Kotauth-domain cookies — the auth server has no SSO state to
+   consult on the next `/authorize` GET. Silent auth is not a flag, it is
+   a witness-cookie protocol.
+2. **The OIDC spec is precise about what "silent auth" means.** Core
+   §3.1.2.1 defines `prompt`, `max_age`, `id_token_hint`; §3.1.2.6
+   defines the `login_required` failure mode; §2 / §3.1.3.7 require the
+   `auth_time` claim on the ID token. We are an OIDC server with full
+   discovery, JWKS, PKCE — silent SSO has to land at that quality bar,
+   not "good enough for our portal."
+3. **Tenant-scoping is not optional.** Kotauth runs many tenants on the
+   same hostname (`https://auth.example.com/t/acme`,
+   `/t/widgets`, …). A domain-scoped SSO cookie would let one tenant
+   silent-auth users into another. This shapes the cookie design more
+   than any other constraint.
+
+## Decision
+
+### Stateful, signed, opaque, path-scoped — `KOTAUTH_SSO`
+
+We mint a server-signed cookie at every successful interactive
+authentication and read it at every subsequent `/authorize` request. The
+cookie is:
+
+- **Path-scoped to `/t/{slug}`** — the URL path already isolates tenants
+  in our routing tree, so the same path-scope automatically gives us
+  per-tenant cookies without us inventing a separate naming scheme.
+  Browsers will not send `KOTAUTH_SSO` on requests to `/t/widgets/*`
+  even though the hostname is the same.
+- **HttpOnly** — JavaScript on a tenant page cannot read the cookie, so
+  XSS in any single SaaS app cannot exfiltrate it.
+- **Signed via `EncryptionService.signCookie`** — same HMAC primitive
+  we already use for `KOTAUTH_AUTH_CONTEXT`, `KOTAUTH_MFA_PENDING`,
+  `KOTAUTH_PORTAL_PKCE`, `KOTAUTH_SOCIAL_PENDING`. One signing key
+  (`KAUTH_SECRET_KEY`), one verification path, no new key surface.
+- **Opaque pipe-delimited payload, version-prefixed** —
+  `v1|userId|tenantId|authTime|mfaCompleted|expiresAt`. Not a JWT: it
+  never leaves our origin, never gets sent to a relying party, never
+  goes through a parser written by anyone else. The `v1` prefix gives
+  us a pinch-point for future revisions without breaking deployed
+  cookies.
+- **`Secure` whenever the deployment is HTTPS** — gated by
+  `KAUTH_BASE_URL` starting with `https://` so local dev still works
+  unchanged.
+
+### Why HMAC over JWT for the cookie payload
+
+A JWT cookie would be self-describing, but it would also be the third
+representation of authentication state — alongside the access token
+(JWT) and the database session row. The cookie travels only between
+the browser and us, never to an RP. We win nothing from
+self-description; we lose ergonomics every time we add a field to the
+payload, since JWT libraries make schema migration awkward.
+
+Pipe-delimited + signed is what every other Kotauth cookie uses. It
+fits the codebase, it round-trips through `signCookie/verifyCookie`,
+and it is trivially decodable in tests.
+
+### `auth_time` is recorded on the cookie, threaded onto the auth code, and emitted on the ID token
+
+The OIDC `auth_time` claim is the moment the End-User most recently
+proved their credentials. Three integration points:
+
+1. `setSsoCookie(...)` is called from `completeAuthorizationCodeFlow`
+   on every successful login. Each credential type passes its own
+   `authTime`:
+   - Password / magic-link / social → `Instant.now()` at completion
+   - **MFA → moment the second factor was verified, not the moment
+     the password was checked.** This matches Keycloak. The user
+     experiences the second factor as the boundary that makes them
+     "authenticated"; that is what `max_age` should be measured from.
+2. `OAuthService.issueAuthorizationCode` accepts `authTime` and persists
+   it on `AuthorizationCode.auth_time` (V38 migration).
+3. `JwtTokenAdapter.issueUserTokens` accepts `authTime` and writes
+   `auth_time` (epoch seconds) onto the ID token. The discovery doc
+   advertises `auth_time` in `claims_supported`.
+
+For silent auth, the cookie's `authTime` flows straight through:
+SSO cookie → silent `issueAuthorizationCode(..., authTime = sso.authTime)`
+→ `AuthorizationCode.authTime` → ID token's `auth_time` claim. The
+RP's `max_age` check works against the original authentication moment,
+not the moment of the silent-auth round-trip.
+
+### `mfaCompleted` flag — Keycloak parity for required-MFA tenants
+
+The cookie carries a single `mfaCompleted` bit alongside the
+identifiers. Silent auth refuses to issue a code if the tenant
+currently requires MFA (`mfaPolicy != "optional"`) and the cookie
+says `mfaCompleted=false`. This handles the case where an admin
+tightens the tenant policy after a user has already authenticated:
+the existing cookie is treated as not-yet-MFA and falls back to the
+interactive flow, which re-runs the policy and triggers MFA enrollment.
+
+The simpler check `policy == "optional" || mfaCompleted` is
+intentionally conservative for `required_admins`-mode non-admin
+users — they would also be denied silent auth without MFA. They get
+re-prompted for password (which they can satisfy without MFA) and
+walk away with a fresh cookie. We pay one round-trip; we don't have
+to ship a route-side role lookup.
+
+### `prompt` semantics on GET `/authorize`
+
+OIDC §3.1.2.1 supports a space-separated set:
+
+| Value            | Behavior                                                                                                                |
+|------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `none`           | Never show UI. Silent-auth via cookie or fail with `error=login_required` redirected back to a **registered** redirect_uri. |
+| `login`          | Force re-auth — `clearSsoCookie(slug)` and render the login form even if the cookie is valid.                          |
+| `consent`        | Force consent. We have no consent UI yet, so it folds into `login` until that ships.                                    |
+| `select_account` | Account picker. Single-account-per-browser today, so identical to `login`.                                              |
+
+Unknown values return `invalid_request`. `none` combined with anything
+else returns `invalid_request` (§3.1.2.1: "if `none` is requested with
+any other value, an error is returned"). Discovery advertises
+`prompt_values_supported`.
+
+### Open-redirect protection is mandatory before any redirect
+
+`prompt=none` failure cannot bounce to a `redirect_uri` that didn't
+come from the client's registered list — that would turn `/authorize`
+into an open-redirect vector. Phase 3 introduced
+`OAuthService.validateRedirectUri(tenantSlug, clientId, redirectUri)`
+exactly for this guard, called before any error redirect for
+`prompt=none`. Mismatch returns 400 in JSON; we never construct a
+redirect with an attacker-supplied URI.
+
+### `id_token_hint` is honored, but signature verification is a follow-up
+
+The route extracts `sub` from the hint via a payload-only base64 decode
+and refuses silent auth on mismatch with the cookie's `userId`. We do
+**not** verify the signature in v1.8.1 — and this is a deliberate
+constraint, not laziness. The worst case from an attacker-supplied
+hint is that silent auth falls through to interactive auth, which is
+the safe default. A spec-strict full-validation pass is tracked as a
+v1.9.x follow-up.
+
+### Logout MUST clear the cookie everywhere
+
+Phase 4 wires `clearSsoCookie(slug)` into:
+
+- `GET /t/{slug}/protocol/openid-connect/logout`
+- `POST /t/{slug}/protocol/openid-connect/logout`
+- `POST /t/{slug}/account/logout` (portal)
+
+Not clearing here would silently undo the user's logout: their
+`KOTAUTH_PORTAL` session is gone, but the next visit to `/account/login`
+silent-auths them straight back in. That is exactly the bug a
+"why-am-I-still-logged-in" support ticket would describe, and it is
+the easiest cookie protocol to get wrong.
+
+### Portal `/login` itself uses `prompt=none` — with a loop break
+
+Phase 5: portal login on first attempt builds the authUrl with
+`&prompt=none`. `/callback` notices `error=login_required` and
+redirects to `/login?prompt_failed=true`, which omits `prompt=none` on
+its second attempt and renders the form. Two server hops, no infinite
+redirect, the user sees one form page if they have no SSO cookie and
+zero form pages if they do.
+
+### TTL knobs
+
+Two env vars, validated at startup (`60s ≤ ttl ≤ maxTtl`):
+
+```
+KAUTH_SSO_SESSION_TTL_SECONDS=86400         # 24h default — Auth0 parity
+KAUTH_SSO_SESSION_MAX_TTL_SECONDS=2592000   # 30d operator ceiling
+```
+
+The default is 24h. The max is the operator's policy ceiling — the cookie
+itself never lives longer than `expiresAt` carried in its own payload, so
+the cap can never be silently exceeded by a stale cookie minted before
+the operator tightened the policy.
+
+## Consequences
+
+### Positive
+
+- **Cross-app silent SSO works without RP cooperation.** A SaaS app
+  receiving `/authorize` does the same call it has always done; the
+  cookie is invisible to the RP and travels only between Kotauth and
+  the browser.
+- **Tenant isolation is structural, not configurational.** Path-scoped
+  cookie + path-scoped routes = no cross-tenant cookie leakage by
+  construction. Operators cannot misconfigure their way into a
+  cross-tenant SSO leak.
+- **`auth_time` finally reaches the ID token.** RPs that rely on it for
+  step-up flows or session-freshness policies (Auth0/Okta-style apps)
+  can adopt Kotauth without the existing pre-feature gap.
+- **Logout actually logs the user out.** Both OIDC end-session and
+  portal logout wipe the cookie, so silent-auth-back-in is impossible.
+- **Failure modes are loud.** Bad redirect_uri → 400. Unknown prompt
+  → 400. Invalid `none + login` combination → 400. Silent-auth miss
+  with `prompt=none` → `error=login_required` to the registered URI.
+  No silent fallthroughs, no half-states.
+
+### Negative — known limitations
+
+1. **`id_token_hint` signatures are not verified in v1.8.1.** The
+   payload-only `sub` extraction is good enough to refuse silent auth on
+   mismatch, but it is not the full §3.1.2.1 contract. A v1.9.x
+   follow-up will add `decodeIdToken` to `TokenPort` and verify against
+   the tenant's JWKS.
+2. **Silent auth respects `mfaCompleted` but does not look up roles for
+   `required_admins`.** Non-admin users on a `required_admins` tenant
+   who did not complete MFA will fall through to the interactive flow
+   even though policy doesn't actually require their second factor. The
+   UX hit is one extra round-trip. Adding the role lookup at the route
+   level would couple the silent-auth path to `RoleRepository`; we
+   prefer the over-restriction.
+3. **Cookie is stateful but does not reference a session row.** A v1.8.1
+   silent-auth issuance is anchored on the cookie's `userId/authTime`;
+   it does not check whether the user's most recent session has been
+   admin-revoked. In practice, an admin who revokes a session and wants
+   to make sure the user is logged out should also disable the user
+   account; the cookie's `expiresAt` will then prevent silent re-auth
+   when the user next tries to authenticate. A "session-bound SSO
+   cookie" variant (cookie carries the session id, silent auth verifies
+   the session is not revoked) is tracked for v1.10.0 — it pairs
+   naturally with the impersonation feature.
+4. **No in-cookie audience scoping.** A user who authenticated via
+   Client A on tenant `acme` will silent-auth into Client B on tenant
+   `acme` — by design (this is the headline feature). Operators who
+   need stricter same-tenant per-client isolation should leave the
+   cookie disabled at deploy time by setting
+   `KAUTH_SSO_SESSION_TTL_SECONDS=0` to suppress writes. (This switch
+   ships in v1.9.x; the env var validation rejects 0 in v1.8.1.)
+
+### Neutral
+
+- The cookie payload is intentionally not a JWT — see "Why HMAC over
+  JWT" above. Operators inspecting cookies in DevTools see a base64
+  blob with a trailing HMAC, identical in shape to every other Kotauth
+  cookie.
+- The cookie is set even for failures of `issueAuthorizationCode`
+  during the post-login redirect (e.g., PKCE missing). The user's
+  authentication fact is established; the cookie tags them with that
+  fact even when the request that prompted the login can't complete.
+  On retry they silent-auth, which is the right outcome.
+
+## Alternatives considered
+
+- **Stateless cookie with no DB session reference** — what we shipped.
+  Considered "session-id in cookie + DB lookup on every silent auth"
+  and rejected for v1.8.1 because the cookie's `expiresAt` already
+  bounds the worst case to a configurable TTL, and adding a DB read
+  to silent auth would re-introduce the per-replica session contention
+  Phase 2 of v1.8.0 was meant to relieve. Revisit in v1.10.0 alongside
+  impersonation.
+- **Domain-scoped cookie with embedded tenantId** — rejected because a
+  bug in tenantId comparison would silently turn cross-tenant SSO on.
+  Path scoping pushes the isolation guarantee into the browser, which
+  is harder to bypass than an `if` statement.
+- **JWT cookie with custom claims** — rejected for the schema-evolution
+  reason above. We would inherit a token format and lose nothing in
+  return; the cookie never leaves our origin.
+- **Per-(tenant, client) SSO scoping** — rejected as a v1.8.1 default.
+  Industry default (Auth0, Keycloak, Okta) is per-tenant, and that is
+  the migration path operators expect. Per-client scoping ships in
+  v1.9.x as `KAUTH_SSO_SCOPE=per_client` for tenants that explicitly
+  need it.
+- **Use `prompt=none` in the cookie freshness check instead of a
+  `mfaCompleted` flag** — rejected because the freshness model is "is
+  the cookie still valid?", not "what did the user do at login time?".
+  We wanted `mfaCompleted` to be readable from the cookie alone so the
+  silent-auth route doesn't need a separate DB lookup.
+
+## Threat model
+
+- **XSS on a tenant SaaS app.** Cookie is HttpOnly → JavaScript can't
+  read it. The attacker can however drive the browser through the
+  silent-auth flow themselves, but only against the tenant where they
+  already have XSS — they don't gain cross-tenant reach. The
+  authorization code they obtain is bound to a redirect_uri they
+  don't control.
+- **CSRF against `/authorize`.** Silent auth issues a code only to
+  registered redirect URIs, and the auth code itself is single-use
+  with PKCE. A forged GET `/authorize` from another origin gets the
+  attacker no auth code they can use.
+- **Cookie theft via lower-layer attack.** Without `HttpOnly` bypass,
+  the only realistic theft is by a CA-trusted MITM, which is the same
+  class of attack that breaks every Kotauth cookie and the database
+  session in transit. We rely on `Secure` + HSTS; this is not unique
+  to the SSO cookie.
+- **Cross-tenant takeover via cookie reuse.** Path scope prevents the
+  browser from sending `KOTAUTH_SSO` across tenants. Even if the
+  cookie were sent, the silent-auth check refuses if
+  `cookie.tenantId != currentRequestTenantId`. Two layers of defense.
+- **Stale cookie after admin policy tightening.** Covered by
+  `mfaCompleted` check above. Cookie outlives a policy change → silent
+  auth refused → user re-runs interactive flow → new cookie reflects
+  the new policy.
+- **Open redirect via `prompt=none` failure path.** Mitigated by
+  `validateRedirectUri` before any redirect involving query-supplied
+  URIs.

--- a/docs/guides/react-spa-tanstack-router.md
+++ b/docs/guides/react-spa-tanstack-router.md
@@ -405,6 +405,22 @@ token=<access_token>&client_id=<backend_client_id>&client_secret=<backend_secret
 
 ---
 
+## Silent SSO across apps (v1.8.1+)
+
+Kotauth honors the OIDC `prompt`, `max_age`, and `id_token_hint` parameters on `/authorize`. After the user signs into one client on your tenant, every subsequent `/authorize` against the same `/t/{slug}` path silent-auths via a server-side witness cookie — **no UI shown, no extra round-trip visible to the user**.
+
+`oidc-client-ts` uses this automatically: `userManager.signinSilent()` and the iframe-based silent renew both hit `/authorize?prompt=none` under the hood. When the witness cookie is present, the response is a fresh authorization code; when it isn't, you get `error=login_required` and `oidc-client-ts` raises `ErrorResponse` for your error handler.
+
+For SPA-side use cases:
+
+- **`prompt=login`** — pass `prompt: "login"` to `signinRedirect({ extraQueryParams: { prompt: "login" } })` to force re-auth even if the user has a valid SSO cookie. Useful for "switch account" or "re-authenticate before sensitive action" flows.
+- **`max_age`** — pass `max_age: "300"` to require a credential proof within the last 5 minutes. RPs that gate sensitive operations (admin pages, payment authorization, etc.) typically pair this with the `auth_time` claim verification on the issued ID token (Kotauth populates `auth_time` since v1.8.1; for MFA logins it is the moment the second factor was verified).
+- **`prompt=select_account`** — same effect as `prompt=login` today. Will diverge once Kotauth ships an account picker.
+
+**Logout that actually logs out.** After v1.8.1, hitting `/protocol/openid-connect/logout` clears the silent-SSO cookie too. Your `userManager.signoutRedirect()` call will fully sign the user out — they will see the login form on their next visit, not silent-auth back into the session.
+
+---
+
 ## Troubleshooting
 
 **`redirect_uri mismatch` error**

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -372,6 +372,7 @@ fun Application.module(
             corsService = s.corsService,
             corsPort = s.corsOriginCache,
             translationPort = s.translationPort,
+            ssoTtlSeconds = config.ssoSessionTtlSeconds,
         )
 
         portalRoutes(

--- a/src/main/kotlin/com/kauth/adapter/persistence/AuthorizationCodesTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/AuthorizationCodesTable.kt
@@ -21,6 +21,7 @@ object AuthorizationCodesTable : Table("authorization_codes") {
     val expiresAt = timestampWithTimeZone("expires_at")
     val usedAt = timestampWithTimeZone("used_at").nullable()
     val createdAt = timestampWithTimeZone("created_at")
+    val authTime = timestampWithTimeZone("auth_time").nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuthorizationCodeRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuthorizationCodeRepository.kt
@@ -32,6 +32,7 @@ class PostgresAuthorizationCodeRepository : AuthorizationCodeRepository {
                     it[expiresAt] = code.expiresAt.toOffsetDateTime()
                     it[usedAt] = code.usedAt?.toOffsetDateTime()
                     it[createdAt] = code.createdAt.toOffsetDateTime()
+                    it[authTime] = code.authTime?.toOffsetDateTime()
                 } get AuthorizationCodesTable.id
 
             code.copy(id = insertedId)
@@ -76,6 +77,7 @@ class PostgresAuthorizationCodeRepository : AuthorizationCodeRepository {
             expiresAt = this[AuthorizationCodesTable.expiresAt].toInstant(),
             usedAt = this[AuthorizationCodesTable.usedAt]?.toInstant(),
             createdAt = this[AuthorizationCodesTable.createdAt].toInstant(),
+            authTime = this[AuthorizationCodesTable.authTime]?.toInstant(),
         )
 
     private fun Instant.toOffsetDateTime(): OffsetDateTime = OffsetDateTime.ofInstant(this, ZoneOffset.UTC)

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -67,6 +67,7 @@ class JwtTokenAdapter(
         roles: List<Role>,
         customAccessClaims: Map<String, String>,
         customIdClaims: Map<String, String>,
+        authTime: java.time.Instant?,
     ): TokenResponse {
         val activeKey = getOrCreateAlgorithm(tenant.id.value)
         val issuer = issuerFor(tenant)
@@ -150,6 +151,7 @@ class JwtTokenAdapter(
                     .withClaim("name", user.fullName)
                     .withClaim("preferred_username", user.username)
                     .apply { if (nonce != null) withClaim("nonce", nonce) }
+                    .apply { if (authTime != null) withClaim("auth_time", authTime.epochSecond) }
                     .apply {
                         for ((claimName, value) in customIdClaims) {
                             withClaim(claimName, value)

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
@@ -2,6 +2,7 @@ package com.kauth.adapter.web.auth
 
 import com.kauth.adapter.web.ViewContext
 import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthError
@@ -17,6 +18,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.util.AttributeKey
+import java.time.Instant
 
 data class AuthTenantContext(
     val slug: String,
@@ -142,6 +144,84 @@ internal fun ApplicationCall.getAuthContext(encryptionService: EncryptionService
 internal fun ApplicationCall.clearAuthContextCookie(slug: String) {
     response.cookies.append(
         name = AUTH_CONTEXT_COOKIE,
+        value = "",
+        maxAge = 0L,
+        httpOnly = true,
+        path = "/t/$slug",
+    )
+}
+
+// -- SSO session cookie (OIDC silent auth) -------------------------------------
+
+private const val SSO_COOKIE = "KOTAUTH_SSO"
+private const val SSO_COOKIE_VERSION = "v1"
+
+/**
+ * Witness of a successful interactive authentication, scoped to `/t/{slug}`.
+ *
+ * Read by GET /authorize when honoring `prompt=none` to issue an authorization
+ * code without re-prompting the user (OIDC Core §3.1.2.1). The `authTime` value
+ * is the moment the user proved possession of their credentials — for MFA
+ * flows it is the MFA completion time (Keycloak convention), not the
+ * first-factor time. It surfaces as the `auth_time` claim in subsequent ID
+ * tokens, and is the value `max_age` is checked against.
+ */
+internal data class SsoCookieData(
+    val userId: Int,
+    val tenantId: Int,
+    val authTime: Instant,
+    val mfaCompleted: Boolean,
+    val expiresAt: Instant,
+)
+
+internal fun ApplicationCall.setSsoCookie(
+    data: SsoCookieData,
+    slug: String,
+    encryptionService: EncryptionService,
+    secure: Boolean = false,
+) {
+    val payload =
+        listOf(
+            SSO_COOKIE_VERSION,
+            data.userId.toString(),
+            data.tenantId.toString(),
+            data.authTime.epochSecond.toString(),
+            if (data.mfaCompleted) "1" else "0",
+            data.expiresAt.epochSecond.toString(),
+        ).joinToString("|")
+    val maxAge = (data.expiresAt.epochSecond - Instant.now().epochSecond).coerceAtLeast(0L)
+    response.cookies.append(
+        name = SSO_COOKIE,
+        value = encryptionService.signCookie(payload),
+        maxAge = maxAge,
+        httpOnly = true,
+        secure = secure,
+        path = "/t/$slug",
+    )
+}
+
+internal fun ApplicationCall.getSsoCookie(encryptionService: EncryptionService): SsoCookieData? {
+    val raw = request.cookies[SSO_COOKIE] ?: return null
+    val payload = encryptionService.verifyCookie(raw) ?: return null
+    val parts = payload.split("|")
+    if (parts.size != 6 || parts[0] != SSO_COOKIE_VERSION) return null
+    val userId = parts[1].toIntOrNull() ?: return null
+    val tenantId = parts[2].toIntOrNull() ?: return null
+    val authTime = parts[3].toLongOrNull()?.let(Instant::ofEpochSecond) ?: return null
+    val mfaCompleted =
+        when (parts[4]) {
+            "0" -> false
+            "1" -> true
+            else -> return null
+        }
+    val expiresAt = parts[5].toLongOrNull()?.let(Instant::ofEpochSecond) ?: return null
+    if (Instant.now().isAfter(expiresAt)) return null
+    return SsoCookieData(userId, tenantId, authTime, mfaCompleted, expiresAt)
+}
+
+internal fun ApplicationCall.clearSsoCookie(slug: String) {
+    response.cookies.append(
+        name = SSO_COOKIE,
         value = "",
         maxAge = 0L,
         httpOnly = true,
@@ -349,9 +429,15 @@ internal fun parseSocialPendingCookie(
 internal suspend fun ApplicationCall.completeAuthorizationCodeFlow(
     slug: String,
     userId: UserId,
+    tenantId: TenantId,
     oauthParams: AuthView.OAuthParams,
     ipAddress: String?,
+    authTime: Instant,
+    mfaCompleted: Boolean,
+    ssoTtlSeconds: Long,
+    secure: Boolean,
     oauthService: OAuthService,
+    encryptionService: EncryptionService,
     renderError: suspend (message: String) -> Unit,
 ) {
     val clientId =
@@ -360,6 +446,19 @@ internal suspend fun ApplicationCall.completeAuthorizationCodeFlow(
     val redirectUri =
         oauthParams.redirectUri
             ?: return respond(HttpStatusCode.BadRequest, "Missing redirect_uri")
+
+    setSsoCookie(
+        SsoCookieData(
+            userId = userId.value,
+            tenantId = tenantId.value,
+            authTime = authTime,
+            mfaCompleted = mfaCompleted,
+            expiresAt = Instant.now().plusSeconds(ssoTtlSeconds),
+        ),
+        slug = slug,
+        encryptionService = encryptionService,
+        secure = secure,
+    )
 
     when (
         val codeResult =

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
@@ -473,6 +473,7 @@ internal suspend fun ApplicationCall.completeAuthorizationCodeFlow(
                 nonce = oauthParams.nonce,
                 state = oauthParams.state,
                 ipAddress = ipAddress,
+                authTime = authTime,
             )
     ) {
         is OAuthResult.Success -> {

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
@@ -42,6 +42,7 @@ fun Route.authRoutes(
     corsService: CorsService? = null,
     corsPort: CorsPort? = null,
     translationPort: TranslationPort,
+    ssoTtlSeconds: Long = 86_400L,
 ) {
     route("/t/{slug}") {
         if (corsService != null) {
@@ -114,6 +115,8 @@ fun Route.authRoutes(
             rateLimiter = registerRateLimiter,
             encryptionService = encryptionService,
             oauthService = oauthService,
+            ssoTtlSeconds = ssoTtlSeconds,
+            secure = baseUrl.startsWith("https"),
         )
 
         mfaRoutes(
@@ -121,6 +124,8 @@ fun Route.authRoutes(
             mfaService = mfaService,
             encryptionService = encryptionService,
             mfaRateLimiter = mfaRateLimiter,
+            ssoTtlSeconds = ssoTtlSeconds,
+            secure = baseUrl.startsWith("https"),
         )
 
         socialLoginRoutes(
@@ -129,6 +134,7 @@ fun Route.authRoutes(
             identityProviderRepository = identityProviderRepository,
             encryptionService = encryptionService,
             baseUrl = baseUrl,
+            ssoTtlSeconds = ssoTtlSeconds,
         )
 
         oauthProtocolRoutes(
@@ -141,6 +147,7 @@ fun Route.authRoutes(
             encryptionService = encryptionService,
             loginRateLimiter = loginRateLimiter,
             baseUrl = baseUrl,
+            ssoTtlSeconds = ssoTtlSeconds,
         )
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutes.kt
@@ -38,6 +38,8 @@ internal fun Route.magicLinkRoutes(
     rateLimiter: RateLimiterPort,
     encryptionService: EncryptionService,
     oauthService: OAuthService,
+    ssoTtlSeconds: Long,
+    secure: Boolean,
 ) {
     get("/magic-link") {
         val ctx = call.attributes[AuthTenantAttr]
@@ -138,13 +140,21 @@ internal fun Route.magicLinkRoutes(
             }
             is SelfServiceResult.Success -> {
                 val user = result.value
+                // ctx.tenant is non-null past the magicLinkEnabled gate at the top of the route.
+                val tenant = ctx.tenant
                 val ipAddress = call.request.local.remoteAddress
                 call.completeAuthorizationCodeFlow(
                     slug = ctx.slug,
                     userId = user.id!!,
+                    tenantId = tenant.id,
                     oauthParams = oauthParams,
                     ipAddress = ipAddress,
+                    authTime = java.time.Instant.now(),
+                    mfaCompleted = false,
+                    ssoTtlSeconds = ssoTtlSeconds,
+                    secure = secure,
                     oauthService = oauthService,
+                    encryptionService = encryptionService,
                     renderError = { message ->
                         call.respondHtml(
                             HttpStatusCode.BadRequest,

--- a/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
@@ -20,6 +20,8 @@ internal fun Route.mfaRoutes(
     mfaService: MfaService?,
     encryptionService: EncryptionService,
     mfaRateLimiter: RateLimiterPort,
+    ssoTtlSeconds: Long,
+    secure: Boolean,
 ) {
     get("/mfa-challenge") {
         val ctx = call.attributes[AuthTenantAttr]
@@ -116,12 +118,22 @@ internal fun Route.mfaRoutes(
                 )
 
                 if (oauthParams.isOAuthFlow) {
+                    val tenant =
+                        ctx.tenant ?: return@post call.respond(HttpStatusCode.NotFound)
                     call.completeAuthorizationCodeFlow(
                         slug = slug,
                         userId = UserId(userId),
+                        tenantId = tenant.id,
                         oauthParams = oauthParams,
                         ipAddress = ipAddress,
+                        // Keycloak convention: auth_time tracks the moment MFA was completed,
+                        // not the original first-factor (password) check.
+                        authTime = java.time.Instant.now(),
+                        mfaCompleted = true,
+                        ssoTtlSeconds = ssoTtlSeconds,
+                        secure = secure,
                         oauthService = oauthService,
+                        encryptionService = encryptionService,
                         renderError = { message ->
                             call.respondHtml(
                                 HttpStatusCode.BadRequest,

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -736,6 +736,7 @@ internal fun Route.oauthProtocolRoutes(
 
     route("/protocol/openid-connect/logout") {
         get {
+            val slug = call.parameters["slug"] ?: "master"
             val bearerToken =
                 extractBearerToken(call)
                     ?: call.request.queryParameters["id_token_hint"]
@@ -745,6 +746,11 @@ internal fun Route.oauthProtocolRoutes(
                 oauthService.endSession(bearerToken, revokeAll, call.request.local.remoteAddress)
             }
 
+            // OIDC end_session must also kill the SSO witness — otherwise the
+            // very next /authorize would silent-auth the user back in via the
+            // KOTAUTH_SSO cookie they just nominally signed out of.
+            call.clearSsoCookie(slug)
+
             val postLogoutUri = call.request.queryParameters["post_logout_redirect_uri"]
             if (!postLogoutUri.isNullOrBlank()) {
                 // Only allow post-logout redirect to same origin to prevent open redirect
@@ -752,16 +758,15 @@ internal fun Route.oauthProtocolRoutes(
                 if (postLogoutUri.startsWith(origin) || postLogoutUri.startsWith("/")) {
                     call.respondRedirect(postLogoutUri)
                 } else {
-                    val slug = call.parameters["slug"] ?: "master"
                     call.respondRedirect("/t/$slug/authorize")
                 }
             } else {
-                val slug = call.parameters["slug"] ?: "master"
                 call.respondRedirect("/t/$slug/authorize")
             }
         }
 
         post {
+            val slug = call.parameters["slug"] ?: "master"
             val params = call.receiveParameters()
             val token = params["token"] ?: extractBearerToken(call)
 
@@ -770,6 +775,7 @@ internal fun Route.oauthProtocolRoutes(
                 oauthService.endSession(token, revokeAll, call.request.local.remoteAddress)
             }
 
+            call.clearSsoCookie(slug)
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -25,6 +25,19 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.serialization.json.*
 
+/**
+ * OIDC Core §3.1.2.1 `prompt` values we recognize at GET /authorize.
+ *
+ * - `none`: silent auth — never display UI. Phase 3 honors this against the
+ *   SSO witness cookie; Phase 2 always returns `login_required`.
+ * - `login`: force re-auth — always render the login form.
+ * - `consent`: force consent screen. We have no separate consent UI yet, so
+ *   it is treated like `login` for now (server simply re-authenticates).
+ * - `select_account`: account picker. Single-account-per-browser today, so
+ *   identical to `login` in behavior.
+ */
+private val OIDC_SUPPORTED_PROMPTS = setOf("none", "login", "consent", "select_account")
+
 internal fun Route.oauthProtocolRoutes(
     oauthService: OAuthService,
     identityProviderRepository: IdentityProviderRepository?,
@@ -98,6 +111,12 @@ internal fun Route.oauthProtocolRoutes(
                     },
                 )
                 put("code_challenge_methods_supported", buildJsonArray { add("S256") })
+                put(
+                    "prompt_values_supported",
+                    buildJsonArray {
+                        OIDC_SUPPORTED_PROMPTS.forEach { add(it) }
+                    },
+                )
             },
         )
     }
@@ -134,6 +153,35 @@ internal fun Route.oauthProtocolRoutes(
         val nonce = q["nonce"]
         val codeChallenge = q["code_challenge"]
         val codeChallengeMethod = q["code_challenge_method"]
+
+        val promptValues =
+            q["prompt"]
+                ?.trim()
+                ?.split(Regex("\\s+"))
+                ?.filter { it.isNotBlank() }
+                ?: emptyList()
+        val unknownPrompts = promptValues.filterNot { it in OIDC_SUPPORTED_PROMPTS }
+        if (unknownPrompts.isNotEmpty()) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf(
+                    "error" to "invalid_request",
+                    "error_description" to "Unsupported prompt value(s): ${unknownPrompts.joinToString(",")}",
+                ),
+            )
+            return@get
+        }
+        // OIDC Core §3.1.2.1: `none` MUST NOT appear with any other prompt value.
+        if ("none" in promptValues && promptValues.size > 1) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf(
+                    "error" to "invalid_request",
+                    "error_description" to "prompt=none cannot be combined with other prompt values",
+                ),
+            )
+            return@get
+        }
 
         // If no OAuth query params, check for an existing auth context cookie.
         // This handles returning from registration/password-reset during an active OAuth flow.
@@ -195,6 +243,40 @@ internal fun Route.oauthProtocolRoutes(
         val tenant =
             ctx.tenant
                 ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
+
+        // prompt=none: never show UI. Phase 3 will silent-auth via the SSO cookie;
+        // Phase 2 always returns login_required. We MUST validate the redirect_uri
+        // against the client's registered URIs first — otherwise an attacker can
+        // turn /authorize into an open redirect by supplying a hostile uri here.
+        if ("none" in promptValues) {
+            if (!oauthService.validateRedirectUri(slug, clientId, redirectUri)) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf(
+                        "error" to "invalid_request",
+                        "error_description" to "Invalid redirect_uri for client",
+                    ),
+                )
+                return@get
+            }
+            val errorRedirect =
+                buildString {
+                    append(redirectUri)
+                    append("?error=login_required")
+                    append("&error_description=").append(encodeParam("Silent authentication is unavailable"))
+                    if (!state.isNullOrBlank()) append("&state=").append(encodeParam(state))
+                }
+            call.respondRedirect(errorRedirect)
+            return@get
+        }
+
+        // prompt=login / consent / select_account: force interactive re-auth even
+        // if a valid SSO cookie is present. Wiping the cookie now keeps Phase 3's
+        // silent-auth path honest — no chance of an in-progress flow falling
+        // through to the cookie after the user explicitly asked to re-authenticate.
+        if (promptValues.any { it == "login" || it == "consent" || it == "select_account" }) {
+            call.clearSsoCookie(slug)
+        }
 
         val oauthParams =
             AuthView.OAuthParams(

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -35,6 +35,7 @@ internal fun Route.oauthProtocolRoutes(
     encryptionService: EncryptionService,
     loginRateLimiter: RateLimiterPort,
     baseUrl: String = "",
+    ssoTtlSeconds: Long,
 ) {
     get("/.well-known/openid-configuration") {
         val ctx = call.attributes[AuthTenantAttr]
@@ -290,10 +291,13 @@ internal fun Route.oauthProtocolRoutes(
             }
             is AuthResult.Success -> {
                 val user = result.value
+                if (tenant == null) {
+                    return@post call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
+                }
 
                 // Enforce MFA enrollment policy before issuing a challenge (skip for portal logins)
                 val isPortalLogin = oauthParams.clientId == PortalClientProvisioning.PORTAL_CLIENT_ID
-                if (mfaService != null && tenant != null && !isPortalLogin) {
+                if (mfaService != null && !isPortalLogin) {
                     val mfaPolicy = tenant.mfaPolicy
                     if (mfaPolicy != "optional") {
                         val userRoles =
@@ -341,9 +345,15 @@ internal fun Route.oauthProtocolRoutes(
                 call.completeAuthorizationCodeFlow(
                     slug = slug,
                     userId = user.id!!,
+                    tenantId = tenant.id,
                     oauthParams = oauthParams,
                     ipAddress = ipAddress,
+                    authTime = java.time.Instant.now(),
+                    mfaCompleted = false,
+                    ssoTtlSeconds = ssoTtlSeconds,
+                    secure = baseUrl.startsWith("https"),
                     oauthService = oauthService,
+                    encryptionService = encryptionService,
                     renderError = { message ->
                         call.respondHtml(
                             HttpStatusCode.BadRequest,
@@ -353,8 +363,8 @@ internal fun Route.oauthProtocolRoutes(
                                 error = message,
                                 oauthParams = oauthParams,
                                 enabledProviders = enabledProviders,
-                                registrationEnabled = tenant?.registrationEnabled ?: true,
-                                magicLinkEnabled = tenant?.securityConfig?.magicLinkEnabled == true,
+                                registrationEnabled = tenant.registrationEnabled,
+                                magicLinkEnabled = tenant.securityConfig.magicLinkEnabled,
                             ),
                         )
                     },

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -24,6 +24,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.serialization.json.*
+import java.time.Instant
 
 /**
  * OIDC Core §3.1.2.1 `prompt` values we recognize at GET /authorize.
@@ -37,6 +38,35 @@ import kotlinx.serialization.json.*
  *   identical to `login` in behavior.
  */
 private val OIDC_SUPPORTED_PROMPTS = setOf("none", "login", "consent", "select_account")
+
+/**
+ * Best-effort `sub` claim extraction from an OIDC ID token used as
+ * `id_token_hint`. The token was issued by us in a prior login and the RP is
+ * now hinting at the desired session — we read the sub but do NOT verify the
+ * signature here. Mismatch only makes us fall back to interactive auth, so the
+ * worst case from an attacker-supplied hint is "no silent auth", which is the
+ * safe default. Strict signature verification would harden the flow further;
+ * tracked as a follow-up to v1.8.1.
+ */
+private fun decodeIdTokenSub(token: String): String? =
+    try {
+        val parts = token.split(".")
+        if (parts.size != 3) {
+            null
+        } else {
+            val payload =
+                String(
+                    java.util.Base64
+                        .getUrlDecoder()
+                        .decode(parts[1]),
+                    Charsets.UTF_8,
+                )
+            val element = Json.parseToJsonElement(payload)
+            element.jsonObject["sub"]?.jsonPrimitive?.contentOrNull
+        }
+    } catch (_: Exception) {
+        null
+    }
 
 internal fun Route.oauthProtocolRoutes(
     oauthService: OAuthService,
@@ -108,6 +138,7 @@ internal fun Route.oauthProtocolRoutes(
                         add("email_verified")
                         add("name")
                         add("preferred_username")
+                        add("auth_time")
                     },
                 )
                 put("code_challenge_methods_supported", buildJsonArray { add("S256") })
@@ -244,38 +275,22 @@ internal fun Route.oauthProtocolRoutes(
             ctx.tenant
                 ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "tenant_not_found"))
 
-        // prompt=none: never show UI. Phase 3 will silent-auth via the SSO cookie;
-        // Phase 2 always returns login_required. We MUST validate the redirect_uri
-        // against the client's registered URIs first — otherwise an attacker can
-        // turn /authorize into an open redirect by supplying a hostile uri here.
-        if ("none" in promptValues) {
-            if (!oauthService.validateRedirectUri(slug, clientId, redirectUri)) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf(
-                        "error" to "invalid_request",
-                        "error_description" to "Invalid redirect_uri for client",
-                    ),
-                )
-                return@get
-            }
-            val errorRedirect =
-                buildString {
-                    append(redirectUri)
-                    append("?error=login_required")
-                    append("&error_description=").append(encodeParam("Silent authentication is unavailable"))
-                    if (!state.isNullOrBlank()) append("&state=").append(encodeParam(state))
-                }
-            call.respondRedirect(errorRedirect)
-            return@get
-        }
+        val isSilentOnly = "none" in promptValues
+        val forceReauth = promptValues.any { it == "login" || it == "consent" || it == "select_account" }
 
-        // prompt=login / consent / select_account: force interactive re-auth even
-        // if a valid SSO cookie is present. Wiping the cookie now keeps Phase 3's
-        // silent-auth path honest — no chance of an in-progress flow falling
-        // through to the cookie after the user explicitly asked to re-authenticate.
-        if (promptValues.any { it == "login" || it == "consent" || it == "select_account" }) {
-            call.clearSsoCookie(slug)
+        // Open-redirect guard for any flow that may issue a redirect-uri-based response
+        // (silent auth success, prompt=none failure). The validation must happen before
+        // we ever build a redirect string from `redirectUri` query data.
+        val redirectUriTrusted = oauthService.validateRedirectUri(slug, clientId, redirectUri)
+        if (isSilentOnly && !redirectUriTrusted) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                mapOf(
+                    "error" to "invalid_request",
+                    "error_description" to "Invalid redirect_uri for client",
+                ),
+            )
+            return@get
         }
 
         val oauthParams =
@@ -289,6 +304,82 @@ internal fun Route.oauthProtocolRoutes(
                 codeChallengeMethod = codeChallengeMethod,
                 nonce = nonce,
             )
+
+        // ---- Silent auth attempt -------------------------------------------
+        // Skip when the RP explicitly asked for a fresh login. Otherwise read
+        // the SSO witness cookie and, if it still matches all the RP's hints
+        // (max_age, id_token_hint, current MFA policy), issue an authorization
+        // code and bounce back to the redirect_uri without showing UI.
+        if (!forceReauth && redirectUriTrusted) {
+            val sso = call.getSsoCookie(encryptionService)
+            if (sso != null && sso.tenantId == tenant.id.value) {
+                val maxAge = q["max_age"]?.toLongOrNull()
+                // max_age=0 is the OIDC sentinel for "force a fresh credential proof now",
+                // so any prior cookie — however recent — fails the check.
+                val withinMaxAge =
+                    when {
+                        maxAge == null -> true
+                        maxAge <= 0L -> false
+                        else -> (Instant.now().epochSecond - sso.authTime.epochSecond) <= maxAge
+                    }
+                val hintSub = q["id_token_hint"]?.let { decodeIdTokenSub(it) }
+                val hintMatches = hintSub == null || hintSub == sso.userId.toString()
+                // If the tenant currently requires MFA but the cookie was minted
+                // before that requirement was satisfied, silent auth is not safe
+                // — fall back to interactive so the policy can re-trigger.
+                val mfaPolicy = tenant.mfaPolicy
+                val mfaSatisfied = sso.mfaCompleted || mfaPolicy == "optional"
+
+                if (withinMaxAge && hintMatches && mfaSatisfied) {
+                    val codeResult =
+                        oauthService.issueAuthorizationCode(
+                            tenantSlug = slug,
+                            userId =
+                                com.kauth.domain.model
+                                    .UserId(sso.userId),
+                            clientId = clientId,
+                            redirectUri = redirectUri,
+                            scopes = scope,
+                            codeChallenge = codeChallenge,
+                            codeChallengeMethod = codeChallengeMethod,
+                            nonce = nonce,
+                            state = state,
+                            ipAddress = call.request.local.remoteAddress,
+                            authTime = sso.authTime,
+                        )
+                    if (codeResult is OAuthResult.Success) {
+                        val redirect =
+                            buildString {
+                                append(redirectUri)
+                                append("?code=").append(codeResult.value.code)
+                                if (!state.isNullOrBlank()) append("&state=").append(encodeParam(state))
+                            }
+                        call.respondRedirect(redirect)
+                        return@get
+                    }
+                    // OAuth failure (e.g., PKCE required + missing challenge): fall through
+                    // to the interactive flow; never leak a silent-auth failure to the client.
+                }
+            }
+        }
+
+        // Silent auth did not happen. If the caller said `prompt=none`, surface
+        // login_required per OIDC §3.1.2.6.
+        if (isSilentOnly) {
+            val errorRedirect =
+                buildString {
+                    append(redirectUri)
+                    append("?error=login_required")
+                    append("&error_description=").append(encodeParam("Silent authentication failed"))
+                    if (!state.isNullOrBlank()) append("&state=").append(encodeParam(state))
+                }
+            call.respondRedirect(errorRedirect)
+            return@get
+        }
+
+        if (forceReauth) {
+            call.clearSsoCookie(slug)
+        }
 
         call.setAuthContextCookie(oauthParams, slug, encryptionService, baseUrl.startsWith("https"))
 

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
@@ -2,7 +2,6 @@ package com.kauth.adapter.web.auth
 
 import com.kauth.domain.model.SocialProvider
 import com.kauth.domain.port.IdentityProviderRepository
-import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginResult
 import com.kauth.domain.service.SocialLoginService
@@ -22,6 +21,7 @@ internal fun Route.socialLoginRoutes(
     identityProviderRepository: IdentityProviderRepository?,
     encryptionService: EncryptionService,
     baseUrl: String,
+    ssoTtlSeconds: Long,
 ) {
     get("/auth/social/{provider}/redirect") {
         val ctx = call.attributes[AuthTenantAttr]
@@ -200,46 +200,32 @@ internal fun Route.socialLoginRoutes(
             is SocialLoginResult.Success -> {
                 val loginSuccess = result.value
                 if (restoredParams.isOAuthFlow) {
-                    val clientId = restoredParams.clientId ?: return@get call.respond(HttpStatusCode.BadRequest)
-                    val redirectUri =
-                        restoredParams.redirectUri ?: return@get call.respond(HttpStatusCode.BadRequest)
-                    when (
-                        val codeResult =
-                            oauthService.issueAuthorizationCode(
-                                tenantSlug = slug,
-                                userId = loginSuccess.user.id!!,
-                                clientId = clientId,
-                                redirectUri = redirectUri,
-                                scopes = restoredParams.scope ?: "openid",
-                                codeChallenge = restoredParams.codeChallenge,
-                                codeChallengeMethod = restoredParams.codeChallengeMethod,
-                                nonce = restoredParams.nonce,
-                                state = restoredParams.state,
-                                ipAddress = ipAddress,
-                            )
-                    ) {
-                        is OAuthResult.Success -> {
-                            val authCode = codeResult.value.code
-                            val stateParam = restoredParams.state
-                            val redirect =
-                                buildString {
-                                    append(redirectUri)
-                                    append("?code=").append(authCode)
-                                    if (!stateParam.isNullOrBlank()) append("&state=").append(stateParam)
-                                }
-                            call.respondRedirect(redirect)
-                        }
-                        is OAuthResult.Failure ->
+                    val activeTenant =
+                        tenant ?: return@get call.respond(HttpStatusCode.NotFound)
+                    call.completeAuthorizationCodeFlow(
+                        slug = slug,
+                        userId = loginSuccess.user.id!!,
+                        tenantId = activeTenant.id,
+                        oauthParams = restoredParams,
+                        ipAddress = ipAddress,
+                        authTime = java.time.Instant.now(),
+                        mfaCompleted = false,
+                        ssoTtlSeconds = ssoTtlSeconds,
+                        secure = baseUrl.startsWith("https"),
+                        oauthService = oauthService,
+                        encryptionService = encryptionService,
+                        renderError = { message ->
                             call.respondHtml(
                                 HttpStatusCode.BadRequest,
                                 AuthView.loginPage(
                                     tenantSlug = slug,
                                     ctx = ctx.viewContext,
-                                    error = codeResult.error.toDescription(),
+                                    error = message,
                                     enabledProviders = enabledProviders,
                                 ),
                             )
-                    }
+                        },
+                    )
                 } else {
                     call.respond(loginSuccess.tokens)
                 }
@@ -367,36 +353,19 @@ internal fun Route.socialLoginRoutes(
                 val restoredParams = parseQueryStringToOAuthParams(pending.oauthParamsRaw)
 
                 if (restoredParams.isOAuthFlow) {
-                    val clientId = restoredParams.clientId ?: return@post call.respond(HttpStatusCode.BadRequest)
-                    val redirectUri =
-                        restoredParams.redirectUri ?: return@post call.respond(HttpStatusCode.BadRequest)
-                    when (
-                        val codeResult =
-                            oauthService.issueAuthorizationCode(
-                                tenantSlug = slug,
-                                userId = loginSuccess.user.id!!,
-                                clientId = clientId,
-                                redirectUri = redirectUri,
-                                scopes = restoredParams.scope ?: "openid",
-                                codeChallenge = restoredParams.codeChallenge,
-                                codeChallengeMethod = restoredParams.codeChallengeMethod,
-                                nonce = restoredParams.nonce,
-                                state = restoredParams.state,
-                                ipAddress = ipAddress,
-                            )
-                    ) {
-                        is OAuthResult.Success -> {
-                            val authCode = codeResult.value.code
-                            val stateParam = restoredParams.state
-                            val redirect =
-                                buildString {
-                                    append(redirectUri)
-                                    append("?code=").append(authCode)
-                                    if (!stateParam.isNullOrBlank()) append("&state=").append(stateParam)
-                                }
-                            call.respondRedirect(redirect)
-                        }
-                        is OAuthResult.Failure ->
+                    call.completeAuthorizationCodeFlow(
+                        slug = slug,
+                        userId = loginSuccess.user.id!!,
+                        tenantId = tenant.id,
+                        oauthParams = restoredParams,
+                        ipAddress = ipAddress,
+                        authTime = java.time.Instant.now(),
+                        mfaCompleted = false,
+                        ssoTtlSeconds = ssoTtlSeconds,
+                        secure = baseUrl.startsWith("https"),
+                        oauthService = oauthService,
+                        encryptionService = encryptionService,
+                        renderError = { message ->
                             call.respondHtml(
                                 HttpStatusCode.BadRequest,
                                 AuthView.socialRegistrationPage(
@@ -405,10 +374,11 @@ internal fun Route.socialLoginRoutes(
                                     workspaceName = workspaceName,
                                     providerName = pending.provider.displayName,
                                     email = pending.email,
-                                    error = codeResult.error.toDescription(),
+                                    error = message,
                                 ),
                             )
-                    }
+                        },
+                    )
                 } else {
                     call.respondRedirect("/t/$slug/account/login")
                 }

--- a/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
@@ -1,5 +1,6 @@
 package com.kauth.adapter.web.portal
 
+import com.kauth.adapter.web.auth.clearSsoCookie
 import com.kauth.adapter.web.decodeJwtPayload
 import com.kauth.adapter.web.generatePkceChallenge
 import com.kauth.adapter.web.generatePkceVerifier
@@ -105,6 +106,13 @@ fun Route.portalRoutes(
                 path = "/t/$slug/account",
             )
 
+            // Try silent SSO first — if a KOTAUTH_SSO cookie exists from prior
+            // authentication (typically the SaaS app), this redirects with a
+            // code and the user lands on /account/profile without seeing the
+            // login form. /callback handles the prompt=none failure path by
+            // bouncing back here with ?prompt_failed=true to break the loop.
+            val promptFailed = call.request.queryParameters["prompt_failed"] == "true"
+
             val redirectUri = "$baseUrl/t/$slug/account/callback"
             val authEndpoint = "/t/$slug/authorize"
             val authUrl =
@@ -117,6 +125,7 @@ fun Route.portalRoutes(
                     append("&code_challenge=").append(challenge)
                     append("&code_challenge_method=S256")
                     append("&state=").append(state)
+                    if (!promptFailed) append("&prompt=none")
                 }
             call.respondRedirect(authUrl)
         }
@@ -129,6 +138,13 @@ fun Route.portalRoutes(
             val slug = call.parameters["slug"] ?: return@get call.respond(HttpStatusCode.BadRequest)
             val code = call.request.queryParameters["code"]
             val error = call.request.queryParameters["error"]
+
+            // Silent SSO miss — the KOTAUTH_SSO cookie was absent or rejected.
+            // Loop back to /login with the marker that suppresses prompt=none on
+            // the next attempt so the user actually sees the form.
+            if (error == "login_required") {
+                return@get call.respondRedirect("/t/$slug/account/login?prompt_failed=true")
+            }
 
             if (oauthService == null || code.isNullOrBlank()) {
                 val desc = error ?: "Authentication failed. Please try again."
@@ -256,6 +272,10 @@ fun Route.portalRoutes(
         post("/logout") {
             val slug = call.parameters["slug"] ?: return@post call.respond(HttpStatusCode.BadRequest)
             call.sessions.clear<PortalSession>()
+            // Wipe the SSO witness too — otherwise the redirect to /account/login
+            // would silent-auth the user straight back into the session they
+            // just signed out of.
+            call.clearSsoCookie(slug)
             call.respondRedirect("/t/$slug/account/login")
         }
 

--- a/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
@@ -49,6 +49,8 @@ data class EnvironmentConfig(
     val redisTimeoutMs: Long,
     val redisStartupProbeTimeoutMs: Long,
     val redisCommandTimeoutMs: Long,
+    val ssoSessionTtlSeconds: Long,
+    val ssoSessionMaxTtlSeconds: Long,
 ) {
     val isHttps: Boolean get() = baseUrl.startsWith("https://")
     val redisEnabled: Boolean get() = redisUrl != null
@@ -66,6 +68,10 @@ data class EnvironmentConfig(
 
             val adminBypass = System.getenv("KAUTH_ADMIN_BYPASS")?.lowercase() == "true"
             validateAdminBypass(adminBypass)
+
+            val ssoTtl = System.getenv("KAUTH_SSO_SESSION_TTL_SECONDS")?.toLongOrNull() ?: 86_400L
+            val ssoMaxTtl = System.getenv("KAUTH_SSO_SESSION_MAX_TTL_SECONDS")?.toLongOrNull() ?: 2_592_000L
+            validateSsoTtls(ssoTtl, ssoMaxTtl)
 
             return EnvironmentConfig(
                 baseUrl = baseUrl,
@@ -95,7 +101,30 @@ data class EnvironmentConfig(
                 redisStartupProbeTimeoutMs =
                     System.getenv("KAUTH_REDIS_STARTUP_PROBE_TIMEOUT_MS")?.toLongOrNull() ?: 2000L,
                 redisCommandTimeoutMs = System.getenv("KAUTH_REDIS_COMMAND_TIMEOUT_MS")?.toLongOrNull() ?: 100L,
+                ssoSessionTtlSeconds = ssoTtl,
+                ssoSessionMaxTtlSeconds = ssoMaxTtl,
             )
+        }
+
+        private fun validateSsoTtls(
+            ttl: Long,
+            maxTtl: Long,
+        ) {
+            if (ttl < 60 || maxTtl < 60 || ttl > maxTtl) {
+                System.err.println(
+                    """
+                    ┌──────────────────────────────────────────────────────────────┐
+                    │  FATAL: invalid SSO session TTL configuration.               │
+                    │                                                              │
+                    │  KAUTH_SSO_SESSION_TTL_SECONDS must be ≥ 60 and ≤            │
+                    │  KAUTH_SSO_SESSION_MAX_TTL_SECONDS.                          │
+                    │                                                              │
+                    │  Current: ttl=$ttl, maxTtl=$maxTtl
+                    └──────────────────────────────────────────────────────────────┘
+                    """.trimIndent(),
+                )
+                exitProcess(1)
+            }
         }
 
         private fun requireBaseUrl(): String {

--- a/src/main/kotlin/com/kauth/domain/model/AuthorizationCode.kt
+++ b/src/main/kotlin/com/kauth/domain/model/AuthorizationCode.kt
@@ -32,6 +32,13 @@ data class AuthorizationCode(
     val expiresAt: Instant,
     val usedAt: Instant? = null,
     val createdAt: Instant = Instant.now(),
+    /**
+     * Moment of the user's most recent interactive credential proof. Surfaces
+     * as the OIDC `auth_time` claim on the ID token (Core §2 / §3.1.3.7).
+     * Null is allowed for backwards compatibility with codes issued before the
+     * field existed; new issuance paths always populate it.
+     */
+    val authTime: Instant? = null,
 ) {
     val isExpired: Boolean get() = Instant.now().isAfter(expiresAt)
     val isUsed: Boolean get() = usedAt != null

--- a/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/TokenPort.kt
@@ -7,6 +7,7 @@ import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TokenResponse
 import com.kauth.domain.model.User
+import java.time.Instant
 
 /**
  * Port (outbound) — defines what the domain needs from a token provider.
@@ -40,6 +41,13 @@ interface TokenPort {
         roles: List<Role> = emptyList(),
         customAccessClaims: Map<String, String> = emptyMap(),
         customIdClaims: Map<String, String> = emptyMap(),
+        /**
+         * Moment of the user's most recent interactive credential proof.
+         * Surfaces as the OIDC `auth_time` claim on the ID token (Core §2 / §3.1.3.7).
+         * Null is allowed for token-issuance paths that do not have it (refresh
+         * token, legacy callers); silent auth and fresh logins always populate it.
+         */
+        authTime: Instant? = null,
     ): TokenResponse
 
     /**

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -85,6 +85,26 @@ class OAuthService(
     // -------------------------------------------------------------------------
 
     /**
+     * Verifies a (clientId, redirectUri) pair without issuing a code.
+     *
+     * Open-redirect protection for GET /authorize when handling `prompt=none`:
+     * before bouncing the user back to `redirect_uri?error=login_required`,
+     * the route must confirm the URI actually belongs to a registered, enabled
+     * client. Returns false when the tenant, client, or redirect_uri does not
+     * match — the route should refuse the redirect in that case.
+     */
+    fun validateRedirectUri(
+        tenantSlug: String,
+        clientId: String,
+        redirectUri: String,
+    ): Boolean {
+        val tenant = tenantRepository.findBySlug(tenantSlug) ?: return false
+        val client = applicationRepository.findByClientId(tenant.id, clientId) ?: return false
+        if (!client.enabled) return false
+        return client.redirectUris.contains(redirectUri)
+    }
+
+    /**
      * Validates an authorization request and issues a short-lived code.
      * Called after the user has authenticated successfully.
      *

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -130,6 +130,7 @@ class OAuthService(
         nonce: String?,
         state: String?,
         ipAddress: String? = null,
+        authTime: Instant = Instant.now(),
     ): OAuthResult<AuthorizationCode> {
         val tenant =
             tenantRepository.findBySlug(tenantSlug)
@@ -171,6 +172,7 @@ class OAuthService(
                 nonce = nonce,
                 state = state,
                 expiresAt = Instant.now().plusSeconds(CODE_EXPIRY_SECONDS),
+                authTime = authTime,
             )
 
         val saved = authCodeRepository.save(code)
@@ -290,6 +292,7 @@ class OAuthService(
                 roles = effectiveRoles,
                 customAccessClaims = customAccessClaims,
                 customIdClaims = customIdClaims,
+                authTime = authCode.authTime,
             )
 
         // Persist session

--- a/src/main/resources/db/migration/V38__authorization_code_auth_time.sql
+++ b/src/main/resources/db/migration/V38__authorization_code_auth_time.sql
@@ -1,0 +1,6 @@
+-- v1.8.1 OIDC SSO: record the moment the user proved their credentials so the
+-- ID token issued from this code can carry the OIDC `auth_time` claim. NULL is
+-- allowed for codes issued before this column existed; new issuance always
+-- populates it.
+ALTER TABLE authorization_codes
+    ADD COLUMN auth_time TIMESTAMP WITH TIME ZONE;

--- a/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
@@ -1,0 +1,266 @@
+package com.kauth.adapter.web.auth
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.MfaService
+import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.EnglishOnlyTranslation
+import com.kauth.infrastructure.InMemoryRateLimiter
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Phase 2 of v1.8.1 OIDC SSO: GET /authorize must honor the OIDC `prompt`
+ * parameter (Core §3.1.2.1). Phase 3 will read the SSO cookie for silent
+ * auth — for now, `prompt=none` always returns `login_required`, and
+ * `prompt=login` / `prompt=select_account` clear the SSO cookie before
+ * re-rendering the login page.
+ */
+class PromptParamTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val authCodeRepo = FakeAuthorizationCodeRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val tokenPort = FakeTokenPort()
+    private val limiter = InMemoryRateLimiter(maxRequests = 1000, windowSeconds = 60)
+    private val mfaService = mockk<MfaService>(relaxed = true)
+    private val selfService = mockk<UserSelfServiceService>(relaxed = true)
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-minimum-len")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(1),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+            securityConfig = SecurityConfig(magicLinkEnabled = true),
+        )
+
+    private val alice =
+        User(
+            id = UserId(10),
+            tenantId = TenantId(1),
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("doesnt-matter"),
+            enabled = true,
+        )
+
+    private val spaApp =
+        Application(
+            id = ApplicationId(1),
+            tenantId = TenantId(1),
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    @BeforeTest
+    fun reset() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        authCodeRepo.clear()
+        sessionRepo.clear()
+        auditLog.clear()
+        tokenPort.reset()
+        tenantRepo.add(tenant)
+        userRepo.add(alice)
+        appRepo.add(spaApp)
+    }
+
+    private fun authService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessionRepo,
+        )
+
+    private fun oauthService() =
+        OAuthService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            sessionRepository = sessionRepo,
+            authCodeRepository = authCodeRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+        )
+
+    private fun appBlock(): io.ktor.server.application.Application.() -> Unit =
+        {
+            install(ContentNegotiation) { json() }
+            routing {
+                authRoutes(
+                    authService = authService(),
+                    oauthService = oauthService(),
+                    tenantRepository = tenantRepo,
+                    loginRateLimiter = limiter,
+                    registerRateLimiter = limiter,
+                    tokenRateLimiter = limiter,
+                    selfServiceService = selfService,
+                    mfaService = mfaService,
+                    encryptionService = encryptionService,
+                    translationPort = EnglishOnlyTranslation(),
+                )
+            }
+        }
+
+    private val authorizeUrl =
+        "/t/acme/authorize" +
+            "?response_type=code" +
+            "&client_id=spa-app" +
+            "&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback" +
+            "&scope=openid"
+
+    @Test
+    fun `prompt=none with valid client redirects to redirect_uri with login_required`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&state=xyz&prompt=none")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"]
+            assertNotNull(location)
+            assertTrue(
+                location.startsWith("https://app.example.com/callback?"),
+                "Must redirect to the registered redirect_uri, was: $location",
+            )
+            assertTrue(location.contains("error=login_required"), "Must include error=login_required")
+            assertTrue(location.contains("state=xyz"), "Must echo the state param back")
+        }
+
+    @Test
+    fun `prompt=none with hostile redirect_uri rejects with 400 instead of redirecting`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            // Attacker-supplied redirect_uri not in client's registered list
+            val hostile =
+                "/t/acme/authorize" +
+                    "?response_type=code" +
+                    "&client_id=spa-app" +
+                    "&redirect_uri=https%3A%2F%2Fattacker.example.com%2Fphish" +
+                    "&prompt=none"
+            val response = noFollow.get(hostile)
+
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                response.status,
+                "Open-redirect must be refused — never bounce a login_required to an unregistered uri",
+            )
+            assertEquals(null, response.headers["Location"])
+        }
+
+    @Test
+    fun `prompt=login renders login page and clears any existing SSO cookie`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&prompt=login")
+
+            assertEquals(HttpStatusCode.OK, response.status, "prompt=login renders the login form")
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            // Clearing a cookie sets it to empty with Max-Age=0
+            val ssoClear =
+                setCookie.firstOrNull { it.startsWith("KOTAUTH_SSO=") }
+                    ?: error("KOTAUTH_SSO clear directive must be present, was: $setCookie")
+            assertTrue(
+                ssoClear.contains("Max-Age=0", ignoreCase = true) || ssoClear.startsWith("KOTAUTH_SSO=;"),
+                "KOTAUTH_SSO clear must zero Max-Age, was: $ssoClear",
+            )
+        }
+
+    @Test
+    fun `prompt=select_account also clears the SSO cookie`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&prompt=select_account")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            assertTrue(
+                setCookie.any { it.startsWith("KOTAUTH_SSO=") && it.contains("Max-Age=0", ignoreCase = true) },
+                "select_account must also wipe the SSO witness cookie, was: $setCookie",
+            )
+        }
+
+    @Test
+    fun `unknown prompt value is rejected with invalid_request`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&prompt=please_log_in")
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `prompt=none cannot be combined with other prompt values`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&prompt=none%20login")
+
+            assertEquals(HttpStatusCode.BadRequest, response.status, "OIDC §3.1.2.1: none is exclusive")
+        }
+
+    @Test
+    fun `discovery doc advertises prompt_values_supported`() =
+        testApplication {
+            application(appBlock())
+            val response = client.get("/t/acme/.well-known/openid-configuration")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(
+                body.contains("\"prompt_values_supported\""),
+                "discovery doc must advertise prompt_values_supported",
+            )
+            assertTrue(body.contains("\"none\""), "Must include 'none' in prompt_values_supported")
+            assertTrue(body.contains("\"login\""), "Must include 'login' in prompt_values_supported")
+        }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
@@ -1,0 +1,435 @@
+package com.kauth.adapter.web.auth
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.MfaService
+import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.EnglishOnlyTranslation
+import com.kauth.infrastructure.InMemoryRateLimiter
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import java.time.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Phase 3 of v1.8.1 OIDC SSO: GET /authorize with a valid `KOTAUTH_SSO`
+ * cookie issues an authorization code and bounces straight back to the RP
+ * — no UI shown. Honors `prompt=none`, `max_age`, `id_token_hint` per
+ * OIDC Core §3.1.2.
+ */
+class SilentAuthTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val authCodeRepo = FakeAuthorizationCodeRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val tokenPort = FakeTokenPort()
+    private val limiter = InMemoryRateLimiter(maxRequests = 1000, windowSeconds = 60)
+    private val mfaService = mockk<MfaService>(relaxed = true)
+    private val selfService = mockk<UserSelfServiceService>(relaxed = true)
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-minimum-len")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(7),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+            securityConfig = SecurityConfig(magicLinkEnabled = true, mfaPolicy = "optional"),
+        )
+
+    private val alice =
+        User(
+            id = UserId(42),
+            tenantId = TenantId(7),
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("doesnt-matter"),
+            enabled = true,
+            emailVerified = true,
+        )
+
+    private val spaApp =
+        Application(
+            id = ApplicationId(1),
+            tenantId = TenantId(7),
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    @BeforeTest
+    fun reset() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        authCodeRepo.clear()
+        sessionRepo.clear()
+        auditLog.clear()
+        tokenPort.reset()
+        tenantRepo.add(tenant)
+        userRepo.add(alice)
+        appRepo.add(spaApp)
+    }
+
+    private fun authService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessionRepo,
+        )
+
+    private fun oauthService() =
+        OAuthService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            sessionRepository = sessionRepo,
+            authCodeRepository = authCodeRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+        )
+
+    private fun appBlock(): io.ktor.server.application.Application.() -> Unit =
+        {
+            install(ContentNegotiation) { json() }
+            routing {
+                authRoutes(
+                    authService = authService(),
+                    oauthService = oauthService(),
+                    tenantRepository = tenantRepo,
+                    loginRateLimiter = limiter,
+                    registerRateLimiter = limiter,
+                    tokenRateLimiter = limiter,
+                    selfServiceService = selfService,
+                    mfaService = mfaService,
+                    encryptionService = encryptionService,
+                    translationPort = EnglishOnlyTranslation(),
+                )
+            }
+        }
+
+    /**
+     * Pre-mints a signed SSO cookie that mirrors what `setSsoCookie` would
+     * produce after a successful interactive login.
+     */
+    private fun ssoCookie(
+        userId: Int = alice.id!!.value,
+        tenantId: Int = tenant.id.value,
+        authTime: Instant = Instant.now(),
+        mfaCompleted: Boolean = false,
+        ttlSeconds: Long = 86_400,
+    ): String {
+        val expires = Instant.now().plusSeconds(ttlSeconds)
+        val payload =
+            listOf(
+                "v1",
+                userId.toString(),
+                tenantId.toString(),
+                authTime.epochSecond.toString(),
+                if (mfaCompleted) "1" else "0",
+                expires.epochSecond.toString(),
+            ).joinToString("|")
+        return encryptionService.signCookie(payload)
+    }
+
+    private val authorizeUrl =
+        "/t/acme/authorize" +
+            "?response_type=code" +
+            "&client_id=spa-app" +
+            "&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback" +
+            "&scope=openid" +
+            "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM" +
+            "&code_challenge_method=S256"
+
+    @Test
+    fun `valid SSO cookie issues code without rendering UI`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&state=xyz") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status, "Silent auth must redirect, not render")
+            val location = response.headers["Location"]
+            assertNotNull(location)
+            assertTrue(
+                location.startsWith("https://app.example.com/callback?code="),
+                "Must redirect to client callback with code, was: $location",
+            )
+            assertTrue(location.contains("state=xyz"), "State must echo back")
+        }
+
+    @Test
+    fun `prompt=none with valid SSO cookie returns code instead of login_required`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&state=xyz") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"]!!
+            assertTrue(
+                location.contains("code=") && !location.contains("error="),
+                "prompt=none with cookie must succeed, was: $location",
+            )
+        }
+
+    @Test
+    fun `prompt=none without SSO cookie returns login_required`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("$authorizeUrl&prompt=none&state=xyz")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"]!!
+            assertTrue(location.contains("error=login_required"))
+        }
+
+    @Test
+    fun `prompt=login skips silent auth even with valid cookie`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&prompt=login") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status, "prompt=login must render the login form, not silent-auth")
+        }
+
+    @Test
+    fun `max_age=0 forces re-auth even with fresh SSO cookie`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            // max_age=0 means "the user must re-prove credentials right now"
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&max_age=0") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie(authTime = Instant.now())}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]!!.contains("error=login_required"))
+        }
+
+    @Test
+    fun `max_age satisfied when authTime is within the window`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&max_age=600") {
+                    header(
+                        "Cookie",
+                        "KOTAUTH_SSO=${ssoCookie(authTime = Instant.now().minusSeconds(60))}",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"]!!
+            assertTrue(location.contains("code="), "60s ≤ 600s max_age, must succeed: $location")
+        }
+
+    @Test
+    fun `max_age violated when authTime is older than the window`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&max_age=300") {
+                    header(
+                        "Cookie",
+                        "KOTAUTH_SSO=${ssoCookie(authTime = Instant.now().minusSeconds(900))}",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]!!.contains("error=login_required"))
+        }
+
+    @Test
+    fun `id_token_hint with matching sub allows silent auth`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            // Manufacture a token whose payload's "sub" matches the cookie userId.
+            // Signature is not verified (best-effort hint).
+            val payload =
+                java.util.Base64
+                    .getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString("""{"sub":"42","iss":"https://idp.example.com"}""".toByteArray())
+            val fakeIdToken = "eyJhbGciOiJSUzI1NiJ9.$payload.SIGNATURE_NOT_CHECKED"
+
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&id_token_hint=$fakeIdToken") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]!!.contains("code="))
+        }
+
+    @Test
+    fun `id_token_hint with mismatched sub blocks silent auth`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            // Hint claims sub=999 but cookie says userId=42 → not the same session.
+            val payload =
+                java.util.Base64
+                    .getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString("""{"sub":"999","iss":"https://idp.example.com"}""".toByteArray())
+            val fakeIdToken = "eyJhbGciOiJSUzI1NiJ9.$payload.SIGNATURE_NOT_CHECKED"
+
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none&id_token_hint=$fakeIdToken") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(
+                response.headers["Location"]!!.contains("error=login_required"),
+                "id_token_hint sub mismatch must reject silent auth",
+            )
+        }
+
+    @Test
+    fun `tenant requires MFA but cookie says mfaCompleted=false blocks silent auth`() =
+        testApplication {
+            tenantRepo.clear()
+            tenantRepo.add(tenant.copy(securityConfig = tenant.securityConfig.copy(mfaPolicy = "required")))
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie(mfaCompleted = false)}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(
+                response.headers["Location"]!!.contains("error=login_required"),
+                "Tenant policy change to required must invalidate non-MFA cookies for silent auth",
+            )
+        }
+
+    @Test
+    fun `cross-tenant cookie cannot silent-auth`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            // Cookie says tenantId=99 but the request is for tenant 7 (acme)
+            val response =
+                noFollow.get("$authorizeUrl&prompt=none") {
+                    header("Cookie", "KOTAUTH_SSO=${ssoCookie(tenantId = 99)}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertTrue(response.headers["Location"]!!.contains("error=login_required"))
+        }
+
+    @Test
+    fun `silent auth records cookie's authTime onto the issued AuthorizationCode`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val pinnedAuthTime = Instant.parse("2026-04-29T10:00:00Z")
+
+            noFollow.get(authorizeUrl) {
+                header("Cookie", "KOTAUTH_SSO=${ssoCookie(authTime = pinnedAuthTime)}")
+            }
+
+            val codes = authCodeRepo.all()
+            assertEquals(1, codes.size, "Silent auth should have minted exactly one code")
+            assertEquals(
+                pinnedAuthTime.epochSecond,
+                codes.single().authTime?.epochSecond,
+                "Issued code must carry the SSO cookie's authTime, not Instant.now()",
+            )
+        }
+
+    @Test
+    fun `auth_time from cookie surfaces on the issued ID token via TokenPort`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val pinnedAuthTime = Instant.parse("2026-04-29T11:00:00Z")
+
+            // Silent auth → issues a code carrying authTime
+            noFollow.get(authorizeUrl) {
+                header("Cookie", "KOTAUTH_SSO=${ssoCookie(authTime = pinnedAuthTime)}")
+            }
+
+            val code = authCodeRepo.all().single().code
+
+            // Exchange the code for tokens — TokenPort must receive the authTime
+            client.submitForm(
+                url = "/t/acme/protocol/openid-connect/token",
+                formParameters =
+                    Parameters.build {
+                        append("grant_type", "authorization_code")
+                        append("code", code)
+                        append("redirect_uri", "https://app.example.com/callback")
+                        append("client_id", "spa-app")
+                        append("code_verifier", "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+                    },
+            )
+
+            assertEquals(
+                pinnedAuthTime.epochSecond,
+                tokenPort.lastAuthTime?.epochSecond,
+                "TokenPort.issueUserTokens must receive the auth code's authTime so the ID token can carry auth_time",
+            )
+        }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
@@ -1,0 +1,397 @@
+package com.kauth.adapter.web.auth
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.MfaService
+import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordPolicyPort
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.EnglishOnlyTranslation
+import com.kauth.infrastructure.InMemoryRateLimiter
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Phase 1 of v1.8.1 OIDC SSO: every successful interactive auth must drop a
+ * signed `KOTAUTH_SSO` witness cookie scoped to `/t/{slug}`. Phase 3 will read
+ * it; Phase 1 only writes it. These tests pin down the contract:
+ *   - cookie is set on password login, magic-link consume, MFA challenge success
+ *   - payload carries userId, tenantId, mfaCompleted, expiresAt
+ *   - mfaCompleted reflects how the user authenticated (password=false,
+ *     MFA=true, magic-link=false)
+ */
+class SsoCookieTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val authCodeRepo = FakeAuthorizationCodeRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val tokenPort = FakeTokenPort()
+    private val emails = FakeEmailPort()
+    private val evTokens = FakeEmailVerificationTokenRepository()
+    private val prTokens = FakePasswordResetTokenRepository()
+    private val passwordPolicy = FakePasswordPolicyPort()
+
+    private val limiter = InMemoryRateLimiter(maxRequests = 1000, windowSeconds = 60)
+    private val mfaService = mockk<MfaService>(relaxed = true)
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-minimum-len")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(7),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+            smtpEnabled = true,
+            smtpHost = "smtp.example.com",
+            smtpPort = 587,
+            smtpUsername = "noreply@acme.com",
+            smtpPassword = "secret",
+            smtpFromAddress = "noreply@acme.com",
+            smtpFromName = "Acme",
+            securityConfig = SecurityConfig(magicLinkEnabled = true),
+        )
+
+    private val alice =
+        User(
+            id = UserId(42),
+            tenantId = TenantId(7),
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("correct-pass"),
+            enabled = true,
+            emailVerified = true,
+        )
+
+    private val spaApp =
+        Application(
+            id = ApplicationId(1),
+            tenantId = TenantId(7),
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    @BeforeTest
+    fun reset() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        authCodeRepo.clear()
+        sessionRepo.clear()
+        prTokens.clear()
+        evTokens.clear()
+        emails.clear()
+        auditLog.clear()
+        tokenPort.reset()
+        passwordPolicy.clear()
+        tenantRepo.add(tenant)
+        userRepo.add(alice)
+        appRepo.add(spaApp)
+    }
+
+    private fun authService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessionRepo,
+        )
+
+    private fun oauthService() =
+        OAuthService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            sessionRepository = sessionRepo,
+            authCodeRepository = authCodeRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+        )
+
+    private fun selfService() =
+        UserSelfServiceService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            sessionRepository = sessionRepo,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = evTokens,
+            prTokenRepo = prTokens,
+            emailPort = emails,
+            passwordPolicy = passwordPolicy,
+            emailScope = CoroutineScope(Dispatchers.Unconfined),
+        )
+
+    private fun appBlock(): io.ktor.server.application.Application.() -> Unit =
+        {
+            install(ContentNegotiation) { json() }
+            routing {
+                authRoutes(
+                    authService = authService(),
+                    oauthService = oauthService(),
+                    tenantRepository = tenantRepo,
+                    loginRateLimiter = limiter,
+                    registerRateLimiter = limiter,
+                    tokenRateLimiter = limiter,
+                    selfServiceService = selfService(),
+                    mfaService = mfaService,
+                    encryptionService = encryptionService,
+                    translationPort = EnglishOnlyTranslation(),
+                )
+            }
+        }
+
+    private fun buildAuthContextCookie(): String {
+        // Public client → PKCE challenge required by issueAuthorizationCode.
+        // Use the RFC 7636 example pair (verifier omitted; the auth server only
+        // checks the challenge at code-issuance time).
+        val payload =
+            listOf(
+                "code",
+                "spa-app",
+                "https://app.example.com/callback",
+                "openid",
+                "",
+                "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "S256",
+                "",
+                System.currentTimeMillis().toString(),
+            ).joinToString("|")
+        return encryptionService.signCookie(payload)
+    }
+
+    /** Pulls the value of a Set-Cookie header by name; null if not present. URL-decodes the value. */
+    private fun extractCookie(
+        setCookie: List<String>,
+        name: String,
+    ): String? {
+        val raw = setCookie.firstOrNull { it.startsWith("$name=") } ?: return null
+        val encoded = raw.substringAfter("$name=").substringBefore(';')
+        return java.net.URLDecoder.decode(encoded, Charsets.UTF_8)
+    }
+
+    private data class SsoPayload(
+        val version: String,
+        val userId: Int,
+        val tenantId: Int,
+        val authTimeEpochSec: Long,
+        val mfaCompleted: Boolean,
+        val expiresAtEpochSec: Long,
+    )
+
+    private fun parseSsoCookie(value: String): SsoPayload {
+        val verified = encryptionService.verifyCookie(value)
+        assertNotNull(verified, "SSO cookie must verify against the same signing key")
+        val parts = verified.split("|")
+        assertEquals(6, parts.size, "SSO cookie must have 6 pipe-delimited fields")
+        return SsoPayload(
+            version = parts[0],
+            userId = parts[1].toInt(),
+            tenantId = parts[2].toInt(),
+            authTimeEpochSec = parts[3].toLong(),
+            mfaCompleted = parts[4] == "1",
+            expiresAtEpochSec = parts[5].toLong(),
+        )
+    }
+
+    @Test
+    fun `password login sets a signed KOTAUTH_SSO cookie with mfaCompleted=false`() =
+        testApplication {
+            every { mfaService.shouldChallengeMfa(any()) } returns false
+            application(appBlock())
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/authorize",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("password", "correct-pass")
+                        },
+                ) {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=${buildAuthContextCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status, "Successful auth must redirect to client callback")
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            val ssoValue =
+                extractCookie(setCookie, "KOTAUTH_SSO")
+                    ?: error("KOTAUTH_SSO must be set on successful password login. Set-Cookie: $setCookie")
+
+            val payload = parseSsoCookie(ssoValue)
+            assertEquals("v1", payload.version)
+            assertEquals(alice.id!!.value, payload.userId)
+            assertEquals(tenant.id.value, payload.tenantId)
+            assertEquals(false, payload.mfaCompleted, "Password-only login must record mfaCompleted=false")
+            assertTrue(
+                payload.expiresAtEpochSec > payload.authTimeEpochSec,
+                "expiresAt must be in the future relative to authTime",
+            )
+
+            // Path scope must keep the cookie out of other tenants.
+            val rawSetHeader = setCookie.first { it.startsWith("KOTAUTH_SSO=") }
+            assertTrue(
+                rawSetHeader.contains("Path=/t/acme") || rawSetHeader.contains("path=/t/acme"),
+                "KOTAUTH_SSO must be path-scoped to /t/{slug}, was: $rawSetHeader",
+            )
+            assertTrue(
+                rawSetHeader.contains("HttpOnly", ignoreCase = true),
+                "KOTAUTH_SSO must be HttpOnly, was: $rawSetHeader",
+            )
+        }
+
+    @Test
+    fun `magic-link consume sets KOTAUTH_SSO cookie with mfaCompleted=false`() =
+        testApplication {
+            application(appBlock())
+
+            // Issue the magic link, capture the token from the email
+            selfService().initiateMagicLink(
+                email = "alice@acme.com",
+                tenantSlug = "acme",
+                baseUrl = "http://localhost",
+                ipAddress = null,
+            )
+            val rawToken =
+                emails.sent
+                    .single { it.type == "magic_link" }
+                    .url
+                    .substringAfter("?token=")
+                    .substringBefore('&')
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.get("/t/acme/magic-link/consume?token=$rawToken") {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=${buildAuthContextCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            val ssoValue =
+                extractCookie(setCookie, "KOTAUTH_SSO")
+                    ?: error("KOTAUTH_SSO must be set on magic-link consume success. Set-Cookie: $setCookie")
+
+            val payload = parseSsoCookie(ssoValue)
+            assertEquals(alice.id!!.value, payload.userId)
+            assertEquals(tenant.id.value, payload.tenantId)
+            assertEquals(false, payload.mfaCompleted, "Magic-link sign-in must record mfaCompleted=false")
+        }
+
+    @Test
+    fun `MFA challenge success sets KOTAUTH_SSO cookie with mfaCompleted=true`() =
+        testApplication {
+            application(appBlock())
+
+            // Bypass the MFA service — verifyTotp returns Success
+            every { mfaService.verifyTotp(UserId(42), "123456") } returns
+                com.kauth.domain.service.MfaResult
+                    .Success(true)
+
+            val mfaPending = "${alice.id!!.value}|acme|${System.currentTimeMillis()}"
+            val mfaCookie = encryptionService.signCookie(mfaPending)
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/mfa-challenge",
+                    formParameters =
+                        Parameters.build {
+                            append("code", "123456")
+                        },
+                ) {
+                    header(
+                        "Cookie",
+                        listOf(
+                            "KOTAUTH_AUTH_CONTEXT=${buildAuthContextCookie()}",
+                            "KOTAUTH_MFA_PENDING=$mfaCookie",
+                        ).joinToString("; "),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status, "MFA success must redirect to client callback")
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            val ssoValue =
+                extractCookie(setCookie, "KOTAUTH_SSO")
+                    ?: error("KOTAUTH_SSO must be set on MFA challenge success. Set-Cookie: $setCookie")
+
+            val payload = parseSsoCookie(ssoValue)
+            assertEquals(alice.id!!.value, payload.userId)
+            assertEquals(true, payload.mfaCompleted, "MFA-completed login must record mfaCompleted=true")
+        }
+
+    @Test
+    fun `KOTAUTH_SSO cookie is NOT set on failed password login`() =
+        testApplication {
+            every { mfaService.shouldChallengeMfa(any()) } returns false
+            application(appBlock())
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/authorize",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("password", "wrong-pass")
+                        },
+                ) {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=${buildAuthContextCookie()}")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            assertTrue(
+                setCookie.none { it.startsWith("KOTAUTH_SSO=") && !it.startsWith("KOTAUTH_SSO=;") },
+                "KOTAUTH_SSO must NOT be set on a failed login. Set-Cookie: $setCookie",
+            )
+        }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
@@ -1,0 +1,183 @@
+package com.kauth.adapter.web.auth
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantTheme
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.domain.service.AuthService
+import com.kauth.domain.service.MfaService
+import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import com.kauth.infrastructure.EncryptionService
+import com.kauth.infrastructure.EnglishOnlyTranslation
+import com.kauth.infrastructure.InMemoryRateLimiter
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase 4 of v1.8.1 OIDC SSO: every logout path must wipe the KOTAUTH_SSO
+ * witness. Otherwise the next /authorize would silent-auth the user back
+ * into the session they just signed out of.
+ */
+class SsoLogoutTest {
+    private val tenantRepo = FakeTenantRepository()
+    private val userRepo = FakeUserRepository()
+    private val appRepo = FakeApplicationRepository()
+    private val authCodeRepo = FakeAuthorizationCodeRepository()
+    private val sessionRepo = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val tokenPort = FakeTokenPort()
+    private val limiter = InMemoryRateLimiter(maxRequests = 1000, windowSeconds = 60)
+    private val mfaService = mockk<MfaService>(relaxed = true)
+    private val selfService = mockk<UserSelfServiceService>(relaxed = true)
+    private val encryptionService = EncryptionService("test-secret-key-32-chars-minimum-len")
+
+    private val tenant =
+        Tenant(
+            id = TenantId(7),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            theme = TenantTheme.DEFAULT,
+            securityConfig = SecurityConfig(magicLinkEnabled = true),
+        )
+
+    private val alice =
+        User(
+            id = UserId(42),
+            tenantId = TenantId(7),
+            username = "alice",
+            email = "alice@acme.com",
+            fullName = "Alice",
+            passwordHash = hasher.hash("doesnt-matter"),
+            enabled = true,
+            emailVerified = true,
+        )
+
+    private val spaApp =
+        Application(
+            id = ApplicationId(1),
+            tenantId = TenantId(7),
+            clientId = "spa-app",
+            name = "SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://app.example.com/callback"),
+        )
+
+    @BeforeTest
+    fun reset() {
+        tenantRepo.clear()
+        userRepo.clear()
+        appRepo.clear()
+        authCodeRepo.clear()
+        sessionRepo.clear()
+        auditLog.clear()
+        tokenPort.reset()
+        tenantRepo.add(tenant)
+        userRepo.add(alice)
+        appRepo.add(spaApp)
+    }
+
+    private fun authService() =
+        AuthService(
+            userRepository = userRepo,
+            tenantRepository = tenantRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessionRepo,
+        )
+
+    private fun oauthService() =
+        OAuthService(
+            tenantRepository = tenantRepo,
+            userRepository = userRepo,
+            applicationRepository = appRepo,
+            sessionRepository = sessionRepo,
+            authCodeRepository = authCodeRepo,
+            tokenPort = tokenPort,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+        )
+
+    private fun appBlock(): io.ktor.server.application.Application.() -> Unit =
+        {
+            install(ContentNegotiation) { json() }
+            routing {
+                authRoutes(
+                    authService = authService(),
+                    oauthService = oauthService(),
+                    tenantRepository = tenantRepo,
+                    loginRateLimiter = limiter,
+                    registerRateLimiter = limiter,
+                    tokenRateLimiter = limiter,
+                    selfServiceService = selfService,
+                    mfaService = mfaService,
+                    encryptionService = encryptionService,
+                    translationPort = EnglishOnlyTranslation(),
+                )
+            }
+        }
+
+    private fun assertSsoCookieCleared(setCookie: List<String>) {
+        val ssoClear = setCookie.firstOrNull { it.startsWith("KOTAUTH_SSO=") }
+        assertTrue(ssoClear != null, "KOTAUTH_SSO clear directive must be present, was: $setCookie")
+        assertTrue(
+            ssoClear!!.contains("Max-Age=0", ignoreCase = true) || ssoClear.startsWith("KOTAUTH_SSO=;"),
+            "KOTAUTH_SSO cookie must be cleared with Max-Age=0, was: $ssoClear",
+        )
+    }
+
+    @Test
+    fun `GET end_session clears KOTAUTH_SSO`() =
+        testApplication {
+            application(appBlock())
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/protocol/openid-connect/logout")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertSsoCookieCleared(response.headers.getAll("Set-Cookie") ?: emptyList())
+        }
+
+    @Test
+    fun `POST end_session clears KOTAUTH_SSO`() =
+        testApplication {
+            application(appBlock())
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/logout",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertSsoCookieCleared(response.headers.getAll("Set-Cookie") ?: emptyList())
+        }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/portal/PortalRoutesTest.kt
@@ -5,14 +5,18 @@ import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TenantTheme
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
+import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserSelfServiceService
+import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeAuthorizationCodeRepository
 import com.kauth.fakes.FakeEmailPort
 import com.kauth.fakes.FakeEmailVerificationTokenRepository
 import com.kauth.fakes.FakePasswordHasher
 import com.kauth.fakes.FakePasswordResetTokenRepository
 import com.kauth.fakes.FakeSessionRepository
 import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
 import com.kauth.fakes.FakeUserRepository
 import com.kauth.infrastructure.EncryptionService
 import io.ktor.client.request.forms.submitForm
@@ -195,6 +199,82 @@ class PortalRoutesTest {
             assertTrue(response.headers["Location"]?.contains("/t/acme/account/login") == true)
         }
 
+    @Test
+    fun `POST logout clears KOTAUTH_SSO cookie`() =
+        testApplication {
+            application { installTestApp() }
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/account/logout",
+                    formParameters = Parameters.build { },
+                )
+
+            val setCookie = response.headers.getAll("Set-Cookie") ?: emptyList()
+            val ssoClear = setCookie.firstOrNull { it.startsWith("KOTAUTH_SSO=") }
+            assertTrue(
+                ssoClear != null &&
+                    (
+                        ssoClear.contains("Max-Age=0", ignoreCase = true) ||
+                            ssoClear.startsWith("KOTAUTH_SSO=;")
+                    ),
+                "Portal logout must wipe KOTAUTH_SSO so silent SSO doesn't bring the user back. Was: $setCookie",
+            )
+        }
+
+    // =========================================================================
+    // Phase 5 — portal silent SSO via prompt=none
+    // =========================================================================
+
+    @Test
+    fun `GET login redirects to authorize with prompt=none on first attempt`() =
+        testApplication {
+            application { installTestAppWithOAuth() }
+
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/login")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(
+                location.contains("prompt=none"),
+                "First /login attempt must include prompt=none, was: $location",
+            )
+        }
+
+    @Test
+    fun `GET login with prompt_failed=true OMITS prompt=none to break the loop`() =
+        testApplication {
+            application { installTestAppWithOAuth() }
+
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/login?prompt_failed=true")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(
+                !location.contains("prompt=none"),
+                "Loop-break attempt must NOT include prompt=none, was: $location",
+            )
+        }
+
+    @Test
+    fun `GET callback with error=login_required redirects to login with prompt_failed=true`() =
+        testApplication {
+            application { installTestAppWithOAuth() }
+
+            val noFollow = createClient { followRedirects = false }
+            val response = noFollow.get("/t/acme/account/callback?error=login_required")
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertTrue(
+                location.contains("/t/acme/account/login") && location.contains("prompt_failed=true"),
+                "login_required failure must loop back to /login?prompt_failed=true, was: $location",
+            )
+        }
+
     // =========================================================================
     // Test app wiring
     // =========================================================================
@@ -209,6 +289,38 @@ class PortalRoutesTest {
                 selfServiceService = buildSelfService(),
                 tenantRepository = tenantRepo,
                 encryptionService = encryptionService,
+            )
+        }
+    }
+
+    /**
+     * Wires a real (fake-backed) OAuthService — required for the prompt=none
+     * silent-SSO branch in /login since that branch only fires when oauthService
+     * is non-null.
+     */
+    private fun io.ktor.server.application.Application.installTestAppWithOAuth() {
+        install(ContentNegotiation) { json() }
+        install(Sessions) {
+            cookie<PortalSession>("KOTAUTH_PORTAL")
+        }
+        val oauthService =
+            OAuthService(
+                tenantRepository = tenantRepo,
+                userRepository = userRepo,
+                applicationRepository = FakeApplicationRepository(),
+                sessionRepository = sessionRepo,
+                authCodeRepository = FakeAuthorizationCodeRepository(),
+                tokenPort = FakeTokenPort(),
+                passwordHasher = hasher,
+                auditLog = auditLogPort,
+            )
+        routing {
+            portalRoutes(
+                selfServiceService = buildSelfService(),
+                tenantRepository = tenantRepo,
+                encryptionService = encryptionService,
+                oauthService = oauthService,
+                baseUrl = "http://localhost",
             )
         }
     }

--- a/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeTokenPort.kt
@@ -30,6 +30,8 @@ class FakeTokenPort : TokenPort {
         private set
     var lastCustomIdClaims: Map<String, String> = emptyMap()
         private set
+    var lastAuthTime: java.time.Instant? = null
+        private set
 
     fun reset() {
         callCount = 0
@@ -37,6 +39,7 @@ class FakeTokenPort : TokenPort {
         jwksToReturn = emptyList()
         lastCustomAccessClaims = emptyMap()
         lastCustomIdClaims = emptyMap()
+        lastAuthTime = null
     }
 
     override fun issueUserTokens(
@@ -48,10 +51,12 @@ class FakeTokenPort : TokenPort {
         roles: List<Role>,
         customAccessClaims: Map<String, String>,
         customIdClaims: Map<String, String>,
+        authTime: java.time.Instant?,
     ): TokenResponse {
         val n = ++callCount
         lastCustomAccessClaims = customAccessClaims
         lastCustomIdClaims = customIdClaims
+        lastAuthTime = authTime
         return TokenResponse(
             access_token = "fake.access.${user.username}.$n",
             token_type = "Bearer",


### PR DESCRIPTION
## What does this PR do?

This pull request introduces OIDC silent SSO via a path-scoped witness cookie, significantly improving the single sign-on experience across clients on the same tenant. It implements full support for the OIDC `prompt` parameter, adds the `auth_time` claim to ID tokens, supports `max_age` and `id_token_hint`, and ensures logout clears the SSO cookie everywhere. The release also introduces new environment variables to configure SSO session TTLs, a database migration for `auth_time`, and extensive documentation and integration tests to cover the new flows.

**OIDC Silent SSO and Authentication Enhancements:**
- Added silent SSO across clients on the same tenant using a signed, path-scoped `KOTAUTH_SSO` witness cookie. This enables seamless authentication without UI for users already signed in, addressing previous UX gaps. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-dae18956e7e42dc8219cd29a6bb24c1b4e725a48e5117a935ae4dd1b8c347715R1-R317)
- Implemented full OIDC `prompt` parameter support (`none`, `login`, `consent`, `select_account`), `max_age`, and `id_token_hint` handling on `/authorize`, with proper error handling and open-redirect protection. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-dae18956e7e42dc8219cd29a6bb24c1b4e725a48e5117a935ae4dd1b8c347715R1-R317) [[3]](diffhunk://#diff-dd7297f7d2aec6133c166521c785dcf7a72ce206fb7fc1c7cd8ca089d4bd66d9R408-R423)
- The `auth_time` claim is now included in every ID token, reflecting the moment credentials were last verified (including MFA). This is threaded through login, authorization code issuance, and token generation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-dae18956e7e42dc8219cd29a6bb24c1b4e725a48e5117a935ae4dd1b8c347715R1-R317)

**Configuration and Database Changes:**
- Introduced two new environment variables: `KAUTH_SSO_SESSION_TTL_SECONDS` (default 24h) and `KAUTH_SSO_SESSION_MAX_TTL_SECONDS` (default 30d), with startup validation and full documentation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-7079314005b77522df62a2954352f395a9387ad3230bf5930f60d0904ff12dd6R215-R244)
- Added a nullable `auth_time` column to the `authorization_codes` table (V38 migration) to persist the authentication time for each code. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-94e5d9404cfdfd8202ac584849ecdb4ce8d4446488e446c790a9a464a6d9caf3R24)

**Documentation and Integration Tests:**
- Added ADR-13 detailing the SSO cookie design, threat model, and limitations. Updated guides and environment reference documentation to explain new behaviors and configuration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-dae18956e7e42dc8219cd29a6bb24c1b4e725a48e5117a935ae4dd1b8c347715R1-R317) [[3]](diffhunk://#diff-7079314005b77522df62a2954352f395a9387ad3230bf5930f60d0904ff12dd6R215-R244) [[4]](diffhunk://#diff-dd7297f7d2aec6133c166521c785dcf7a72ce206fb7fc1c7cd8ca089d4bd66d9R408-R423)
- Extensive integration tests were added to cover SSO cookie logic, prompt parameter handling, silent auth, end-session, and portal flows.

**Codebase and API Changes:**
- Extended signatures for `completeAuthorizationCodeFlow`, `OAuthService.issueAuthorizationCode`, and `TokenPort.issueUserTokens` to support the new SSO and `auth_time` flows. All logout paths now clear the SSO cookie to prevent unintended silent re-authentication. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R375)

**References:** [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R37) [[2]](diffhunk://#diff-dae18956e7e42dc8219cd29a6bb24c1b4e725a48e5117a935ae4dd1b8c347715R1-R317) [[3]](diffhunk://#diff-7079314005b77522df62a2954352f395a9387ad3230bf5930f60d0904ff12dd6R215-R244) [[4]](diffhunk://#diff-dd7297f7d2aec6133c166521c785dcf7a72ce206fb7fc1c7cd8ca089d4bd66d9R408-R423) [[5]](diffhunk://#diff-94e5d9404cfdfd8202ac584849ecdb4ce8d4446488e446c790a9a464a6d9caf3R24) [[6]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R375)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [x] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
