### PR TITLE
feature/client-default-roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.11.0] - 2026-05-22
+
+### Added
+
+#### Client default roles
+
+- **Per-application default roles granted at self-registration** — an admin can configure a set of roles that are assigned automatically to any user who self-registers through a given OAuth application. When a user completes registration via an application's `/authorize` flow, every role associated with that application is granted to the new user, so their very first token already carries the intended roles. Eliminates the common integration friction where a Backend-for-Frontend has to detect the missing role after login, call the admin API to assign it, and force a token refresh — and the tenant-wide admin API key that pattern required. Standard IAM capability, modelled on Keycloak's "default roles" and Auth0's post-registration Actions
+- **Grant-at-registration semantics** — default roles are granted when the user account is created through a self-registration flow, attributed to the originating OAuth client. A returning user who later registers their first OAuth client through a different application does **not** retroactively receive that client's defaults — silently gaining roles by signing into a new app is a privilege-escalation surprise. Default roles are also **not** applied to admin-created or invite-accepted users — an admin creating a user already has full role control. Applies to both the password-registration path (`AuthService.register`) and the social-registration path (`SocialLoginService.completeSocialRegistration`) identically
+- **V42 `client_default_roles` table** — a clean `(client_id, role_id)` join table, both columns `ON DELETE CASCADE`. The composite primary key doubles as the lookup index. New `RoleRepository.findDefaultRolesForClient` / `setDefaultRolesForClient` (atomic full-set replace) port methods, implemented for both Postgres and the in-memory test fake
+- **Admin UI — "Registration Defaults" card** on the application detail page (`/admin/workspaces/{slug}/applications/{clientId}`) — lists the configured default roles in a table with per-row removal, plus a dropdown + "Add Role" control. The dropdown is server-filtered to only the roles that are valid here (tenant-scoped roles and this application's own client-scoped roles), so an invalid selection is never offered. Mirrors the existing "Composite Children" card pattern exactly
+- **Admin API — `GET` and `PUT /t/{slug}/api/v1/applications/{appId}/default-roles`** — read the configured set, or replace it atomically with a `{ "roleIds": [...] }` body. `GET` is scoped to `applications:read`, `PUT` to `applications:write`
+- **Role-assignment admin API accepts a role name** — `POST`/`DELETE /t/{slug}/api/v1/users/{userId}/roles/{roleRef}` now resolves `{roleRef}` as either a numeric role id (unchanged) or a role name. Role ids are environment-specific `SERIAL` values unknown at build time; addressing a role by its stable name removes a per-environment lookup or config value for integrators. A name that is ambiguous across scopes (the same name used as both a tenant-scoped and a client-scoped role) is rejected with a clear message pointing back to the numeric id
+
+#### Custom token audience
+
+- **Per-application token audience** — an application can now declare the `aud` claim its issued JWTs carry, instead of `aud` always equalling the `client_id`. Lets one OAuth client mint tokens for a resource server whose identifier differs from the client_id, without overloading `client_id` itself or registering a throwaway client named after the audience. V43 migration adds a nullable `audience` column to `clients`; `JwtTokenAdapter` resolves the access-token audience as `audience → client_id → tenant slug`. Configurable via a "Token Audience" field on the application edit page and the `audience` field on the application admin API. This is deliberately a single configurable value, not RFC 8707 Resource Indicators — the column solves the real multi-resource-server case at minimal cost
+- **`Application.audience` field** — surfaced on the application admin API DTO and threaded through `ApplicationRepository.update` and `AdminService.updateApplication` (rejects values over 200 characters)
+
+### Changed
+
+- **`AuthService` and `SocialLoginService`** gained optional `applicationRepository` + `roleRepository` constructor dependencies and an `originatingClientId` parameter on their registration methods. The originating `client_id` is threaded from the register route via the OAuth auth-context cookie and from the social-registration route via the pending-registration cookie's stored OAuth parameters. Defaults preserve the prior behavior — no originating client means no default roles
+- **`RoleGroupService`** gained `getClientDefaultRoles`, `setClientDefaultRoles`, and `resolveRole` (numeric-id-or-name resolution). `setClientDefaultRoles` records an `ADMIN_CLIENT_UPDATED` audit event
+- **`ServiceGraph`** wires the new repository dependencies into `AuthService` and `SocialLoginService`; `adminApplicationRoutes` and `apiApplicationRoutes` now receive `RoleGroupService`
+
+### Security
+
+- **Cross-client privilege-escalation guard** — `RoleGroupService.setClientDefaultRoles` rejects associating a client-scoped role that belongs to a *different* application as a default for this one, and rejects roles from another tenant. Without this guard the `client_default_roles` table would let a compromised or careless admin hand out another application's roles to every new user. The admin-console dropdown is also pre-filtered so an invalid role is never even presented
+- **Default roles are independent of the email-verification gate** — roles are granted at account creation regardless of whether the tenant requires email verification. A role is a claim about who the user is; the `email_verified` token claim is a separate gate enforced by the resource server. Resource servers that require verified email continue to enforce it on the token, unaffected
+
+### Notes
+
+- Both features are generic, integrator-agnostic IAM capabilities. They were prompted by an internal onboarding-BFF integration but nothing integration-specific appears in the schema, domain model, or API
+- 30 new tests — repository-contract tests for the default-roles store, `RoleGroupService` tests for the scope guard and name resolution, registration-grant tests across the password and social paths, `JwtTokenAdapter` audience-resolution tests, and admin-API integration tests including the cross-client rejection
+
+---
+
 ## [1.10.0] - 2026-04-30
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.10.0"
+version = "1.11.0"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/main/kotlin/com/kauth/adapter/persistence/ClientsTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/ClientsTable.kt
@@ -36,6 +36,7 @@ object ClientsTable : Table("clients") {
     val iconUrl = varchar("icon_url", 500).nullable()
     val launcherVisible = bool("launcher_visible").default(true)
     val launcherDisplayOrder = integer("launcher_display_order").default(0)
+    val audience = varchar("audience", 200).nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresApplicationRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresApplicationRepository.kt
@@ -123,6 +123,7 @@ class PostgresApplicationRepository : ApplicationRepository {
         iconUrl: String?,
         launcherVisible: Boolean,
         launcherDisplayOrder: Int,
+        audience: String?,
     ): Application =
         transaction {
             ClientsTable.update({ ClientsTable.id eq appId.value }) {
@@ -133,6 +134,7 @@ class PostgresApplicationRepository : ApplicationRepository {
                 it[ClientsTable.iconUrl] = iconUrl
                 it[ClientsTable.launcherVisible] = launcherVisible
                 it[ClientsTable.launcherDisplayOrder] = launcherDisplayOrder
+                it[ClientsTable.audience] = audience
             }
             // Replace all redirect URIs atomically
             ClientRedirectUrisTable.deleteWhere { ClientRedirectUrisTable.clientId eq appId.value }
@@ -181,5 +183,6 @@ class PostgresApplicationRepository : ApplicationRepository {
             iconUrl = this[ClientsTable.iconUrl],
             launcherVisible = this[ClientsTable.launcherVisible],
             launcherDisplayOrder = this[ClientsTable.launcherDisplayOrder],
+            audience = this[ClientsTable.audience],
         )
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresRoleRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresRoleRepository.kt
@@ -315,6 +315,33 @@ class PostgresRoleRepository : RoleRepository {
     }
 
     // -------------------------------------------------------------------------
+    // Client default roles
+    // -------------------------------------------------------------------------
+
+    override fun findDefaultRolesForClient(clientId: ApplicationId): List<Role> =
+        transaction {
+            (ClientDefaultRolesTable innerJoin RolesTable)
+                .selectAll()
+                .where { ClientDefaultRolesTable.clientId eq clientId.value }
+                .orderBy(RolesTable.name)
+                .map { it.toRole() }
+        }
+
+    override fun setDefaultRolesForClient(
+        clientId: ApplicationId,
+        roleIds: List<RoleId>,
+    ): Unit =
+        transaction {
+            ClientDefaultRolesTable.deleteWhere { ClientDefaultRolesTable.clientId eq clientId.value }
+            if (roleIds.isNotEmpty()) {
+                ClientDefaultRolesTable.batchInsert(roleIds.distinct()) { roleId ->
+                    this[ClientDefaultRolesTable.clientId] = clientId.value
+                    this[ClientDefaultRolesTable.roleId] = roleId.value
+                }
+            }
+        }
+
+    // -------------------------------------------------------------------------
     // Row mapping
     // -------------------------------------------------------------------------
 

--- a/src/main/kotlin/com/kauth/adapter/persistence/RolesTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/RolesTable.kt
@@ -38,3 +38,16 @@ object UserRolesTable : Table("user_roles") {
 
     override val primaryKey = PrimaryKey(userId, roleId)
 }
+
+/**
+ * Exposed ORM mapping for 'client_default_roles' (V42).
+ *
+ * Roles granted automatically to a user who self-registers through the
+ * associated OAuth client's /authorize flow.
+ */
+object ClientDefaultRolesTable : Table("client_default_roles") {
+    val clientId = integer("client_id") references ClientsTable.id
+    val roleId = integer("role_id") references RolesTable.id
+
+    override val primaryKey = PrimaryKey(clientId, roleId)
+}

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -73,7 +73,8 @@ class JwtTokenAdapter(
     ): TokenResponse {
         val activeKey = getOrCreateAlgorithm(tenant.id.value)
         val issuer = issuerFor(tenant)
-        val audience = client?.clientId ?: tenant.slug
+        // Per-client custom audience falls back to the client_id, then the tenant slug.
+        val audience = client?.audience ?: client?.clientId ?: tenant.slug
         val subject = user.id!!.value.toString()
         val expiryMs = (client?.tokenExpiryOverride?.toLong() ?: tenant.tokenExpirySeconds) * 1_000L
         val expiresAt = Date(System.currentTimeMillis() + expiryMs)

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
@@ -1,9 +1,13 @@
 package com.kauth.adapter.web.admin
 
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.RoleId
+import com.kauth.domain.model.RoleScope
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.CorsPort
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.RoleGroupService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
@@ -20,6 +24,7 @@ import io.ktor.server.sessions.sessions
 fun Route.adminApplicationRoutes(
     adminService: AdminService,
     applicationRepository: ApplicationRepository,
+    roleGroupService: RoleGroupService,
     corsPort: CorsPort? = null,
 ) {
     route("/applications") {
@@ -98,6 +103,23 @@ fun Route.adminApplicationRoutes(
                 val wsPairs = call.attributes[WsPairsAttr]
                 val allApps = applicationRepository.findByTenantId(workspace.id)
                 val newSecret = FlashStore.take(call.request.queryParameters["flash"])
+
+                val defaultRoles =
+                    when (val r = roleGroupService.getClientDefaultRoles(workspace.id, app.id)) {
+                        is AdminResult.Success -> r.value
+                        is AdminResult.Failure -> emptyList()
+                    }
+                val defaultRoleIds = defaultRoles.mapNotNull { it.id }.toSet()
+                // Only tenant-scoped roles and this app's own client-scoped roles are
+                // eligible — see RoleGroupService.setClientDefaultRoles scope guard.
+                val availableDefaultRoles =
+                    roleGroupService
+                        .listRoles(workspace.id)
+                        .filter { role ->
+                            role.id !in defaultRoleIds &&
+                                (role.scope == RoleScope.TENANT || role.clientId == app.id)
+                        }
+
                 call.respondHtml(
                     HttpStatusCode.OK,
                     AdminView.applicationDetailPage(
@@ -107,6 +129,8 @@ fun Route.adminApplicationRoutes(
                         allApps,
                         session.username,
                         newSecret,
+                        defaultRoles,
+                        availableDefaultRoles,
                     ),
                 )
             }
@@ -150,6 +174,7 @@ fun Route.adminApplicationRoutes(
                 val launcherVisible = params["launcherVisible"] == "true"
                 val launcherDisplayOrder =
                     params["launcherDisplayOrder"]?.trim()?.toIntOrNull()?.coerceIn(0, 9999) ?: 0
+                val audience = params["audience"]?.trim().orEmpty()
                 when (
                     val result =
                         adminService.updateApplication(
@@ -163,6 +188,7 @@ fun Route.adminApplicationRoutes(
                             iconUrl = iconUrl,
                             launcherVisible = launcherVisible,
                             launcherDisplayOrder = launcherDisplayOrder,
+                            audience = audience,
                         )
                 ) {
                     is AdminResult.Success ->
@@ -216,6 +242,55 @@ fun Route.adminApplicationRoutes(
                         call.respond(HttpStatusCode.BadRequest, result.error.message)
                 }
             }
+
+            post("/default-roles") {
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
+                val clientId =
+                    call.parameters["clientId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val app =
+                    applicationRepository.findByClientId(workspace.id, clientId)
+                        ?: return@post call.respond(HttpStatusCode.NotFound)
+                val roleId =
+                    call.receiveParameters()["roleId"]?.toIntOrNull()?.let { RoleId(it) }
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                updateDefaultRoles(app.id, workspace.id, roleGroupService) { current ->
+                    current + roleId
+                }
+                call.respondRedirect("/admin/workspaces/$slug/applications/$clientId")
+            }
+
+            post("/default-roles/remove") {
+                val workspace = call.attributes[WorkspaceAttr]
+                val slug = workspace.slug
+                val clientId =
+                    call.parameters["clientId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val app =
+                    applicationRepository.findByClientId(workspace.id, clientId)
+                        ?: return@post call.respond(HttpStatusCode.NotFound)
+                val roleId =
+                    call.receiveParameters()["roleId"]?.toIntOrNull()?.let { RoleId(it) }
+                        ?: return@post call.respond(HttpStatusCode.BadRequest)
+                updateDefaultRoles(app.id, workspace.id, roleGroupService) { current ->
+                    current - roleId
+                }
+                call.respondRedirect("/admin/workspaces/$slug/applications/$clientId")
+            }
         }
     }
+}
+
+/** Read-modify-write of a client's default roles — the admin console mutates one at a time. */
+private fun updateDefaultRoles(
+    appId: ApplicationId,
+    tenantId: com.kauth.domain.model.TenantId,
+    roleGroupService: RoleGroupService,
+    transform: (List<RoleId>) -> List<RoleId>,
+) {
+    val current =
+        when (val r = roleGroupService.getClientDefaultRoles(tenantId, appId)) {
+            is AdminResult.Success -> r.value.mapNotNull { it.id }
+            is AdminResult.Failure -> return
+        }
+    roleGroupService.setClientDefaultRoles(tenantId, appId, transform(current).distinct())
 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -495,6 +495,7 @@ fun Route.adminRoutes(
                 adminApplicationRoutes(
                     adminService = adminService,
                     applicationRepository = applicationRepository,
+                    roleGroupService = roleGroupService,
                     corsPort = corsPort,
                 )
 

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -118,7 +118,19 @@ object AdminView {
         allApps: List<Application>,
         loggedInAs: String,
         newSecret: String? = null,
-    ): HTML.() -> Unit = applicationDetailPageImpl(workspace, application, allWorkspaces, allApps, loggedInAs, newSecret)
+        defaultRoles: List<com.kauth.domain.model.Role> = emptyList(),
+        availableDefaultRoles: List<com.kauth.domain.model.Role> = emptyList(),
+    ): HTML.() -> Unit =
+        applicationDetailPageImpl(
+            workspace,
+            application,
+            allWorkspaces,
+            allApps,
+            loggedInAs,
+            newSecret,
+            defaultRoles,
+            availableDefaultRoles,
+        )
 
     fun editApplicationPage(
         workspace: Tenant,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
@@ -3,6 +3,7 @@ package com.kauth.adapter.web.admin
 import com.kauth.adapter.web.inlineSvgIcon
 import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.Application
+import com.kauth.domain.model.Role
 import com.kauth.domain.model.Tenant
 import kotlinx.html.*
 
@@ -24,6 +25,9 @@ internal fun applicationDetailPageImpl(
     allApps: List<Application>,
     loggedInAs: String,
     newSecret: String? = null,
+    defaultRoles: List<Role> = emptyList(),
+    // Tenant-scoped + this app's client-scoped roles, minus those already set.
+    availableDefaultRoles: List<Role> = emptyList(),
 ): HTML.() -> Unit =
     {
         val appPairs = allApps.map { it.clientId to it.name }
@@ -202,6 +206,81 @@ internal fun applicationDetailPageImpl(
                         }
                     }
                     ovRowText("Display order", application.launcherDisplayOrder.toString())
+                }
+            }
+
+            // ── Registration Defaults ──────────────────────────────
+            div("ov-card") {
+                div("ov-card__section-label") { +"Registration Defaults" }
+                if (defaultRoles.isEmpty()) {
+                    p("edit-row__hint") {
+                        style = "padding:8px 16px 12px;"
+                        +"No default roles configured — roles added here are granted "
+                        +"automatically to users who self-register through this app."
+                    }
+                } else {
+                    p("edit-row__hint") {
+                        style = "padding:0 16px 4px;"
+                        +"Roles granted automatically to users who self-register through this "
+                        +"application. Does not affect users created by an admin."
+                    }
+                    table("data-table") {
+                        thead {
+                            tr {
+                                th { +"Role" }
+                                th { style = "width:80px;" }
+                            }
+                        }
+                        tbody {
+                            defaultRoles.forEach { role ->
+                                tr {
+                                    td { span("data-table__name") { +role.name } }
+                                    td {
+                                        form(
+                                            action =
+                                                "/admin/workspaces/${workspace.slug}/applications/" +
+                                                    "${application.clientId}/default-roles/remove",
+                                            method = FormMethod.post,
+                                        ) {
+                                            input(type = InputType.hidden, name = "roleId") {
+                                                value = role.id?.value.toString()
+                                            }
+                                            button(type = ButtonType.submit) {
+                                                classes = setOf("btn", "btn--ghost", "btn--sm")
+                                                +"Remove"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if (availableDefaultRoles.isNotEmpty()) {
+                    div("edit-actions") {
+                        form(
+                            action =
+                                "/admin/workspaces/${workspace.slug}/applications/" +
+                                    "${application.clientId}/default-roles",
+                            method = FormMethod.post,
+                        ) {
+                            style = "display:flex; align-items:center; gap:8px;"
+                            select {
+                                classes = setOf("edit-row__field", "edit-row__field--select")
+                                name = "roleId"
+                                availableDefaultRoles.forEach { role ->
+                                    option {
+                                        value = role.id?.value.toString()
+                                        +role.name
+                                    }
+                                }
+                            }
+                            button(type = ButtonType.submit) {
+                                classes = setOf("btn", "btn--primary")
+                                +"Add Role"
+                            }
+                        }
+                    }
                 }
             }
 
@@ -543,6 +622,23 @@ internal fun editApplicationPageImpl(
                         div("edit-row__hint") {
                             +"One URI per line. Their origins are automatically CORS-allowed "
                             +"for SPAs in this workspace."
+                        }
+                    }
+                }
+                div("edit-row") {
+                    span("edit-row__label") { +"Token Audience" }
+                    div {
+                        input(type = InputType.text, name = "audience") {
+                            attributes["form"] = "edit-app-form"
+                            classes = setOf("edit-row__field", "edit-row__field--mono")
+                            this.id = "audience"
+                            placeholder = "https://api.example.com"
+                            value = application.audience ?: ""
+                        }
+                        div("edit-row__hint") {
+                            +"Sets the "
+                            code { +"aud" }
+                            +" claim in issued JWTs. Leave blank to use the client ID as the audience."
                         }
                     }
                 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutes.kt
@@ -2,9 +2,11 @@ package com.kauth.adapter.web.api
 
 import com.kauth.domain.model.ApiScope
 import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.RoleId
 import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
+import com.kauth.domain.service.RoleGroupService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.request.receive
@@ -18,6 +20,7 @@ import io.ktor.server.routing.route
 internal fun Route.apiApplicationRoutes(
     applicationRepository: ApplicationRepository,
     adminService: AdminService,
+    roleGroupService: RoleGroupService,
 ) {
     route("/applications") {
         get {
@@ -68,6 +71,7 @@ internal fun Route.apiApplicationRoutes(
                         description = body.description,
                         accessType = body.accessType,
                         redirectUris = body.redirectUris,
+                        audience = body.audience,
                     )
             ) {
                 is AdminResult.Success -> call.respond(HttpStatusCode.OK, result.value.toApiDto())
@@ -87,6 +91,53 @@ internal fun Route.apiApplicationRoutes(
                     )
             when (val result = adminService.setApplicationEnabled(appId, tenantId, false)) {
                 is AdminResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                is AdminResult.Failure -> call.respondAdminError(result.error)
+            }
+        }
+
+        get("/{appId}/default-roles") {
+            requireScope(call, ApiScope.APPLICATIONS_READ) ?: return@get
+            val tenantId = call.attributes[TenantIdAttr]
+            val appId =
+                call.parameters["appId"]?.toIntOrNull()?.let { ApplicationId(it) }
+                    ?: return@get call.respondProblem(HttpStatusCode.BadRequest, "Invalid application ID", "")
+            when (val result = roleGroupService.getClientDefaultRoles(tenantId, appId)) {
+                is AdminResult.Success ->
+                    call.respond(
+                        HttpStatusCode.OK,
+                        ApiResponse(
+                            data = result.value.map { it.toApiDto() },
+                            meta = ApiMeta(total = result.value.size),
+                        ),
+                    )
+                is AdminResult.Failure -> call.respondAdminError(result.error)
+            }
+        }
+
+        // Full-set replace — simpler for API consumers than per-role add/remove.
+        put("/{appId}/default-roles") {
+            requireScope(call, ApiScope.APPLICATIONS_WRITE) ?: return@put
+            val tenantId = call.attributes[TenantIdAttr]
+            val appId =
+                call.parameters["appId"]?.toIntOrNull()?.let { ApplicationId(it) }
+                    ?: return@put call.respondProblem(HttpStatusCode.BadRequest, "Invalid application ID", "")
+            val body = call.receive<SetDefaultRolesRequest>()
+            when (
+                val result =
+                    roleGroupService.setClientDefaultRoles(tenantId, appId, body.roleIds.map { RoleId(it) })
+            ) {
+                is AdminResult.Success ->
+                    when (val refreshed = roleGroupService.getClientDefaultRoles(tenantId, appId)) {
+                        is AdminResult.Success ->
+                            call.respond(
+                                HttpStatusCode.OK,
+                                ApiResponse(
+                                    data = refreshed.value.map { it.toApiDto() },
+                                    meta = ApiMeta(total = refreshed.value.size),
+                                ),
+                            )
+                        is AdminResult.Failure -> call.respondAdminError(refreshed.error)
+                    }
                 is AdminResult.Failure -> call.respondAdminError(result.error)
             }
         }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -173,6 +173,11 @@ data class ProblemDetail(
     val description: String? = null,
     val accessType: String? = null,
     val redirectUris: List<String>? = null,
+    val audience: String? = null,
+)
+
+@Serializable data class SetDefaultRolesRequest(
+    val roleIds: List<Int>,
 )
 
 @Serializable data class UpsertUserAttributeRequest(
@@ -244,6 +249,7 @@ data class ProblemDetail(
     val accessType: String,
     val enabled: Boolean,
     val redirectUris: List<String>,
+    val audience: String? = null,
 )
 
 @Serializable data class SessionDto(
@@ -321,6 +327,7 @@ internal fun com.kauth.domain.model.Application.toApiDto() =
         accessType = accessType.name.lowercase(),
         enabled = enabled,
         redirectUris = redirectUris,
+        audience = audience,
     )
 
 internal fun com.kauth.domain.model.Session.toApiDto() =

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiRoutes.kt
@@ -109,7 +109,7 @@ fun Route.apiRoutes(
 
             apiUserRoutes(adminService, roleGroupService)
             apiRbacRoutes(roleRepository, groupRepository, roleGroupService)
-            apiApplicationRoutes(applicationRepository, adminService)
+            apiApplicationRoutes(applicationRepository, adminService, roleGroupService)
             apiSessionAuditRoutes(sessionRepository, auditLogRepository)
             apiUserAttributeRoutes(userAttributeService)
             apiClaimMapperRoutes(claimMapperService)

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
@@ -2,7 +2,6 @@ package com.kauth.adapter.web.api
 
 import com.kauth.adapter.web.admin.resolvedBaseUrl
 import com.kauth.domain.model.ApiScope
-import com.kauth.domain.model.RoleId
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminService
@@ -213,20 +212,31 @@ internal fun Route.apiUserRoutes(
             }
 
             route("/roles") {
-                post("/{roleId}") {
+                // {roleRef} accepts either a numeric role id or a role name —
+                // see RoleGroupService.resolveRole.
+                post("/{roleRef}") {
                     requireScope(call, ApiScope.USERS_WRITE) ?: return@post
                     val tenantId = call.attributes[TenantIdAttr]
                     val userId =
                         call.parameters["userId"]?.toIntOrNull()?.let { UserId(it) }
                             ?: return@post call.respondProblem(HttpStatusCode.BadRequest, "Invalid user ID", "")
-                    val roleId =
-                        call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
-                            ?: return@post call.respondProblem(HttpStatusCode.BadRequest, "Invalid role ID", "")
-                    roleGroupService.assignRoleToUser(userId, roleId, tenantId)
-                    call.respond(HttpStatusCode.NoContent, "")
+                    val roleRef =
+                        call.parameters["roleRef"]
+                            ?: return@post call.respondProblem(HttpStatusCode.BadRequest, "Missing role", "")
+                    when (val resolved = roleGroupService.resolveRole(tenantId, roleRef)) {
+                        is AdminResult.Success ->
+                            when (
+                                val assigned =
+                                    roleGroupService.assignRoleToUser(userId, resolved.value.id!!, tenantId)
+                            ) {
+                                is AdminResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                                is AdminResult.Failure -> call.respondAdminError(assigned.error)
+                            }
+                        is AdminResult.Failure -> call.respondAdminError(resolved.error)
+                    }
                 }
 
-                delete("/{roleId}") {
+                delete("/{roleRef}") {
                     requireScope(call, ApiScope.USERS_WRITE) ?: return@delete
                     val tenantId = call.attributes[TenantIdAttr]
                     val userId =
@@ -236,15 +246,20 @@ internal fun Route.apiUserRoutes(
                                 "Invalid user ID",
                                 "",
                             )
-                    val roleId =
-                        call.parameters["roleId"]?.toIntOrNull()?.let { RoleId(it) }
-                            ?: return@delete call.respondProblem(
-                                HttpStatusCode.BadRequest,
-                                "Invalid role ID",
-                                "",
-                            )
-                    roleGroupService.unassignRoleFromUser(userId, roleId, tenantId)
-                    call.respond(HttpStatusCode.NoContent, "")
+                    val roleRef =
+                        call.parameters["roleRef"]
+                            ?: return@delete call.respondProblem(HttpStatusCode.BadRequest, "Missing role", "")
+                    when (val resolved = roleGroupService.resolveRole(tenantId, roleRef)) {
+                        is AdminResult.Success ->
+                            when (
+                                val removed =
+                                    roleGroupService.unassignRoleFromUser(userId, resolved.value.id!!, tenantId)
+                            ) {
+                                is AdminResult.Success -> call.respond(HttpStatusCode.NoContent, "")
+                                is AdminResult.Failure -> call.respondAdminError(removed.error)
+                            }
+                        is AdminResult.Failure -> call.respondAdminError(resolved.error)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/RegisterRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/RegisterRoutes.kt
@@ -82,7 +82,21 @@ internal fun Route.registerRoutes(
         val confirmPassword = params["confirmPassword"] ?: ""
         val prefill = RegisterPrefill(username = username, email = email, fullName = fullName)
 
-        when (val result = authService.register(slug, username, email, fullName, password, confirmPassword, baseUrl)) {
+        val originatingClientId = call.getAuthContext(encryptionService)?.clientId
+
+        when (
+            val result =
+                authService.register(
+                    tenantSlug = slug,
+                    username = username,
+                    email = email,
+                    fullName = fullName,
+                    rawPassword = password,
+                    confirmPassword = confirmPassword,
+                    baseUrl = baseUrl,
+                    originatingClientId = originatingClientId,
+                )
+        ) {
             is AuthResult.Success -> {
                 if (passwordlessTenant) {
                     // No password the user knows — issue a magic-link so they can complete

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
@@ -302,6 +302,8 @@ internal fun Route.socialLoginRoutes(
         val chosenFullName = params["full_name"]?.trim()
         val ipAddress = call.request.local.remoteAddress
         val userAgent = call.request.headers["User-Agent"]
+        val originatingClientId =
+            parseQueryStringToOAuthParams(pending.oauthParamsRaw).clientId
 
         when (
             val result =
@@ -316,6 +318,7 @@ internal fun Route.socialLoginRoutes(
                     chosenUsername = chosenUsername,
                     ipAddress = ipAddress,
                     userAgent = userAgent,
+                    originatingClientId = originatingClientId,
                 )
         ) {
             is SocialLoginResult.Failure -> {

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -262,6 +262,8 @@ data class ServiceGraph(
                     sessionRepository = sessionRepository,
                     selfServiceService = selfServiceService,
                     passwordPolicy = passwordPolicyAdapter,
+                    applicationRepository = applicationRepository,
+                    roleRepository = roleRepository,
                 )
             // -- User attributes + claim mapping ------------------------------
             val userAttributeService =
@@ -353,6 +355,8 @@ data class ServiceGraph(
                             SocialProvider.GOOGLE to GoogleOAuthAdapter(),
                             SocialProvider.GITHUB to GitHubOAuthAdapter(),
                         ),
+                    applicationRepository = applicationRepository,
+                    roleRepository = roleRepository,
                 )
 
             // -- Key rotation -------------------------------------------------

--- a/src/main/kotlin/com/kauth/domain/model/Application.kt
+++ b/src/main/kotlin/com/kauth/domain/model/Application.kt
@@ -30,6 +30,12 @@ data class Application(
     val launcherVisible: Boolean = true,
     /** Admin-controlled sort order in the launcher; ties broken by name. */
     val launcherDisplayOrder: Int = 0,
+    /**
+     * Custom access-token `aud` claim. Null falls back to [clientId], then the
+     * tenant slug. Lets one client mint tokens for a resource server whose
+     * identifier differs from the client_id.
+     */
+    val audience: String? = null,
 )
 
 enum class AccessType(

--- a/src/main/kotlin/com/kauth/domain/port/ApplicationRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/ApplicationRepository.kt
@@ -51,6 +51,7 @@ interface ApplicationRepository {
         iconUrl: String? = null,
         launcherVisible: Boolean = true,
         launcherDisplayOrder: Int = 0,
+        audience: String? = null,
     ): Application
 
     /** Enables or disables the application. */

--- a/src/main/kotlin/com/kauth/domain/port/RoleRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/RoleRepository.kt
@@ -78,4 +78,18 @@ interface RoleRepository {
         userId: UserId,
         tenantId: TenantId,
     ): List<Role>
+
+    // Client default roles — granted on self-registration through a client
+
+    /** Returns the roles configured as defaults for [clientId]. */
+    fun findDefaultRolesForClient(clientId: ApplicationId): List<Role>
+
+    /**
+     * Replaces the full set of default roles for [clientId] with [roleIds].
+     * Atomic — clears the prior set, then inserts the new one.
+     */
+    fun setDefaultRolesForClient(
+        clientId: ApplicationId,
+        roleIds: List<RoleId>,
+    )
 }

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -661,6 +661,7 @@ class AdminService(
         iconUrl: String? = null,
         launcherVisible: Boolean? = null,
         launcherDisplayOrder: Int? = null,
+        audience: String? = null,
     ): AdminResult<Application> {
         val app =
             applicationRepository.findById(appId)
@@ -687,9 +688,15 @@ class AdminService(
             if (iconUrl != null) iconUrl.trim().takeIf { it.isNotBlank() } else app.iconUrl
         val resolvedLauncherVisible = launcherVisible ?: app.launcherVisible
         val resolvedLauncherDisplayOrder = launcherDisplayOrder ?: app.launcherDisplayOrder
+        val resolvedAudience =
+            if (audience != null) audience.trim().takeIf { it.isNotBlank() } else app.audience
 
         if (resolvedName.isBlank()) {
             return AdminResult.Failure(AdminError.Validation("Name is required."))
+        }
+
+        if (resolvedAudience != null && resolvedAudience.length > 200) {
+            return AdminResult.Failure(AdminError.Validation("Token audience must be 200 characters or fewer."))
         }
 
         // Origin validation prevents a phishing surface where a compromised admin sets the
@@ -733,6 +740,7 @@ class AdminService(
                 iconUrl = resolvedIconUrl,
                 launcherVisible = resolvedLauncherVisible,
                 launcherDisplayOrder = resolvedLauncherDisplayOrder,
+                audience = resolvedAudience,
             )
 
         invalidateCors(tenantId)

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -8,9 +8,11 @@ import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TokenResponse
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
+import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.port.PasswordHasher
 import com.kauth.domain.port.PasswordPolicyPort
+import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.TokenPort
@@ -42,6 +44,8 @@ class AuthService(
     private val sessionRepository: SessionRepository,
     private val selfServiceService: UserSelfServiceService? = null,
     private val passwordPolicy: PasswordPolicyPort? = null,
+    private val applicationRepository: ApplicationRepository? = null,
+    private val roleRepository: RoleRepository? = null,
 ) {
     /**
      * Authenticates a user and returns the User domain object.
@@ -308,6 +312,13 @@ class AuthService(
         rawPassword: String,
         confirmPassword: String,
         baseUrl: String,
+        /**
+         * The `client_id` of the OAuth client whose `/authorize` flow this
+         * registration originated from. When set, that client's configured
+         * default roles are granted to the new user. Null for non-OAuth
+         * registrations (no defaults are granted).
+         */
+        originatingClientId: String? = null,
     ): AuthResult<User> {
         val tenant =
             tenantRepository.findBySlug(tenantSlug)
@@ -375,6 +386,8 @@ class AuthService(
             passwordPolicy.recordPasswordHistory(savedUser.id!!, tenant.id, newUser.passwordHash)
         }
 
+        grantClientDefaultRoles(tenant.id, savedUser.id!!, originatingClientId)
+
         auditLog.record(
             AuditEvent(
                 tenantId = tenant.id,
@@ -400,6 +413,25 @@ class AuthService(
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Grants the originating client's configured default roles to a freshly
+     * registered user. No-op when there is no originating client, the client
+     * is unknown, or the repositories were not wired (test setups).
+     */
+    private fun grantClientDefaultRoles(
+        tenantId: TenantId,
+        userId: UserId,
+        originatingClientId: String?,
+    ) {
+        if (originatingClientId == null) return
+        val apps = applicationRepository ?: return
+        val roles = roleRepository ?: return
+        val app = apps.findByClientId(tenantId, originatingClientId) ?: return
+        roles.findDefaultRolesForClient(app.id).forEach { role ->
+            roles.assignRoleToUser(userId, role.id!!)
+        }
+    }
 
     // Two UUIDs concatenated — 256 bits of entropy. Used as the stored hash for
     // passwordless registrations; the user never sees or types this value.

--- a/src/main/kotlin/com/kauth/domain/service/RoleGroupService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/RoleGroupService.kt
@@ -327,12 +327,112 @@ class RoleGroupService(
         return AdminResult.Success(Unit)
     }
 
+    /**
+     * Resolves a role reference that is either a numeric role id or a role
+     * name. Names are matched tenant-wide; an ambiguous name (the same name
+     * used in more than one scope) is rejected so the caller falls back to
+     * the numeric id. Lets integrators address roles by stable name instead
+     * of an environment-specific SERIAL id.
+     */
+    fun resolveRole(
+        tenantId: TenantId,
+        ref: String,
+    ): AdminResult<Role> {
+        ref.trim().toIntOrNull()?.let { idValue ->
+            val role = roleRepository.findById(RoleId(idValue))
+            return if (role != null && role.tenantId == tenantId) {
+                AdminResult.Success(role)
+            } else {
+                AdminResult.Failure(AdminError.NotFound("Role not found."))
+            }
+        }
+        val matches = roleRepository.findByTenantId(tenantId).filter { it.name == ref.trim() }
+        return when (matches.size) {
+            0 -> AdminResult.Failure(AdminError.NotFound("No role named '${ref.trim()}'."))
+            1 -> AdminResult.Success(matches.single())
+            else ->
+                AdminResult.Failure(
+                    AdminError.Validation(
+                        "Role name '${ref.trim()}' is ambiguous across scopes — use the numeric role id.",
+                    ),
+                )
+        }
+    }
+
     fun getRolesForUser(userId: UserId): List<Role> = roleRepository.findRolesForUser(userId)
 
     fun getEffectiveRolesForUser(
         userId: UserId,
         tenantId: TenantId,
     ): List<Role> = roleRepository.resolveEffectiveRoles(userId, tenantId)
+
+    // =========================================================================
+    // Client default roles — granted automatically on self-registration
+    // =========================================================================
+
+    /** Returns the roles configured as registration defaults for [clientId]. */
+    fun getClientDefaultRoles(
+        tenantId: TenantId,
+        clientId: ApplicationId,
+    ): AdminResult<List<Role>> {
+        val app = applicationRepository.findById(clientId)
+        if (app == null || app.tenantId != tenantId) {
+            return AdminResult.Failure(AdminError.NotFound("Application not found in this workspace."))
+        }
+        return AdminResult.Success(roleRepository.findDefaultRolesForClient(clientId))
+    }
+
+    /**
+     * Replaces the full set of default roles for [clientId].
+     *
+     * Scope guard: a client-scoped role may only be a default for its own
+     * client — otherwise the table becomes a privilege-escalation vector
+     * (client A handing out client B's roles to every new user).
+     */
+    fun setClientDefaultRoles(
+        tenantId: TenantId,
+        clientId: ApplicationId,
+        roleIds: List<RoleId>,
+    ): AdminResult<Unit> {
+        val app = applicationRepository.findById(clientId)
+        if (app == null || app.tenantId != tenantId) {
+            return AdminResult.Failure(AdminError.NotFound("Application not found in this workspace."))
+        }
+        val distinct = roleIds.distinct()
+        for (roleId in distinct) {
+            val role =
+                roleRepository.findById(roleId)
+                    ?: return AdminResult.Failure(AdminError.NotFound("Role not found."))
+            if (role.tenantId != tenantId) {
+                return AdminResult.Failure(
+                    AdminError.Validation("Role '${role.name}' does not belong to this workspace."),
+                )
+            }
+            if (role.scope == RoleScope.CLIENT && role.clientId != clientId) {
+                return AdminResult.Failure(
+                    AdminError.Validation(
+                        "Role '${role.name}' is scoped to a different application and cannot be a default here.",
+                    ),
+                )
+            }
+        }
+
+        roleRepository.setDefaultRolesForClient(clientId, distinct)
+
+        auditLog.record(
+            AuditEvent(
+                tenantId = tenantId,
+                userId = null,
+                clientId = clientId,
+                eventType = AuditEventType.ADMIN_CLIENT_UPDATED,
+                ipAddress = null,
+                userAgent = null,
+                details = mapOf("change" to "default_roles", "count" to distinct.size.toString()),
+            ),
+        )
+
+        return AdminResult.Success(Unit)
+    }
 
     // =========================================================================
     // Group CRUD

--- a/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
@@ -9,9 +9,11 @@ import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.TokenResponse
 import com.kauth.domain.model.User
+import com.kauth.domain.port.ApplicationRepository
 import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.PasswordHasher
+import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.SocialAccountRepository
 import com.kauth.domain.port.SocialProviderPort
@@ -55,6 +57,8 @@ class SocialLoginService(
     private val passwordHasher: PasswordHasher,
     private val auditLog: AuditLogPort,
     private val providerAdapters: Map<SocialProvider, SocialProviderPort>,
+    private val applicationRepository: ApplicationRepository? = null,
+    private val roleRepository: RoleRepository? = null,
 ) {
     /**
      * Builds the provider authorization URL that the browser should be redirected to.
@@ -175,6 +179,12 @@ class SocialLoginService(
         chosenUsername: String,
         ipAddress: String? = null,
         userAgent: String? = null,
+        /**
+         * The `client_id` of the OAuth client this social registration
+         * originated from. When set, that client's default roles are granted
+         * to the new user. Mirrors [AuthService.register].
+         */
+        originatingClientId: String? = null,
     ): SocialLoginResult<SocialLoginSuccess> {
         val tenant =
             tenantRepository.findBySlug(tenantSlug)
@@ -251,7 +261,28 @@ class SocialLoginService(
             ),
         )
 
+        grantClientDefaultRoles(tenant.id, newUser.id!!, originatingClientId)
+
         return issueTokens(newUser, tenant, provider, isNewUser = true, ipAddress, userAgent)
+    }
+
+    /**
+     * Grants the originating client's configured default roles to a freshly
+     * registered social user. Mirrors [AuthService.grantClientDefaultRoles] —
+     * password and social registration paths must behave identically.
+     */
+    private fun grantClientDefaultRoles(
+        tenantId: TenantId,
+        userId: com.kauth.domain.model.UserId,
+        originatingClientId: String?,
+    ) {
+        if (originatingClientId == null) return
+        val apps = applicationRepository ?: return
+        val roles = roleRepository ?: return
+        val app = apps.findByClientId(tenantId, originatingClientId) ?: return
+        roles.findDefaultRolesForClient(app.id).forEach { role ->
+            roles.assignRoleToUser(userId, role.id!!)
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/resources/db/migration/V42__client_default_roles.sql
+++ b/src/main/resources/db/migration/V42__client_default_roles.sql
@@ -1,0 +1,18 @@
+-- V42: Per-client default roles granted at self-registration.
+--
+-- When a user self-registers through an OAuth client's /authorize flow, every
+-- role associated with that client here is assigned to the new user. Builds on
+-- the existing roles / user_roles primitives — no new entitlement concept.
+--
+-- Cross-client privilege escalation is prevented at the service layer: a
+-- client-scoped role belonging to a different client must not be associated
+-- as a default for this client. Tenant-scoped roles are valid for any client.
+--
+-- The (client_id, role_id) primary key doubles as the lookup index for
+-- "default roles for client X" — client_id is the leading column.
+
+CREATE TABLE client_default_roles (
+    client_id INTEGER NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+    role_id   INTEGER NOT NULL REFERENCES roles(id)   ON DELETE CASCADE,
+    PRIMARY KEY (client_id, role_id)
+);

--- a/src/main/resources/db/migration/V43__client_audience.sql
+++ b/src/main/resources/db/migration/V43__client_audience.sql
@@ -1,0 +1,12 @@
+-- V43: Custom token audience per client.
+--
+-- When set, JwtTokenAdapter uses this value for the access-token `aud` claim
+-- instead of the client_id. Lets one OAuth client mint tokens for a resource
+-- server whose identifier differs from the client_id, without overloading
+-- client_id itself.
+--
+-- Null = fall back to client_id, then tenant slug — the pre-v1.11 behavior.
+-- This is deliberately not RFC 8707 Resource Indicators; it is a single
+-- configurable audience value.
+
+ALTER TABLE clients ADD COLUMN audience VARCHAR(200);

--- a/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterAudienceTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterAudienceTest.kt
@@ -1,0 +1,97 @@
+package com.kauth.adapter.token
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.TenantKey
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeTenantKeyRepository
+import com.kauth.infrastructure.KeyGenerator
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies the access-token `aud` claim resolution:
+ * custom client audience → client_id → tenant slug.
+ */
+class JwtTokenAdapterAudienceTest {
+    private val keyRepo = FakeTenantKeyRepository()
+    private val adapter = JwtTokenAdapter(baseUrl = "http://localhost:8080", tenantKeyRepository = keyRepo)
+    private val keyPair = KeyGenerator.generateRsaKeyPair("aud-key")
+
+    private val tenant =
+        Tenant(id = TenantId(1), slug = "acme", displayName = "Acme", issuerUrl = null)
+
+    private val user =
+        User(
+            id = UserId(7),
+            tenantId = TenantId(1),
+            username = "alice",
+            email = "alice@acme.test",
+            fullName = "Alice",
+            passwordHash = "x",
+        )
+
+    private fun app(audience: String?) =
+        Application(
+            id = ApplicationId(3),
+            tenantId = TenantId(1),
+            clientId = "acme-spa",
+            name = "Acme SPA",
+            description = null,
+            accessType = AccessType.PUBLIC,
+            enabled = true,
+            redirectUris = listOf("https://acme.test/cb"),
+            audience = audience,
+        )
+
+    @BeforeTest
+    fun setup() {
+        keyRepo.clear()
+        keyRepo.add(
+            TenantKey(
+                tenantId = TenantId(1),
+                keyId = keyPair.keyId,
+                publicKeyPem = keyPair.publicKeyPem,
+                privateKeyPem = keyPair.privateKeyPem,
+                enabled = true,
+                active = true,
+            ),
+        )
+        adapter.invalidateSigningKeyCache(TenantId(1))
+    }
+
+    private fun audOf(token: String) =
+        com.auth0.jwt.JWT
+            .decode(token)
+            .audience
+            .first()
+
+    @Test
+    fun `custom audience is used for the aud claim when set`() {
+        val response =
+            adapter.issueUserTokens(user, tenant, app(audience = "acme-resource-api"), listOf("openid"))
+
+        assertEquals("acme-resource-api", audOf(response.access_token))
+    }
+
+    @Test
+    fun `aud falls back to client_id when audience is null`() {
+        val response =
+            adapter.issueUserTokens(user, tenant, app(audience = null), listOf("openid"))
+
+        assertEquals("acme-spa", audOf(response.access_token))
+    }
+
+    @Test
+    fun `aud falls back to tenant slug when there is no client`() {
+        val response =
+            adapter.issueUserTokens(user, tenant, client = null, scopes = listOf("openid"))
+
+        assertEquals("acme", audOf(response.access_token))
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -811,6 +811,88 @@ class ApiRoutesTest {
         }
 
     // =========================================================================
+    // Client default roles
+    // =========================================================================
+
+    @Test
+    fun `GET default-roles is empty for a fresh application`() =
+        testApplication {
+            application { installTestApp() }
+            val app =
+                appRepo.create(TenantId(1), "spa", "SPA", null, "public", listOf("https://spa.test/cb"))
+
+            val response =
+                client.get("/t/acme/api/v1/applications/${app.id.value}/default-roles") {
+                    bearerAuth(rawApiKey)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"total\":0"))
+        }
+
+    @Test
+    fun `PUT default-roles sets the roles and GET returns them`() =
+        testApplication {
+            application { installTestApp() }
+            val app =
+                appRepo.create(TenantId(1), "spa", "SPA", null, "public", listOf("https://spa.test/cb"))
+            val role =
+                (
+                    roleGroupService.createRole(
+                        TenantId(1),
+                        "applicant",
+                        null,
+                        com.kauth.domain.model.RoleScope.TENANT,
+                        null,
+                    ) as AdminResult.Success
+                ).value
+
+            val put =
+                client.put("/t/acme/api/v1/applications/${app.id.value}/default-roles") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"roleIds":[${role.id!!.value}]}""")
+                }
+            assertEquals(HttpStatusCode.OK, put.status)
+            assertTrue(put.bodyAsText().contains("applicant"))
+
+            val get =
+                client.get("/t/acme/api/v1/applications/${app.id.value}/default-roles") {
+                    bearerAuth(rawApiKey)
+                }
+            assertTrue(get.bodyAsText().contains("applicant"))
+        }
+
+    @Test
+    fun `PUT default-roles rejects a client-scoped role from another application`() =
+        testApplication {
+            application { installTestApp() }
+            val appA =
+                appRepo.create(TenantId(1), "app-a", "App A", null, "public", listOf("https://a.test/cb"))
+            val appB =
+                appRepo.create(TenantId(1), "app-b", "App B", null, "public", listOf("https://b.test/cb"))
+            val foreignRole =
+                (
+                    roleGroupService.createRole(
+                        TenantId(1),
+                        "b-only",
+                        null,
+                        com.kauth.domain.model.RoleScope.CLIENT,
+                        appB.id,
+                    ) as AdminResult.Success
+                ).value
+
+            val response =
+                client.put("/t/acme/api/v1/applications/${appA.id.value}/default-roles") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"roleIds":[${foreignRole.id!!.value}]}""")
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        }
+
+    // =========================================================================
     // Test application wiring
     // =========================================================================
 

--- a/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
@@ -1,0 +1,221 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AccessType
+import com.kauth.domain.model.Application
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
+import com.kauth.domain.model.SocialProvider
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeIdentityProviderRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeSocialAccountRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeTokenPort
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that a client's configured default roles are granted to users who
+ * self-register through that client — across both the password-registration
+ * (`AuthService.register`) and social-registration
+ * (`SocialLoginService.completeSocialRegistration`) paths.
+ */
+class ClientDefaultRolesRegistrationTest {
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val roles = FakeRoleRepository()
+    private val apps = FakeApplicationRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val sessions = FakeSessionRepository()
+    private val tokens = FakeTokenPort()
+    private val socialAccounts = FakeSocialAccountRepository()
+    private val idpRepo = FakeIdentityProviderRepository()
+
+    private val authService =
+        AuthService(
+            userRepository = users,
+            tenantRepository = tenants,
+            tokenPort = tokens,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            sessionRepository = sessions,
+            applicationRepository = apps,
+            roleRepository = roles,
+        )
+
+    private val socialService =
+        SocialLoginService(
+            identityProviderRepository = idpRepo,
+            socialAccountRepository = socialAccounts,
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            tokenPort = tokens,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            providerAdapters = emptyMap(),
+            applicationRepository = apps,
+            roleRepository = roles,
+        )
+
+    private val tenant =
+        Tenant(
+            id = TenantId(1),
+            slug = "acme",
+            displayName = "Acme",
+            issuerUrl = null,
+            registrationEnabled = true,
+        )
+
+    private lateinit var onboardingApp: Application
+    private lateinit var applicantRole: Role
+
+    @BeforeTest
+    fun setUp() {
+        tenants.clear()
+        users.clear()
+        roles.clear()
+        apps.clear()
+        auditLog.clear()
+        sessions.clear()
+        tokens.reset()
+        socialAccounts.clear()
+        idpRepo.clear()
+
+        tenants.add(tenant)
+        onboardingApp =
+            apps.create(
+                tenantId = tenant.id,
+                clientId = "onboarding-spa",
+                name = "Onboarding",
+                description = null,
+                accessType = AccessType.PUBLIC.value,
+                redirectUris = listOf("https://onboarding.acme.test/cb"),
+            )
+        applicantRole =
+            roles.add(Role(tenantId = tenant.id, name = "onboarding.applicant", scope = RoleScope.TENANT))
+    }
+
+    private fun register(originatingClientId: String?) =
+        authService.register(
+            tenantSlug = "acme",
+            username = "newuser",
+            email = "newuser@acme.test",
+            fullName = "New User",
+            rawPassword = "Sufficiently-long-pass-1",
+            confirmPassword = "Sufficiently-long-pass-1",
+            baseUrl = "https://acme.test",
+            originatingClientId = originatingClientId,
+        )
+
+    @Test
+    fun `password registration through a client grants that client's default roles`() {
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        val result = register(originatingClientId = "onboarding-spa")
+
+        assertIs<AuthResult.Success<*>>(result)
+        val user = (result as AuthResult.Success).value
+        assertEquals(
+            listOf("onboarding.applicant"),
+            roles.findRolesForUser(user.id!!).map { it.name },
+        )
+    }
+
+    @Test
+    fun `registration without an originating client grants nothing`() {
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        val result = register(originatingClientId = null)
+
+        val user = (result as AuthResult.Success).value
+        assertTrue(roles.findRolesForUser(user.id!!).isEmpty())
+    }
+
+    @Test
+    fun `registration through an unknown client grants nothing and still succeeds`() {
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        val result = register(originatingClientId = "no-such-client")
+
+        assertIs<AuthResult.Success<*>>(result)
+        val user = (result as AuthResult.Success).value
+        assertTrue(roles.findRolesForUser(user.id!!).isEmpty())
+    }
+
+    @Test
+    fun `registration through a client with no defaults configured grants nothing`() {
+        val result = register(originatingClientId = "onboarding-spa")
+
+        val user = (result as AuthResult.Success).value
+        assertTrue(roles.findRolesForUser(user.id!!).isEmpty())
+    }
+
+    @Test
+    fun `default roles are granted even when the tenant requires email verification`() {
+        tenants.clear()
+        tenants.add(tenant.copy(emailVerificationRequired = true))
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        val result = register(originatingClientId = "onboarding-spa")
+
+        val user = (result as AuthResult.Success).value
+        assertEquals(false, user.emailVerified)
+        assertEquals(1, roles.findRolesForUser(user.id!!).size)
+    }
+
+    @Test
+    fun `social registration through a client grants that client's default roles`() {
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        val result =
+            socialService.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = SocialProvider.GOOGLE,
+                providerUserId = "google-uid-1",
+                email = "social@acme.test",
+                providerName = "Social User",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "socialuser",
+                originatingClientId = "onboarding-spa",
+            )
+
+        assertIs<SocialLoginResult.Success<*>>(result)
+        val created = users.findByEmail(tenant.id, "social@acme.test")!!
+        assertEquals(
+            listOf("onboarding.applicant"),
+            roles.findRolesForUser(created.id!!).map { it.name },
+        )
+    }
+
+    @Test
+    fun `social registration without an originating client grants nothing`() {
+        roles.setDefaultRolesForClient(onboardingApp.id, listOf(applicantRole.id!!))
+
+        socialService.completeSocialRegistration(
+            tenantSlug = "acme",
+            provider = SocialProvider.GOOGLE,
+            providerUserId = "google-uid-2",
+            email = "social2@acme.test",
+            providerName = "Social Two",
+            avatarUrl = null,
+            emailVerified = true,
+            chosenUsername = "socialtwo",
+            originatingClientId = null,
+        )
+
+        val created = users.findByEmail(tenant.id, "social2@acme.test")!!
+        assertTrue(roles.findRolesForUser(created.id!!).isEmpty())
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
@@ -620,4 +620,134 @@ class RoleGroupServiceTest {
         assertEquals(0, svc.getGroupsForUser(UserId(10)).size)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_MEMBER_REMOVED))
     }
+
+    // =========================================================================
+    // Client default roles
+    // =========================================================================
+
+    private fun tenantRole(name: String) =
+        roles.add(Role(tenantId = TenantId(1), name = name, scope = RoleScope.TENANT))
+
+    private fun clientRole(
+        name: String,
+        client: ApplicationId,
+    ) = roles.add(Role(tenantId = TenantId(1), name = name, scope = RoleScope.CLIENT, clientId = client))
+
+    @Test
+    fun `setClientDefaultRoles persists a tenant-scoped role`() {
+        val applicant = tenantRole("applicant")
+
+        val result = svc.setClientDefaultRoles(TenantId(1), testApp.id, listOf(applicant.id!!))
+
+        assertIs<AdminResult.Success<Unit>>(result)
+        assertEquals(listOf("applicant"), roles.findDefaultRolesForClient(testApp.id).map { it.name })
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_CLIENT_UPDATED))
+    }
+
+    @Test
+    fun `setClientDefaultRoles accepts a client-scoped role for the same client`() {
+        val viewer = clientRole("viewer", testApp.id)
+
+        val result = svc.setClientDefaultRoles(TenantId(1), testApp.id, listOf(viewer.id!!))
+
+        assertIs<AdminResult.Success<Unit>>(result)
+    }
+
+    @Test
+    fun `setClientDefaultRoles rejects a client-scoped role from a different client`() {
+        val otherApp =
+            apps.add(testApp.copy(id = ApplicationId(0), clientId = "other-app", name = "Other"))
+        val foreignRole = clientRole("foreign", otherApp.id)
+
+        val result = svc.setClientDefaultRoles(TenantId(1), testApp.id, listOf(foreignRole.id!!))
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertTrue(roles.findDefaultRolesForClient(testApp.id).isEmpty())
+    }
+
+    @Test
+    fun `setClientDefaultRoles rejects a role from another tenant`() {
+        val foreignTenantRole =
+            roles.add(Role(tenantId = TenantId(2), name = "elsewhere", scope = RoleScope.TENANT))
+
+        val result = svc.setClientDefaultRoles(TenantId(1), testApp.id, listOf(foreignTenantRole.id!!))
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `setClientDefaultRoles rejects an unknown application`() {
+        val applicant = tenantRole("applicant")
+
+        val result = svc.setClientDefaultRoles(TenantId(1), ApplicationId(9999), listOf(applicant.id!!))
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `getClientDefaultRoles returns the configured set`() {
+        val applicant = tenantRole("applicant")
+        svc.setClientDefaultRoles(TenantId(1), testApp.id, listOf(applicant.id!!))
+
+        val result = svc.getClientDefaultRoles(TenantId(1), testApp.id)
+
+        assertIs<AdminResult.Success<List<Role>>>(result)
+        assertEquals(listOf("applicant"), result.value.map { it.name })
+    }
+
+    // =========================================================================
+    // resolveRole — role-by-name or numeric id
+    // =========================================================================
+
+    @Test
+    fun `resolveRole resolves a numeric id`() {
+        val role = tenantRole("applicant")
+
+        val result = svc.resolveRole(TenantId(1), role.id!!.value.toString())
+
+        assertIs<AdminResult.Success<Role>>(result)
+        assertEquals(role.id, result.value.id)
+    }
+
+    @Test
+    fun `resolveRole resolves a unique role name`() {
+        val role = tenantRole("onboarding.applicant")
+
+        val result = svc.resolveRole(TenantId(1), "onboarding.applicant")
+
+        assertIs<AdminResult.Success<Role>>(result)
+        assertEquals(role.id, result.value.id)
+    }
+
+    @Test
+    fun `resolveRole rejects a name that is ambiguous across scopes`() {
+        tenantRole("staff")
+        clientRole("staff", testApp.id)
+
+        val result = svc.resolveRole(TenantId(1), "staff")
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `resolveRole returns NotFound for an unknown name`() {
+        val result = svc.resolveRole(TenantId(1), "ghost-role")
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `resolveRole returns NotFound for a numeric id in another tenant`() {
+        val foreign = roles.add(Role(tenantId = TenantId(2), name = "x", scope = RoleScope.TENANT))
+
+        val result = svc.resolveRole(TenantId(1), foreign.id!!.value.toString())
+
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeApplicationRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeApplicationRepository.kt
@@ -88,6 +88,7 @@ class FakeApplicationRepository : ApplicationRepository {
         iconUrl: String?,
         launcherVisible: Boolean,
         launcherDisplayOrder: Int,
+        audience: String?,
     ): Application {
         val updated =
             store[appId.value]!!.copy(
@@ -99,6 +100,7 @@ class FakeApplicationRepository : ApplicationRepository {
                 iconUrl = iconUrl,
                 launcherVisible = launcherVisible,
                 launcherDisplayOrder = launcherDisplayOrder,
+                audience = audience,
             )
         store[appId.value] = updated
         return updated

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepository.kt
@@ -22,6 +22,9 @@ class FakeRoleRepository : RoleRepository {
     // userId -> set of roleIds
     private val userRoles = mutableMapOf<Int, MutableSet<Int>>()
 
+    // clientId -> ordered list of default roleIds
+    private val clientDefaultRoles = mutableMapOf<Int, MutableList<Int>>()
+
     fun add(role: Role): Role {
         val r = if (role.id == null) role.copy(id = RoleId(nextId++)) else role
         store[r.id!!.value] = r
@@ -32,6 +35,7 @@ class FakeRoleRepository : RoleRepository {
         store.clear()
         composites.clear()
         userRoles.clear()
+        clientDefaultRoles.clear()
         nextId = 1
     }
 
@@ -140,5 +144,18 @@ class FakeRoleRepository : RoleRepository {
             }
         }
         return allRoleIds.mapNotNull { store[it] }.filter { it.tenantId == tenantId }
+    }
+
+    override fun findDefaultRolesForClient(clientId: ApplicationId): List<Role> =
+        clientDefaultRoles[clientId.value]
+            ?.mapNotNull { store[it] }
+            ?.sortedBy { it.name }
+            ?: emptyList()
+
+    override fun setDefaultRolesForClient(
+        clientId: ApplicationId,
+        roleIds: List<RoleId>,
+    ) {
+        clientDefaultRoles[clientId.value] = roleIds.distinct().map { it.value }.toMutableList()
     }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepositoryDefaultRolesTest.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepositoryDefaultRolesTest.kt
@@ -1,0 +1,81 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.ApplicationId
+import com.kauth.domain.model.Role
+import com.kauth.domain.model.RoleScope
+import com.kauth.domain.model.TenantId
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the client-default-roles contract on [FakeRoleRepository] — the
+ * v1.11.0 registration-grant logic depends on replace-semantics and
+ * name-sorted reads, so they are verified here directly.
+ */
+class FakeRoleRepositoryDefaultRolesTest {
+    private val roles = FakeRoleRepository()
+    private val tenantId = TenantId(1)
+    private val clientId = ApplicationId(10)
+
+    private fun role(name: String) = roles.add(Role(tenantId = tenantId, name = name, scope = RoleScope.TENANT))
+
+    @BeforeTest
+    fun setUp() {
+        roles.clear()
+    }
+
+    @Test
+    fun `findDefaultRolesForClient is empty when none configured`() {
+        assertTrue(roles.findDefaultRolesForClient(clientId).isEmpty())
+    }
+
+    @Test
+    fun `setDefaultRolesForClient round-trips and reads back sorted by name`() {
+        val viewer = role("viewer")
+        val applicant = role("applicant")
+        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!, applicant.id!!))
+
+        val found = roles.findDefaultRolesForClient(clientId)
+
+        assertEquals(listOf("applicant", "viewer"), found.map { it.name })
+    }
+
+    @Test
+    fun `setDefaultRolesForClient replaces the prior set, never appends`() {
+        val first = role("first")
+        val second = role("second")
+        roles.setDefaultRolesForClient(clientId, listOf(first.id!!))
+        roles.setDefaultRolesForClient(clientId, listOf(second.id!!))
+
+        val found = roles.findDefaultRolesForClient(clientId)
+
+        assertEquals(listOf("second"), found.map { it.name })
+    }
+
+    @Test
+    fun `setDefaultRolesForClient with an empty list clears the configuration`() {
+        val viewer = role("viewer")
+        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!))
+        roles.setDefaultRolesForClient(clientId, emptyList())
+
+        assertTrue(roles.findDefaultRolesForClient(clientId).isEmpty())
+    }
+
+    @Test
+    fun `setDefaultRolesForClient de-duplicates repeated role ids`() {
+        val viewer = role("viewer")
+        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!, viewer.id!!))
+
+        assertEquals(1, roles.findDefaultRolesForClient(clientId).size)
+    }
+
+    @Test
+    fun `default roles are scoped per client`() {
+        val viewer = role("viewer")
+        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!))
+
+        assertTrue(roles.findDefaultRolesForClient(ApplicationId(99)).isEmpty())
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces two major IAM features: **per-application default roles for self-registration** and **customizable JWT token audiences**. Admins can now configure roles that are automatically granted to users who self-register through a specific OAuth application, and applications can set a custom audience for their issued JWTs. The changes include schema migrations, repository and service updates, admin API and UI enhancements, and security safeguards to prevent privilege escalation. The most important changes are grouped below.

**Per-application default roles:**

* Added the `client_default_roles` table and ORM mapping, with repository methods to get/set default roles per client (`ClientDefaultRolesTable`, `RoleRepository.findDefaultRolesForClient`, `setDefaultRolesForClient`) [[1]](diffhunk://#diff-7d19da0837b04c6e63ed45ef43649c3f9f658ce5ced9f6d7f0c05b62ca9a4906R41-R53) [[2]](diffhunk://#diff-db77c0a4cfdf20001b1f63737be568472dcf809c17511d6271030b204bd14409R317-R343).
* Extended the admin UI and API to allow admins to view and manage default roles for each application, including new endpoints and UI controls (`AdminApplicationRoutes.kt`, `AdminView.applicationDetailPage`, `ApplicationViews.kt`) [[1]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R3-R10) [[2]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R106-R122) [[3]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R132-R133) [[4]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R245-R295) [[5]](diffhunk://#diff-6d868fd06b5413145d0dac337e8080992d31d5fbbe7994727ef600c2215661e6L121-R133) [[6]](diffhunk://#diff-cf4ffcba6d2bd0d8bbd8c0b13f674db6b81ca78f33517dbe1b6e0968ecd45df4R28-R30).
* Updated `RoleGroupService` and related services to support default role assignment at registration, with security checks to prevent cross-client or cross-tenant role assignment (see changelog).

**Custom token audience:**

* Added an optional `audience` column to the `clients` table and surfaced it through the domain model, repository, and admin UI/API (`ClientsTable`, `PostgresApplicationRepository`, `AdminApplicationRoutes.kt`) [[1]](diffhunk://#diff-b80b5b0c283bd4b76f27a2bb1a9e2d2a1c5649c6dbeb249f2e74a526bbe31560R39) [[2]](diffhunk://#diff-7f3d082209521efd5f7eb8229a125202608a14b22e500f11ed79e1315de3cd82R126) [[3]](diffhunk://#diff-7f3d082209521efd5f7eb8229a125202608a14b22e500f11ed79e1315de3cd82R137) [[4]](diffhunk://#diff-7f3d082209521efd5f7eb8229a125202608a14b22e500f11ed79e1315de3cd82R186) [[5]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R177) [[6]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R191).
* Modified `JwtTokenAdapter` to resolve the JWT `aud` claim as `audience → client_id → tenant slug` (`JwtTokenAdapter.kt`).

**Other improvements and tests:**

* 30 new tests cover repository contracts, service logic, registration flows, audience resolution, and admin API integration.

For more details, see the [1.11.0] changelog section.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
