### PR TITLE
Feature/polish v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.11.1] - 2026-05-22
+
+Polish release. Closes long-deferred small items, two impersonation
+discoverability fixes promised in v1.10.0, a real bug in the backup format,
+and one developer-experience improvement.
+
+### Added
+
+- **Per-tenant magic-link token TTL** — magic-link expiry was a hardcoded 15
+  minutes; tenants can now configure it in workspace Security settings (range
+  1–1440 minutes, default 15). The `MAGIC_LINK_REQUESTED` audit event also now
+  records the TTL that was applied, so post-incident analysis can correlate
+  "expired before user clicked" reports against the configured window. V44
+  Flyway migration adds the column; one constant read in
+  `UserSelfServiceService.initiateMagicLink` becomes a per-tenant lookup. Was
+  feature-backlog item #9, started as a free-rider in V39 and reverted
+- **Impersonation events have their own audit-log filter group** — the
+  workspace audit log dropdown gains an "Impersonation" optgroup before
+  "Admin Actions". Filtering to impersonation-only is now a one-click action
+  instead of scrolling a dropdown of 30 ADMIN_* events
+- **"Recent Impersonations" panel on the admin user-detail page** — when a
+  user has been impersonated, the page renders a compact table of the last
+  5 impersonations of that user (admin username + timestamp), pulled from
+  the audit log. Empty when none — no noise on regular users. For operator
+  incident response: "was this user impersonated, and by whom?" no longer
+  requires opening the audit log and filtering by hand
+- **`admin_username` in `ADMIN_IMPERSONATION_STARTED` audit details** — the
+  event already carried the admin's user id; the username is now stored
+  alongside so consumers (the new panel, log scrapers, future tooling) do not
+  need a cross-tenant user lookup to render attribution
+- **ADR-14 — admin impersonation session model** — documents the
+  parallel-sessions + RFC 8693 `act` claim + cascade-revocation choices made
+  in v1.10.0, and the alternatives we rejected
+- **`make run` target — fast inner loop without full Docker rebuilds** —
+  starts only `db` + `redis` in Docker and runs the JAR locally via
+  `./gradlew run` with safe dev-only env vars. Avoids the multi-minute Docker
+  rebuild on every Kotlin change. The existing `make up` (full Docker stack,
+  build from source) is unchanged and remains the right target for verifying
+  the production container before pushing
+
+### Changed
+
+- **"Impersonate user" button is rendered disabled (with tooltip)** instead
+  of being hidden when the target user is disabled, locked, or has a pending
+  invite. Discoverability matters — an admin investigating a problem user
+  used to wonder where the action went; now they see the button with an
+  explanation of why it is unavailable
+- **Magic-link admin-settings copy** — the help text on the existing "Allow
+  sign-in via email magic link" toggle no longer hardcodes "15 minutes";
+  it points to the new TTL field below
+
+### Fixed
+
+- **Backup/restore loses `passwordLoginEnabled`** — a tenant configured as
+  passwordless (v1.10.0+) would silently come back as password-enabled after
+  a restore, because `SecurityConfigBackup` was missing the field. Now
+  included; old backups still import (the field has a default of `true`,
+  which matches the historical behavior). The new `magicLinkTokenTtlMinutes`
+  field is also included with a default of 15
+- **`MAGIC_LINK_TTL_SECONDS` constant removed** — it had been bypassed by the
+  per-tenant lookup but the stale 15-minute value was still readable from
+  the class
+
+### Notes
+
+- 4 new tests covering the per-tenant TTL behavior (honors configured value,
+  defaults to 15, records on audit, coerces 1..1440 at the service layer)
+- **`detekt` was evaluated and explicitly deferred** — ktlint covers
+  formatting; detekt's complexity findings would largely confirm what
+  `wc -l` already shows on the large service classes, and the baseline-file
+  maintenance cost is not yet earned by the codebase. Reconsider when the
+  team is actively splitting service classes or adopts coroutines broadly
+- **Docker compose layout was reviewed and judged sound** — six files looks
+  like a lot but each has a distinct purpose (quickstart, base, dev,
+  external-db, demo overlay, prod TLS overlay). The quickstart file was
+  given a maintainer-note comment about drift from the base stack; a deeper
+  refactor via `include:` is possible but the merge semantics are subtle and
+  the current overlay design is the right pattern
+
+---
+
 ## [1.11.0] - 2026-05-22
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 .DEFAULT_GOAL := help
-.PHONY: help css css-admin css-auth js lint lint-fix test test-redis e2e build jar version up up-fresh down nuke logs health generate-key reset-mfa
+.PHONY: help css css-admin css-auth js lint lint-fix test test-redis e2e build jar version up up-fresh down nuke logs health generate-key reset-mfa run infra-up
 
 # ── CSS ───────────────────────────────────────────────────────────────────────
 
@@ -78,6 +78,25 @@ down: ## Stop and remove containers
 
 nuke: ## Stop containers and wipe volumes (destroys the database)
 	$(COMPOSE_DEV) down -v
+
+# Fast inner loop — start only the infrastructure (db + redis) in Docker and
+# run the JAR directly on the host. Avoids the multi-minute Docker rebuild on
+# every Kotlin change. Use this for IDE-driven work.
+infra-up: ## Start only db + redis in Docker, wait for healthchecks
+	$(COMPOSE_DEV) up -d --wait db redis
+
+run: infra-up ## Run Kotauth locally against Docker-hosted db + redis (fast inner loop)
+	@env \
+	  KAUTH_BASE_URL=http://localhost:8080 \
+	  KAUTH_ENV=development \
+	  KAUTH_SECRET_KEY=dev-only-not-for-production-replace-this-secret-key \
+	  DB_HOST=localhost \
+	  DB_PORT=5432 \
+	  DB_USER=postgres \
+	  DB_PASSWORD=password \
+	  DB_NAME=kotauth_db \
+	  KAUTH_REDIS_URL=redis://localhost:6379 \
+	  ./gradlew run
 
 logs: ## Follow app container logs
 	$(COMPOSE_DEV) logs -f app

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.11.0"
+version = "1.11.1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -7,6 +7,11 @@
 #
 # This file is for local evaluation only. For production, see docker/docker-compose.yml
 # and the deployment guide: https://kotauth.com/deployment/production/
+#
+# MAINTAINER NOTE: this file is intentionally self-contained for zero-config
+# eval. It mirrors the service shape of docker/docker-compose.yml. When you
+# change healthchecks, add a service (e.g. redis), or update the image tag in
+# the base stack, mirror the change here too — there is no automatic sync.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: kotauth-quickstart

--- a/docs/adr/ADR-14-admin-impersonation-session-model.md
+++ b/docs/adr/ADR-14-admin-impersonation-session-model.md
@@ -1,0 +1,131 @@
+# ADR-14: Admin impersonation session model
+
+**Status:** Accepted (v1.10.0)
+**Date:** 2026-05-01
+**Supersedes:** —
+**Related:** ADR-06 (sealed Result types), RFC 8693 (Token Exchange)
+
+## Context
+
+v1.10.0 introduced admin impersonation: an admin can act as a tenant user
+without learning their password. The feature touches three load-bearing
+surfaces simultaneously — the session model, the token issuer, and the audit
+log — and the design choices in each were genuinely under-determined by the
+existing architecture. This ADR records the decisions so future maintainers
+do not have to re-derive them from the diff.
+
+Three questions dominated the design.
+
+1. **What does an impersonation "session" look like in the data model?** Two
+   options: swap the admin's session for a new one, or carry two sessions in
+   parallel.
+2. **How does a downstream API distinguish "alice clicked submit" from
+   "admin acting as alice clicked submit"?** Standard JWT shapes do not encode
+   delegation; the access token's `sub` is just a user id.
+3. **What does "stop impersonating" mean when the admin's own session has
+   expired in the meantime?**
+
+## Decision
+
+**Parallel sessions, not a swap.** When an admin starts impersonation, a new
+`sessions` row is created with `user_id = target_user_id` and a new column
+`impersonator_session_id` pointing back to the admin's own session row. The
+admin's session is untouched. The browser holds two cookies: `AdminSession`
+(path-scoped to `/admin/*`) and `PortalSession` (path-scoped to `/`). Both
+are independently valid; the admin can navigate `/admin/*` in one tab while
+acting as the target user in another.
+
+**RFC 8693 `act` claim for delegation provenance.** Access tokens and ID
+tokens issued during impersonation carry a nested `act` claim:
+
+```json
+{
+  "sub": "<impersonated-user-id>",
+  "act": { "sub": "<admin-user-id>" },
+  ...
+}
+```
+
+`sub` remains the impersonated user — every existing resource server that
+authorizes on `sub` continues to work without changes. The `act.sub` is the
+acting admin, available to any consumer that wants to attribute or filter.
+`TokenPort.issueUserTokens` gains an optional `actingSubject: UserId?` and
+`JwtTokenAdapter` stamps the claim only when it is non-null; the normal
+token shape is preserved for every non-impersonated flow.
+
+**Cascade revocation at the repository layer.** When the admin's own session
+row is revoked — through logout, `revokeAllForUser`, or any other path —
+`SessionRepository.revoke()` and `revokeAllForUser()` also revoke every
+active impersonation child whose `impersonator_session_id` matches. The
+cascade lives in the repository, not at every call site, because the
+invariant "no impersonation session outlives its admin session" must hold
+regardless of which path triggered the parent revocation.
+
+## Alternatives considered
+
+**Session swap (rejected).** Replace the admin's session cookie with a new
+one for the target user; restore the admin session on "stop." This is what
+some IAM products do. We rejected it for two reasons. First, it creates an
+orphan-state problem: if the admin's session expires mid-impersonation, the
+restore-path has nothing to restore to, and the admin gets bounced to login
+with no obvious recovery. Second, it is hostile to the multi-tab workflow —
+an admin investigating a user's experience often wants to keep the admin
+console open alongside the impersonated view.
+
+**`amr` claim instead of `act` (rejected).** OIDC Core defines
+`amr` (Authentication Methods References) and an admin could conceivably add
+`"impersonation"` to that array. `amr` describes *how* the user
+authenticated, not *who* is acting on their behalf. RFC 8693's `act` claim
+exists precisely for this case; using it preserves SCIM-style delegation
+semantics that downstream tools may already understand.
+
+**Custom flat claim like `acting_admin_id` (rejected).** A flat claim is
+simpler to consume but is not standard, encodes only the id (no room for
+nested attributes like `act.iss` if we ever federate impersonation), and
+would have to be invented per-tenant. RFC 8693 already standardised the
+shape — there is no upside to diverging.
+
+**No cascade — let impersonation sessions expire naturally (rejected).**
+Impersonation tokens have the same lifetime as normal sessions. Without
+cascade, an admin logging out leaves valid impersonation tokens in the wild
+for up to the token lifetime. That is a dangling-privilege gap and the
+opposite of least-privilege.
+
+## Consequences
+
+**Positive:**
+
+- The admin shell survives an impersonation session ending — no
+  re-authentication required.
+- Downstream APIs that verify Kotauth tokens see standard OIDC tokens with a
+  nested `act` claim; consumers can opt in to delegation-aware logic without
+  any breaking change to the existing claim shape.
+- Cascade revocation is enforced at one layer (the repo), so adding a new
+  admin-logout path in the future cannot accidentally leave impersonation
+  tokens valid.
+- Audit attribution is complete: every action performed during impersonation
+  carries `act.sub` on its token, and the `ADMIN_IMPERSONATION_STARTED` event
+  records `admin_user_id`, `admin_username`, `target_user_id`,
+  `target_username`, `admin_session_id`, and `impersonation_session_id`.
+
+**Negative:**
+
+- Two cookies coexist in the same browser, which is a slightly larger surface
+  area than a single-cookie design. Path-scoping prevents cross-contamination
+  but new admin routes must be careful to live under `/admin/*` so they
+  receive the `AdminSession` cookie rather than the `PortalSession`.
+- The portal UI must explicitly guard destructive self-service actions
+  ("Delete account", "Change password") to refuse during impersonation. The
+  banner is the user-visible cue; the route handlers also return 403. Belt
+  and suspenders, because the consequence of forgetting one is a real-data
+  mutation by the wrong actor.
+- `client_default_roles` (v1.11.0) and any other future feature that fires
+  on registration cannot fire on impersonation — the impersonated user is
+  not "registering," they are being acted on. So far this has not required
+  a special case, but new "first-time setup" flows need to consider it.
+
+## References
+
+- RFC 8693 §4.1 — `act` claim shape
+- V41 migration: `impersonator_session_id` on `sessions`
+- `ImpersonationService`, `JwtTokenAdapter`, `SessionRepository`

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
@@ -124,6 +124,7 @@ class PostgresTenantRepository(
                     it[corsAllowCredentials] = tenant.securityConfig.corsAllowCredentials
                     it[hibpCheckEnabled] = tenant.securityConfig.hibpCheckEnabled
                     it[magicLinkEnabled] = tenant.securityConfig.magicLinkEnabled
+                    it[magicLinkTokenTtlMinutes] = tenant.securityConfig.magicLinkTokenTtlMinutes
                     it[passwordLoginEnabled] = tenant.securityConfig.passwordLoginEnabled
                 }
             if (updatedRows == 0) {
@@ -142,6 +143,7 @@ class PostgresTenantRepository(
                     it[corsAllowCredentials] = tenant.securityConfig.corsAllowCredentials
                     it[hibpCheckEnabled] = tenant.securityConfig.hibpCheckEnabled
                     it[magicLinkEnabled] = tenant.securityConfig.magicLinkEnabled
+                    it[magicLinkTokenTtlMinutes] = tenant.securityConfig.magicLinkTokenTtlMinutes
                     it[passwordLoginEnabled] = tenant.securityConfig.passwordLoginEnabled
                 }
             }
@@ -223,6 +225,7 @@ class PostgresTenantRepository(
             corsAllowCredentials = this[TenantSecurityConfigTable.corsAllowCredentials],
             hibpCheckEnabled = this[TenantSecurityConfigTable.hibpCheckEnabled],
             magicLinkEnabled = this[TenantSecurityConfigTable.magicLinkEnabled],
+            magicLinkTokenTtlMinutes = this[TenantSecurityConfigTable.magicLinkTokenTtlMinutes],
             passwordLoginEnabled = this[TenantSecurityConfigTable.passwordLoginEnabled],
         )
     }

--- a/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
@@ -26,6 +26,7 @@ object TenantSecurityConfigTable : Table("tenant_security_config") {
     val corsAllowCredentials = bool("cors_allow_credentials").default(false)
     val hibpCheckEnabled = bool("hibp_check_enabled").default(false)
     val magicLinkEnabled = bool("magic_link_enabled").default(false)
+    val magicLinkTokenTtlMinutes = integer("magic_link_token_ttl_minutes").default(15)
     val passwordLoginEnabled = bool("password_login_enabled").default(true)
     val createdAt = timestampWithTimeZone("created_at")
     val updatedAt = timestampWithTimeZone("updated_at")

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -256,8 +256,12 @@ object EnglishStrings {
     const val AUTH_METHODS_MAGIC_LINK_LABEL = "Allow sign-in via email magic link"
     const val AUTH_METHODS_MAGIC_LINK_DESC =
         "Users can request a one-time sign-in link delivered to their email. " +
-            "Links expire in 15 minutes and are single-use. MFA still required " +
-            "when enrolled. Requires SMTP to be configured."
+            "Links are single-use and expire after the window set below. MFA still " +
+            "required when enrolled. Requires SMTP to be configured."
+    const val AUTH_METHODS_MAGIC_LINK_TTL_LABEL = "Magic link expiry"
+    const val AUTH_METHODS_MAGIC_LINK_TTL_HINT =
+        "Minutes before a magic link expires. 1–1440 (default 15). " +
+            "Raise it for slow corporate mail relays; lower it for high-assurance tenants."
     const val AUTH_METHODS_PASSWORDLESS_LABEL = "Require passwordless sign-in"
     const val AUTH_METHODS_PASSWORDLESS_DESC =
         "Hides the password form and rejects password-based authentication. " +

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -166,6 +166,11 @@ object EnglishStrings {
     const val IMPERSONATE_FAILED_LOCKED = "Cannot impersonate a temporarily locked user."
     const val IMPERSONATE_FAILED_GENERIC = "Could not start impersonation."
 
+    // Disabled-state tooltips on the Impersonate button
+    const val IMPERSONATE_BLOCKED_DISABLED = "Cannot impersonate a disabled user."
+    const val IMPERSONATE_BLOCKED_LOCKED = "Cannot impersonate a temporarily locked user."
+    const val IMPERSONATE_BLOCKED_PENDING = "Cannot impersonate a user who hasn't activated their account."
+
     // Invite Users feature
     const val INVITE_WELCOME_TITLE = "Welcome to"
     const val INVITE_ACCEPT_SUBTITLE = "Set a password to activate your account."

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminImpersonationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminImpersonationRoutes.kt
@@ -56,6 +56,7 @@ fun Route.adminUserImpersonationRoute(
         val result =
             impersonationService.startImpersonation(
                 adminUserId = UserId(ctx.session.userId),
+                adminUsername = ctx.session.username,
                 adminSessionId = adminSessionId,
                 targetTenantId = ctx.workspace.id,
                 targetUserId = userId,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -507,6 +507,7 @@ fun Route.adminRoutes(
                     claimMapperService = claimMapperService,
                     impersonationService = impersonationService,
                     userRepository = userRepository,
+                    auditLogRepository = auditLogRepository,
                 )
 
                 adminSessionAuditRoutes(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -322,6 +322,9 @@ fun Route.adminSettingsRoutes(
                     corsAllowCredentials = params["corsAllowCredentials"] == "true",
                     hibpCheckEnabled = params["hibpCheckEnabled"] == "true",
                     magicLinkEnabled = params["magicLinkEnabled"] == "true",
+                    magicLinkTokenTtlMinutes =
+                        params["magicLinkTokenTtlMinutes"]?.toIntOrNull()
+                            ?: workspace.securityConfig.magicLinkTokenTtlMinutes,
                     passwordLoginEnabled = params["requirePasswordless"] != "true",
                 )
         ) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -1,7 +1,9 @@
 package com.kauth.adapter.web.admin
 
 import com.kauth.adapter.web.EnglishStrings
+import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.UserId
+import com.kauth.domain.port.AuditLogRepository
 import com.kauth.domain.port.SessionRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.service.AdminResult
@@ -31,6 +33,7 @@ fun Route.adminUserRoutes(
     claimMapperService: CachingClaimMapperService,
     impersonationService: ImpersonationService? = null,
     userRepository: UserRepository? = null,
+    auditLogRepository: AuditLogRepository? = null,
 ) {
     route("/users") {
         get {
@@ -170,6 +173,22 @@ fun Route.adminUserRoutes(
                     } else {
                         null
                     }
+                val recentImpersonations =
+                    auditLogRepository?.let { repo ->
+                        repo
+                            .findByTenant(
+                                ctx.workspace.id,
+                                AuditEventType.ADMIN_IMPERSONATION_STARTED,
+                                limit = 200,
+                            ).filter { it.details["target_user_id"] == userId.value.toString() }
+                            .take(5)
+                            .map {
+                                ImpersonationRecord(
+                                    adminUsername = it.details["admin_username"].orEmpty().ifBlank { "—" },
+                                    startedAt = it.createdAt,
+                                )
+                            }
+                    } ?: emptyList()
                 call.respondHtml(
                     HttpStatusCode.OK,
                     AdminView.userDetailPage(
@@ -185,6 +204,7 @@ fun Route.adminUserRoutes(
                         userAttributes = attributes,
                         mappedKeys = mappedKeys,
                         tempPasswordLink = tempPasswordLink,
+                        recentImpersonations = recentImpersonations,
                     ),
                 )
             }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -177,6 +177,7 @@ object AdminView {
         mappedKeys: Map<String, String> = emptyMap(),
         attributeError: String? = null,
         tempPasswordLink: String? = null,
+        recentImpersonations: List<ImpersonationRecord> = emptyList(),
     ): HTML.() -> Unit =
         userDetailPageImpl(
             workspace,
@@ -192,6 +193,7 @@ object AdminView {
             mappedKeys,
             attributeError,
             tempPasswordLink,
+            recentImpersonations,
         )
 
     fun userAttributeFormPage(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -197,19 +197,25 @@ internal fun auditLogPageImpl(
                                 selected = (eventTypeFilter == null)
                                 +"All events"
                             }
+                            // Order matters — each event lands in the first group it
+                            // matches, so "Impersonation" must precede "Admin Actions"
+                            // to claim the ADMIN_IMPERSONATION_* events.
                             val groups = linkedMapOf(
                                 "Login & Registration" to listOf("LOGIN_", "REGISTER_", "ACCOUNT_"),
                                 "Tokens & Authorization" to listOf("TOKEN_", "AUTHORIZATION_CODE_"),
                                 "Sessions" to listOf("SESSION_"),
+                                "Impersonation" to listOf("ADMIN_IMPERSONATION_"),
                                 "Admin Actions" to listOf("ADMIN_"),
                                 "Email & Password" to listOf("EMAIL_", "PASSWORD_"),
                                 "User Self-Service" to listOf("USER_"),
                                 "MFA" to listOf("MFA_"),
                             )
+                            val assignedTypes = mutableSetOf<AuditEventType>()
                             groups.forEach { (groupLabel, prefixes) ->
                                 val types = AuditEventType.entries.filter { t ->
-                                    prefixes.any { t.name.startsWith(it) }
+                                    t !in assignedTypes && prefixes.any { t.name.startsWith(it) }
                                 }
+                                assignedTypes.addAll(types)
                                 if (types.isNotEmpty()) {
                                     optGroup(groupLabel) {
                                         types.forEach { type ->

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -9,8 +9,15 @@ import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.User
 import kotlinx.html.*
+import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+
+/** One row in the user-detail "Recent impersonations" panel. */
+data class ImpersonationRecord(
+    val adminUsername: String,
+    val startedAt: Instant,
+)
 
 internal fun userDetailPageImpl(
     workspace: Tenant,
@@ -32,6 +39,7 @@ internal fun userDetailPageImpl(
      * slot is empty and the panel is gone.
      */
     tempPasswordLink: String? = null,
+    recentImpersonations: List<ImpersonationRecord> = emptyList(),
 ): HTML.() -> Unit =
     {
         adminShell(
@@ -125,18 +133,32 @@ internal fun userDetailPageImpl(
                         attributes["hx-swap"] = "outerHTML"
                         +"Edit Profile"
                     }
-                    if (
-                        !workspace.isMaster &&
-                        user.enabled &&
-                        !user.isLocked &&
-                        RequiredAction.SET_PASSWORD !in user.requiredActions
-                    ) {
-                        postButton(
-                            action = "/admin/workspaces/${workspace.slug}/users/${user.id?.value}/impersonate",
-                            label = EnglishStrings.IMPERSONATE_BUTTON,
-                            btnClass = "btn btn--primary",
-                            confirmMessage = EnglishStrings.IMPERSONATE_CONFIRM,
-                        )
+                    if (!workspace.isMaster) {
+                        val impersonateBlockedReason =
+                            when {
+                                !user.enabled -> EnglishStrings.IMPERSONATE_BLOCKED_DISABLED
+                                user.isLocked -> EnglishStrings.IMPERSONATE_BLOCKED_LOCKED
+                                RequiredAction.SET_PASSWORD in user.requiredActions ->
+                                    EnglishStrings.IMPERSONATE_BLOCKED_PENDING
+                                else -> null
+                            }
+                        if (impersonateBlockedReason == null) {
+                            postButton(
+                                action =
+                                    "/admin/workspaces/${workspace.slug}/users/${user.id?.value}/impersonate",
+                                label = EnglishStrings.IMPERSONATE_BUTTON,
+                                btnClass = "btn btn--primary",
+                                confirmMessage = EnglishStrings.IMPERSONATE_CONFIRM,
+                            )
+                        } else {
+                            span("tooltip-wrap") {
+                                attributes["data-tooltip"] = impersonateBlockedReason
+                                button(classes = "btn btn--primary") {
+                                    disabled = true
+                                    +EnglishStrings.IMPERSONATE_BUTTON
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -250,6 +272,29 @@ internal fun userDetailPageImpl(
                                             )
                                         }
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Recent impersonations ────────────────────────────────
+            if (recentImpersonations.isNotEmpty()) {
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Recent Impersonations" }
+                    table("data-table") {
+                        thead {
+                            tr {
+                                th { +"Admin" }
+                                th { +"Started" }
+                            }
+                        }
+                        tbody {
+                            recentImpersonations.forEach { record ->
+                                tr {
+                                    td { span("data-table__name") { +record.adminUsername } }
+                                    td { +record.startedAt.toDisplayString() }
                                 }
                             }
                         }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -832,6 +832,18 @@ internal fun securityPolicyPageImpl(
                             span("check-row__desc") { +EnglishStrings.AUTH_METHODS_MAGIC_LINK_DESC }
                         }
                     }
+                    div("edit-row") {
+                        span("edit-row__label") { +EnglishStrings.AUTH_METHODS_MAGIC_LINK_TTL_LABEL }
+                        div {
+                            input(type = InputType.number, name = "magicLinkTokenTtlMinutes") {
+                                classes = setOf("edit-row__field", "edit-row__field--mono")
+                                attributes["min"] = "1"
+                                attributes["max"] = "1440"
+                                value = workspace.securityConfig.magicLinkTokenTtlMinutes.toString()
+                            }
+                            div("edit-row__hint") { +EnglishStrings.AUTH_METHODS_MAGIC_LINK_TTL_HINT }
+                        }
+                    }
                     label("check-row") {
                         input(type = InputType.checkBox, name = "requirePasswordless") {
                             attributes["value"] = "true"

--- a/src/main/kotlin/com/kauth/domain/model/BackupExport.kt
+++ b/src/main/kotlin/com/kauth/domain/model/BackupExport.kt
@@ -90,6 +90,9 @@ data class SecurityConfigBackup(
     val corsAllowCredentials: Boolean,
     val hibpCheckEnabled: Boolean,
     val magicLinkEnabled: Boolean,
+    // Defaulted so backups taken before these fields existed still import.
+    val magicLinkTokenTtlMinutes: Int = 15,
+    val passwordLoginEnabled: Boolean = true,
 )
 
 @Serializable

--- a/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
+++ b/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
@@ -27,6 +27,8 @@ data class SecurityConfig(
     // Breach detection — block passwords that appear in HIBP's breach corpus
     val hibpCheckEnabled: Boolean = false,
     val magicLinkEnabled: Boolean = false,
+    // Magic-link expiry window, in minutes. Range 1-1440 enforced at the service layer.
+    val magicLinkTokenTtlMinutes: Int = 15,
     // Disabling password login affects only the password flow; magic-link and
     // social providers are governed by their own per-tenant config.
     val passwordLoginEnabled: Boolean = true,

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -141,6 +141,7 @@ class AdminService(
         corsAllowCredentials: Boolean = false,
         hibpCheckEnabled: Boolean = false,
         magicLinkEnabled: Boolean = false,
+        magicLinkTokenTtlMinutes: Int = 15,
         passwordLoginEnabled: Boolean = true,
     ): AdminResult<Tenant> {
         val tenant =
@@ -201,6 +202,7 @@ class AdminService(
                         corsAllowCredentials = corsAllowCredentials,
                         hibpCheckEnabled = hibpCheckEnabled,
                         magicLinkEnabled = magicLinkEnabled,
+                        magicLinkTokenTtlMinutes = magicLinkTokenTtlMinutes.coerceIn(1, 1440),
                         passwordLoginEnabled = passwordLoginEnabled,
                     ),
             )

--- a/src/main/kotlin/com/kauth/domain/service/BackupExporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupExporterService.kt
@@ -111,6 +111,8 @@ class BackupExporterService(
                             corsAllowCredentials = corsAllowCredentials,
                             hibpCheckEnabled = hibpCheckEnabled,
                             magicLinkEnabled = magicLinkEnabled,
+                            magicLinkTokenTtlMinutes = magicLinkTokenTtlMinutes,
+                            passwordLoginEnabled = passwordLoginEnabled,
                         )
                     },
                 theme =

--- a/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
@@ -148,6 +148,8 @@ class BackupImporterService(
                             corsAllowCredentials = corsAllowCredentials,
                             hibpCheckEnabled = hibpCheckEnabled,
                             magicLinkEnabled = magicLinkEnabled,
+                            magicLinkTokenTtlMinutes = magicLinkTokenTtlMinutes,
+                            passwordLoginEnabled = passwordLoginEnabled,
                         )
                     },
                 smtpHost = tb.smtp.host,

--- a/src/main/kotlin/com/kauth/domain/service/ImpersonationService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ImpersonationService.kt
@@ -50,6 +50,7 @@ class ImpersonationService(
      */
     fun startImpersonation(
         adminUserId: UserId,
+        adminUsername: String,
         adminSessionId: SessionId,
         targetTenantId: TenantId,
         targetUserId: UserId,
@@ -126,6 +127,7 @@ class ImpersonationService(
                     mapOf(
                         "target_user_id" to target.id!!.value.toString(),
                         "target_username" to target.username,
+                        "admin_username" to adminUsername,
                         "admin_session_id" to adminSessionId.value.toString(),
                         "impersonation_session_id" to saved.id!!.value.toString(),
                     ),

--- a/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserSelfServiceService.kt
@@ -992,13 +992,14 @@ class UserSelfServiceService(
 
         val (rawToken, tokenHash) = generateToken()
 
+        val ttlMinutes = tenant.securityConfig.magicLinkTokenTtlMinutes.coerceIn(1, 1440)
         prTokenRepo.deleteByUserAndPurpose(user.id!!, TokenPurpose.MAGIC_LINK)
         prTokenRepo.create(
             PasswordResetToken(
                 userId = user.id,
                 tenantId = tenant.id,
                 tokenHash = tokenHash,
-                expiresAt = Instant.now().plusSeconds(MAGIC_LINK_TTL_SECONDS),
+                expiresAt = Instant.now().plusSeconds(ttlMinutes * 60L),
                 purpose = TokenPurpose.MAGIC_LINK,
                 ipAddress = ipAddress,
             ),
@@ -1027,6 +1028,7 @@ class UserSelfServiceService(
                 eventType = AuditEventType.MAGIC_LINK_REQUESTED,
                 ipAddress = ipAddress,
                 userAgent = null,
+                details = mapOf("ttl_minutes" to ttlMinutes.toString()),
             ),
         )
 
@@ -1105,11 +1107,6 @@ class UserSelfServiceService(
         )
 
         return SelfServiceResult.Success(userRepository.findById(token.userId, token.tenantId)!!)
-    }
-
-    companion object {
-        /** Magic-link validity window. 15 minutes is standard — single click, not a password form. */
-        const val MAGIC_LINK_TTL_SECONDS: Long = 15L * 60L
     }
 }
 

--- a/src/main/resources/db/migration/V44__magic_link_token_ttl.sql
+++ b/src/main/resources/db/migration/V44__magic_link_token_ttl.sql
@@ -1,0 +1,9 @@
+-- V44: Per-tenant magic-link token TTL.
+--
+-- Magic-link expiry was a hardcoded 15 minutes. High-assurance tenants may
+-- want shorter links; tenants on slow corporate mail relays may need longer
+-- to avoid expiry-before-delivery. Range 1-1440 minutes is enforced at the
+-- service layer (AdminService.updateWorkspaceSettings).
+
+ALTER TABLE tenant_security_config
+    ADD COLUMN magic_link_token_ttl_minutes INTEGER NOT NULL DEFAULT 15;

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -1057,6 +1057,7 @@ class AdminServiceTest {
         passwordPolicyRequireSpecial: Boolean = false,
         mfaPolicy: String = "optional",
         magicLinkEnabled: Boolean = false,
+        magicLinkTokenTtlMinutes: Int = 15,
         passwordLoginEnabled: Boolean = true,
     ) = svc.updateWorkspaceSettings(
         slug = slug,
@@ -1070,8 +1071,24 @@ class AdminServiceTest {
         passwordPolicyRequireSpecial = passwordPolicyRequireSpecial,
         mfaPolicy = mfaPolicy,
         magicLinkEnabled = magicLinkEnabled,
+        magicLinkTokenTtlMinutes = magicLinkTokenTtlMinutes,
         passwordLoginEnabled = passwordLoginEnabled,
     )
+
+    @Test
+    fun `updateWorkspaceSettings coerces magic-link TTL into the 1 to 1440 range`() {
+        val tooHigh = callUpdateSettings(magicLinkTokenTtlMinutes = 99_999)
+        assertIs<AdminResult.Success<Tenant>>(tooHigh)
+        assertEquals(1440, tooHigh.value.securityConfig.magicLinkTokenTtlMinutes)
+
+        val tooLow = callUpdateSettings(magicLinkTokenTtlMinutes = 0)
+        assertIs<AdminResult.Success<Tenant>>(tooLow)
+        assertEquals(1, tooLow.value.securityConfig.magicLinkTokenTtlMinutes)
+
+        val inRange = callUpdateSettings(magicLinkTokenTtlMinutes = 45)
+        assertIs<AdminResult.Success<Tenant>>(inRange)
+        assertEquals(45, inRange.value.securityConfig.magicLinkTokenTtlMinutes)
+    }
 
     // =========================================================================
     // Password-login toggle — passwordless-only enforcement

--- a/src/test/kotlin/com/kauth/domain/service/ImpersonationServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ImpersonationServiceTest.kt
@@ -106,6 +106,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = customerTenant.id,
                 targetUserId = target.id!!,
@@ -125,6 +126,7 @@ class ImpersonationServiceTest {
     fun `startImpersonation passes admin id as actingSubject so tokens carry the act claim`() {
         service.startImpersonation(
             adminUserId = admin.id!!,
+            adminUsername = admin.username,
             adminSessionId = adminSession.id!!,
             targetTenantId = customerTenant.id,
             targetUserId = target.id!!,
@@ -138,6 +140,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = customerTenant.id,
                 targetUserId = target.id!!,
@@ -149,6 +152,7 @@ class ImpersonationServiceTest {
         assertEquals(customerTenant.id, event.tenantId)
         assertEquals(target.id!!.value.toString(), event.details["target_user_id"])
         assertEquals(target.username, event.details["target_username"])
+        assertEquals(admin.username, event.details["admin_username"])
         assertEquals(adminSession.id!!.value.toString(), event.details["admin_session_id"])
         val sessionId = (result as AdminResult.Success).value.impersonationSessionId
         assertEquals(sessionId.value.toString(), event.details["impersonation_session_id"])
@@ -170,6 +174,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = masterTenant.id,
                 targetUserId = masterUser.id!!,
@@ -190,6 +195,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = otherTenant.id,
                 targetUserId = target.id!!,
@@ -209,6 +215,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = customerTenant.id,
                 targetUserId = disabled.id!!,
@@ -233,6 +240,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = customerTenant.id,
                 targetUserId = locked.id!!,
@@ -249,6 +257,7 @@ class ImpersonationServiceTest {
         val result =
             service.startImpersonation(
                 adminUserId = admin.id!!,
+                adminUsername = admin.username,
                 adminSessionId = adminSession.id!!,
                 targetTenantId = customerTenant.id,
                 targetUserId = target.id!!,
@@ -264,6 +273,7 @@ class ImpersonationServiceTest {
             (
                 service.startImpersonation(
                     adminUserId = admin.id!!,
+                    adminUsername = admin.username,
                     adminSessionId = adminSession.id!!,
                     targetTenantId = customerTenant.id,
                     targetUserId = target.id!!,
@@ -290,6 +300,7 @@ class ImpersonationServiceTest {
             (
                 service.startImpersonation(
                     adminUserId = admin.id!!,
+                    adminUsername = admin.username,
                     adminSessionId = adminSession.id!!,
                     targetTenantId = customerTenant.id,
                     targetUserId = target.id!!,
@@ -325,6 +336,7 @@ class ImpersonationServiceTest {
             (
                 service.startImpersonation(
                     adminUserId = admin.id!!,
+                    adminUsername = admin.username,
                     adminSessionId = adminSession.id!!,
                     targetTenantId = customerTenant.id,
                     targetUserId = target.id!!,
@@ -345,6 +357,7 @@ class ImpersonationServiceTest {
             (
                 service.startImpersonation(
                     adminUserId = admin.id!!,
+                    adminUsername = admin.username,
                     adminSessionId = adminSession.id!!,
                     targetTenantId = customerTenant.id,
                     targetUserId = target.id!!,
@@ -364,6 +377,7 @@ class ImpersonationServiceTest {
             (
                 service.startImpersonation(
                     adminUserId = admin.id!!,
+                    adminUsername = admin.username,
                     adminSessionId = adminSession.id!!,
                     targetTenantId = customerTenant.id,
                     targetUserId = target.id!!,

--- a/src/test/kotlin/com/kauth/domain/service/MagicLinkTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/MagicLinkTest.kt
@@ -1,5 +1,6 @@
 package com.kauth.domain.service
 
+import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.PasswordResetToken
 import com.kauth.domain.model.RequiredAction
 import com.kauth.domain.model.SecurityConfig
@@ -146,6 +147,54 @@ class MagicLinkTest {
         svc.initiateMagicLink("alice@acme.com", "acme", "http://localhost:8080", null)
         val tokens = prTokenRepo.all().filter { it.purpose == TokenPurpose.MAGIC_LINK }
         assertEquals(1, tokens.size, "Second request must supersede the first")
+    }
+
+    @Test
+    fun `initiate honors the tenant's configured magic-link TTL`() {
+        tenants.clear()
+        tenants.add(
+            enabledTenant.copy(
+                securityConfig = SecurityConfig(magicLinkEnabled = true, magicLinkTokenTtlMinutes = 45),
+            ),
+        )
+
+        val before = java.time.Instant.now()
+        svc.initiateMagicLink("alice@acme.com", "acme", "http://localhost:8080", null)
+        val token = prTokenRepo.all().single { it.purpose == TokenPurpose.MAGIC_LINK }
+
+        val ttlSeconds =
+            java.time.Duration
+                .between(before, token.expiresAt)
+                .seconds
+        assertTrue(ttlSeconds in 2640..2760, "Expiry should be ~45 minutes out, was ${ttlSeconds}s")
+    }
+
+    @Test
+    fun `initiate defaults to a 15-minute TTL when not configured`() {
+        val before = java.time.Instant.now()
+        svc.initiateMagicLink("alice@acme.com", "acme", "http://localhost:8080", null)
+        val token = prTokenRepo.all().single { it.purpose == TokenPurpose.MAGIC_LINK }
+
+        val ttlSeconds =
+            java.time.Duration
+                .between(before, token.expiresAt)
+                .seconds
+        assertTrue(ttlSeconds in 840..960, "Expiry should be ~15 minutes out, was ${ttlSeconds}s")
+    }
+
+    @Test
+    fun `initiate records the TTL on the MAGIC_LINK_REQUESTED audit event`() {
+        tenants.clear()
+        tenants.add(
+            enabledTenant.copy(
+                securityConfig = SecurityConfig(magicLinkEnabled = true, magicLinkTokenTtlMinutes = 30),
+            ),
+        )
+
+        svc.initiateMagicLink("alice@acme.com", "acme", "http://localhost:8080", null)
+
+        val event = auditLog.events.single { it.eventType == AuditEventType.MAGIC_LINK_REQUESTED }
+        assertEquals("30", event.details["ttl_minutes"])
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

This pull request delivers a "polish" release focused on closing out smaller backlog items, improving impersonation discoverability, fixing a backup/restore bug, and enhancing the developer experience. Notable changes include making the magic-link token expiry configurable per tenant, improving auditability and discoverability of impersonation events, and adding a fast local development workflow. Below are the most important grouped changes:

**Authentication & Security Improvements:**

* Added a per-tenant configurable magic-link token TTL (`magicLinkTokenTtlMinutes`), replacing the previous global constant. The expiry window can now be set in workspace Security settings (1–1440 minutes, default 15), and the applied TTL is recorded in the `MAGIC_LINK_REQUESTED` audit event. Database and repository layers updated to support this. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R127) [[3]](diffhunk://#diff-fb39c7bef8ec3227338925b11cf788d9fe90dfacf1625079a995fd5be441f9a9R29) [[4]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R146) [[5]](diffhunk://#diff-6a31941b984901583b4ed949be0d7d450cbafd032efc417a2a1175dae819c357R228) [[6]](diffhunk://#diff-47522b97f4d91fde53545fd9aa82e27e26d7aacc6d897fdb124b708a0fa9d604R325-R327)
* Fixed backup/restore to correctly persist and restore the `passwordLoginEnabled` and new `magicLinkTokenTtlMinutes` fields, preventing silent fallback to password-enabled after restore.

**Impersonation Discoverability & Auditability:**

* Added a dedicated "Impersonation" filter group in the workspace audit log UI, making it easy to filter impersonation events.
* Added a "Recent Impersonations" panel to the admin user-detail page, showing the last 5 impersonations of a user, including admin username and timestamp, sourced from the audit log. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-aeca734722e7420f7bd61665c002068c3e98b5a4a1c6095c7927a0c5ef0a418dR4-R6) [[3]](diffhunk://#diff-aeca734722e7420f7bd61665c002068c3e98b5a4a1c6095c7927a0c5ef0a418dR36) [[4]](diffhunk://#diff-aeca734722e7420f7bd61665c002068c3e98b5a4a1c6095c7927a0c5ef0a418dR176-R191) [[5]](diffhunk://#diff-47ca0b2d6fd5ee5ddea10c04029f555bf500d4d81a24e409c29de75433d3e04dR510)
* The `ADMIN_IMPERSONATION_STARTED` audit event now records the admin's username in addition to their user id, enabling easier attribution in logs and UI. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-c096b013f569bdea0c0f0aafa50de4fc47d45a4985afe03c8b37e4cf6951f237R59)

**User Interface Enhancements:**

* The "Impersonate user" button is now shown disabled (with context-specific tooltip) rather than hidden when impersonation is not allowed (e.g., user is disabled, locked, or pending invite), improving discoverability for admins. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-6c98636927c5832ede822a5b4efc36cd44bc0c0e3dcffbdccf0ad563ceba0731R169-R173)
* Updated magic-link-related admin UI copy to reference the new configurable TTL and added supporting hints and labels.

**Developer Experience:**

* Introduced a new `make run` target for a faster local development loop: starts only `db` and `redis` in Docker and runs the app locally, avoiding full Docker rebuilds on every code change. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R82-R100)
* Added a maintainer note to the quickstart Docker Compose file to clarify its update process and purpose.

**Documentation:**

* Added ADR-14, documenting the admin impersonation session model, token shapes, and revocation strategy for future maintainers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R90) [[2]](diffhunk://#diff-5fb1f9a8c207d58d5d997ec9e213401406d59f2218808eaaa75a5ec744ed81efR1-R131)

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
