### PR TITLE
v1.12.1:polish-bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ would have failed in Postgres at boot for any tenant slug ≥ 3 chars.
   longer save a client with zero redirect URIs. Previously the surface
   showed up only at use-time as a 422 `invalid_client` from verify-otp.
   ADR-15 follow-up
+- **`EMAIL_OTP_SENT` audit detail no longer carries `source=admin_api`** —
+  the OTP send path isn't admin-API-exclusive (v1.13 hosted page will
+  share the code). A `source=admin_api` filter for compliance would have
+  produced false positives
 
 ### Added
 
@@ -59,13 +63,30 @@ would have failed in Postgres at boot for any tenant slug ≥ 3 chars.
   `AuthService`, `SocialLoginService`, `*Views`, and the test suite —
   build output is now warning-free except for the unrelated Ktor
   `Principal` deprecation
+- **`ServiceGraph` rate-limiter wiring** — 6 nearly-identical
+  Redis-or-in-memory blocks collapse to a `buildRateLimiter(max,
+  windowSecs, prefix)` factory
+- **`EMAIL_OTP_*` audit events get coloured badges** — verified is green,
+  rejected and lockout are red. Default neutral was misleading
 
 ### Notes
 
-- 1 new regression test (`default keyPrefix fits the 16-char column
-  ceiling for any tenant slug`)
-- 1 new service test (`updateApplication - rejects when redirect URIs
-  is empty`)
+- New regression and coverage tests:
+  - `default keyPrefix fits the 16-char column ceiling for any tenant slug`
+  - `updateApplication - rejects when redirect URIs is empty`
+  - `sendOtp swallows SMTP failure but still records the audit event`
+  - `verifyOtp on the stale handle after resend returns InvalidOtp`
+  - 4 `updateEmailBranding` validation paths (hex, support email, NotFound,
+    persisted sanitised fields)
+  - `updateEmailBranding is a soft no-op when the repository is not wired`
+  - `import preserves OTP security config fields and email branding`
+    (closes the v1.12.0 backup round-trip blind spot)
+  - `verify-otp rejects a challenge from a different tenant`
+  - Content-Type problem+json header assertion on the wrong-code path
+- ADR-15 follow-ups noted in code: PKCE-bypass rationale + scope-derivation
+  TODO on `EmailOtpService.issueAuthorizationCodeFor`; future-split TODO on
+  `AdminService` (`WorkspaceSettings` / `AdminUser` / `ApplicationManagement`
+  earmarked for v1.13)
 - Next: **v1.13.0** ships the hosted login-page Email OTP — same
   `EmailOtpService` consumer-agnostic core, plus the auth-page views
   and challenge-id session-state for the browser-driven flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.12.1] - 2026-05-26
+
+Polish release closing the ADR-15 follow-ups, the UX-review deferred items,
+and the OTP observability gaps before v1.13.0 hosted-page work begins.
+Also fixes a `keyPrefix` overflow bug in the v1.12.0 bootstrap path that
+would have failed in Postgres at boot for any tenant slug ≥ 3 chars.
+
+### Fixed
+
+- **`KAUTH_BOOTSTRAP_API_KEYS` default `keyPrefix` overflowed the
+  `api_keys.key_prefix` `VARCHAR(16)` column** — the v1.12.0 default
+  `"kauth_${slug}_bootstrap"` produced strings up to 20 chars. Failed
+  silently in the in-memory fake and only surfaced against Postgres at
+  boot. Default now truncates to fit; the fake repository enforces the
+  16-char ceiling so the regression class is caught at test time
+- **Redirect-URI presence validated at client save** — admins can no
+  longer save a client with zero redirect URIs. Previously the surface
+  showed up only at use-time as a 422 `invalid_client` from verify-otp.
+  ADR-15 follow-up
+
+### Added
+
+- **OpenAPI spec covers the OTP endpoints + new scopes** — `/auth/send-otp`
+  and `/auth/verify-otp` documented with request/response schemas,
+  status codes (202 / 200 / 410 / 422 / 429), and the `auth:send-otp` /
+  `auth:verify-otp` scopes. The `/api/docs` Swagger page is now complete
+- **"Email OTP" audit-log filter group** — `EMAIL_OTP_*` events get
+  their own optgroup in the workspace audit log dropdown, before the
+  generic "Email & Password" group. Same first-match-wins pattern v1.11.1
+  used for the "Impersonation" group
+- **"Recent OTP activity" panel on the admin user-detail page** — mirrors
+  the "Recent Impersonations" panel from v1.11.1. Shows last 5
+  `EMAIL_OTP_SENT/VERIFIED/REJECTED/LOCKOUT` events for the user
+- **SMTP-not-configured signal for OTP** — sends now log a WARN with
+  tenant slug + email + exception class when delivery fails. The admin
+  Security settings card warns operators when the OTP signup toggle is
+  enabled against an SMTP-unready tenant
+
+### Changed
+
+- **Auth Methods card reorders so the magic-link and OTP pairs stay
+  grouped** — the passwordless-only toggle moves to the bottom of the
+  card. It governs the whole password channel, not magic links
+  specifically, so sandwiching it between the two passwordless rows
+  was misleading
+- **Bootstrap API key rows use an inline info icon with `aria-label`** —
+  replaces the title-only tooltip on "Env-managed" that wasn't
+  discoverable on keyboard or touch
+- **33 `Unnecessary non-null assertion` compiler warnings cleared** across
+  `AuthService`, `SocialLoginService`, `*Views`, and the test suite —
+  build output is now warning-free except for the unrelated Ktor
+  `Principal` deprecation
+
+### Notes
+
+- 1 new regression test (`default keyPrefix fits the 16-char column
+  ceiling for any tenant slug`)
+- 1 new service test (`updateApplication - rejects when redirect URIs
+  is empty`)
+- Next: **v1.13.0** ships the hosted login-page Email OTP — same
+  `EmailOtpService` consumer-agnostic core, plus the auth-page views
+  and challenge-id session-state for the browser-driven flow
+
+---
+
 ## [1.12.0] - 2026-05-25
 
 Three agnostic IAM primitives driven by the second round of Zion-onboarding

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.12.0"
+version = "1.12.1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/frontend/css/components/check-row.css
+++ b/frontend/css/components/check-row.css
@@ -92,3 +92,11 @@
   color: var(--color-subtle);
   line-height: 1.5;
 }
+
+.check-row__warn {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--color-amber);
+  line-height: 1.5;
+}

--- a/frontend/css/components/empty-state.css
+++ b/frontend/css/components/empty-state.css
@@ -28,6 +28,12 @@
   gap: var(--space-2);
 }
 
+.ov-card .empty-state {
+  border: none;
+  background: transparent;
+  padding: var(--space-6) var(--space-4);
+}
+
 .empty-state__icon {
   width: 32px;
   height: 32px;

--- a/frontend/css/pages/user-detail.css
+++ b/frontend/css/pages/user-detail.css
@@ -104,6 +104,20 @@
   padding-top: var(--space-2);
 }
 
+.read-only-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-1);
+}
+
+.read-only-badges + .edit-row__hint a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+.read-only-badges + .edit-row__hint a:hover { text-decoration: underline; }
+
 .edit-row__field {
   background: rgba(255, 255, 255, 0.05);
   border: 0.5px solid var(--color-border-md);

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -286,6 +286,9 @@ object EnglishStrings {
         "After this many failed OTP challenges, the user is locked using the existing " +
             "lockout window above. 0 disables the cross-challenge guard (per-challenge cap " +
             "of 5 still applies)."
+    const val AUTH_METHODS_EMAIL_OTP_SMTP_WARN =
+        "SMTP is not configured for this workspace — OTP emails will fail silently until " +
+            "you configure SMTP under workspace settings."
 
     const val TOAST_BACKUP_EXPORTED = "Backup exported. Download started."
     const val TOAST_BACKUP_IMPORTED = "Workspace imported successfully."

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
@@ -71,6 +71,8 @@ fun Route.adminApplicationRoutes(
                         clientId,
                     ) -> "Client ID '$clientId' already exists."
                     name.isBlank() -> "Name is required."
+                    redirectUris.isEmpty() ->
+                        "At least one redirect URI is required. The authorization code flow needs a registered URI to bind to."
                     else -> null
                 }
             if (error != null) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -398,14 +398,15 @@ fun Route.adminSettingsRoutes(
             )
         when (val result = adminService.updateTheme(slug, theme)) {
             is AdminResult.Success -> {
+                val existingBranding = workspace.emailBranding
                 val emailBrandingResult =
                     adminService.updateEmailBranding(
                         slug,
                         com.kauth.domain.model.TenantEmailBranding(
                             tenantId = workspace.id,
-                            brandName = params["emailBrandName"],
-                            brandColorHex = params["emailBrandColor"],
-                            brandLogoUrl = params["emailBrandLogoUrl"],
+                            brandName = existingBranding?.brandName,
+                            brandColorHex = existingBranding?.brandColorHex,
+                            brandLogoUrl = existingBranding?.brandLogoUrl,
                             supportEmail = params["emailSupportEmail"],
                             fromDisplayName = params["emailFromDisplayName"],
                         ),

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -323,6 +323,8 @@ fun Route.adminUserRoutes(
                                     ctx.workspace,
                                     user,
                                     editError = result.error.message,
+                                    roles = roleGroupService.getRolesForUser(userId),
+                                    groups = roleGroupService.getGroupsForUser(userId),
                                 ),
                                 ContentType.Text.Html,
                                 HttpStatusCode.UnprocessableEntity,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -178,6 +178,7 @@ object AdminView {
         attributeError: String? = null,
         tempPasswordLink: String? = null,
         recentImpersonations: List<ImpersonationRecord> = emptyList(),
+        recentOtpActivity: List<OtpActivityRecord> = emptyList(),
     ): HTML.() -> Unit =
         userDetailPageImpl(
             workspace,
@@ -194,6 +195,7 @@ object AdminView {
             attributeError,
             tempPasswordLink,
             recentImpersonations,
+            recentOtpActivity,
         )
 
     fun userAttributeFormPage(

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -234,7 +234,9 @@ object AdminView {
         workspace: Tenant,
         user: User,
         editError: String? = null,
-    ): String = renderFragment { userProfileEditFragment(workspace, user, editError) }
+        roles: List<Role> = emptyList(),
+        groups: List<Group> = emptyList(),
+    ): String = renderFragment { userProfileEditFragment(workspace, user, editError, roles, groups) }
 
     // ── Sessions & Audit ────────────────────────────────────────────────
 

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
@@ -186,9 +186,9 @@ internal fun applicationDetailPageImpl(
                         ) { +"+ Set launcher URL" }
                     }
                 } else {
-                    ovRowMono("Launcher URL", application.launcherUrl!!, copyable = true)
+                    ovRowMono("Launcher URL", application.launcherUrl, copyable = true)
                     if (!application.iconUrl.isNullOrBlank()) {
-                        ovRowMono("Icon URL", application.iconUrl!!, copyable = true)
+                        ovRowMono("Icon URL", application.iconUrl, copyable = true)
                     } else {
                         ovRowMuted("Icon URL", "Using letter fallback")
                     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
@@ -300,7 +300,7 @@ internal fun identityProvidersPageImpl(
                             div("provider-header__name") {
                                 +prov.displayName
                                 if (isConfigured) {
-                                    val badgeCls = if (existing!!.enabled) "badge badge--active" else "badge badge--inactive"
+                                    val badgeCls = if (existing.enabled) "badge badge--active" else "badge badge--inactive"
                                     span(badgeCls) { +(if (existing.enabled) "Enabled" else "Disabled") }
                                 } else {
                                     span("badge badge--inactive") { +"Not configured" }
@@ -535,11 +535,18 @@ internal fun apiKeysListPageImpl(
                             }
                             td {
                                 when {
-                                    key.bootstrapName != null ->
-                                        span("key-table__meta") {
-                                            title = "Managed via KAUTH_BOOTSTRAP_API_KEYS \u2014 edit the env var to rotate or revoke."
-                                            +"Env-managed"
+                                    key.bootstrapName != null -> {
+                                        val bootstrapHint =
+                                            "Managed via KAUTH_BOOTSTRAP_API_KEYS \u2014 edit the env var to rotate or revoke."
+                                        span("key-table__meta key-table__meta--with-icon") {
+                                            attributes["aria-label"] = bootstrapHint
+                                            +"Env-managed "
+                                            span("inline-help") {
+                                                title = bootstrapHint
+                                                inlineSvgIcon("info", "Bootstrap key information")
+                                            }
                                         }
+                                    }
                                     key.enabled ->
                                         form(
                                             action = "/admin/workspaces/$slug/settings/api-keys/${key.id}/revoke",

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -198,14 +198,15 @@ internal fun auditLogPageImpl(
                                 +"All events"
                             }
                             // Order matters — each event lands in the first group it
-                            // matches, so "Impersonation" must precede "Admin Actions"
-                            // to claim the ADMIN_IMPERSONATION_* events.
+                            // matches. "Impersonation" must precede "Admin Actions" and
+                            // "Email OTP" must precede "Email & Password".
                             val groups = linkedMapOf(
                                 "Login & Registration" to listOf("LOGIN_", "REGISTER_", "ACCOUNT_"),
                                 "Tokens & Authorization" to listOf("TOKEN_", "AUTHORIZATION_CODE_"),
                                 "Sessions" to listOf("SESSION_"),
                                 "Impersonation" to listOf("ADMIN_IMPERSONATION_"),
                                 "Admin Actions" to listOf("ADMIN_"),
+                                "Email OTP" to listOf("EMAIL_OTP_"),
                                 "Email & Password" to listOf("EMAIL_", "PASSWORD_"),
                                 "User Self-Service" to listOf("USER_"),
                                 "MFA" to listOf("MFA_"),

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -338,6 +338,7 @@ private fun AuditEventType.badgeModifier(): String =
         AuditEventType.ADMIN_CLIENT_ENABLED,
         AuditEventType.ADMIN_USER_PASSWORD_RESET,
         AuditEventType.ACCOUNT_UNLOCKED,
+        AuditEventType.EMAIL_OTP_VERIFIED,
         -> "badge--active"
 
         AuditEventType.LOGIN_FAILED,
@@ -347,6 +348,8 @@ private fun AuditEventType.badgeModifier(): String =
         AuditEventType.ADMIN_USER_DISABLED,
         AuditEventType.ADMIN_CLIENT_DISABLED,
         AuditEventType.USER_ACCOUNT_DISABLED_SELF,
+        AuditEventType.EMAIL_OTP_REJECTED,
+        AuditEventType.EMAIL_OTP_LOCKOUT,
         -> "badge--danger"
 
         AuditEventType.LOGIN_RATE_LIMITED,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -466,6 +466,8 @@ internal fun DIV.userProfileEditFragment(
     workspace: Tenant,
     user: User,
     editError: String? = null,
+    roles: List<Role> = emptyList(),
+    groups: List<Group> = emptyList(),
 ) {
     div {
         id = "profile-section"
@@ -509,6 +511,16 @@ internal fun DIV.userProfileEditFragment(
                         value = user.fullName
                     }
                 }
+                readOnlyBadgesRow(
+                    label = "Roles",
+                    items = roles.map { it.name },
+                    manageUrl = "/admin/workspaces/${workspace.slug}/roles",
+                )
+                readOnlyBadgesRow(
+                    label = "Groups",
+                    items = groups.map { it.name },
+                    manageUrl = "/admin/workspaces/${workspace.slug}/groups",
+                )
                 div("edit-actions") {
                     button(type = ButtonType.submit, classes = "btn btn--primary btn--sm") {
                         +"Save changes"
@@ -522,6 +534,31 @@ internal fun DIV.userProfileEditFragment(
                         +"Cancel"
                     }
                 }
+            }
+        }
+    }
+}
+
+private fun FlowContent.readOnlyBadgesRow(
+    label: String,
+    items: List<String>,
+    manageUrl: String,
+) {
+    div("edit-row") {
+        span("edit-row__label") { +label }
+        div {
+            div("read-only-badges") {
+                if (items.isEmpty()) {
+                    span("edit-row__hint") { +"None assigned" }
+                } else {
+                    items.forEach { name ->
+                        span("badge badge--id-muted") { +name }
+                    }
+                }
+            }
+            div("edit-row__hint") {
+                +"Managed elsewhere — "
+                a(href = manageUrl) { +"manage ${label.lowercase()}" }
             }
         }
     }
@@ -936,7 +973,7 @@ private fun FlowContent.userAttributesSection(
 
         if (attributes.isEmpty()) {
             emptyState(
-                iconName = "key",
+                iconName = "code",
                 title = "No custom attributes",
                 description =
                     "Add key-value pairs to this user. Configure how they appear in JWTs under " +

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -19,6 +19,13 @@ data class ImpersonationRecord(
     val startedAt: Instant,
 )
 
+data class OtpActivityRecord(
+    val eventType: String,
+    val ipAddress: String?,
+    val reason: String?,
+    val occurredAt: Instant,
+)
+
 internal fun userDetailPageImpl(
     workspace: Tenant,
     user: User,
@@ -40,6 +47,7 @@ internal fun userDetailPageImpl(
      */
     tempPasswordLink: String? = null,
     recentImpersonations: List<ImpersonationRecord> = emptyList(),
+    recentOtpActivity: List<OtpActivityRecord> = emptyList(),
 ): HTML.() -> Unit =
     {
         adminShell(
@@ -295,6 +303,36 @@ internal fun userDetailPageImpl(
                                 tr {
                                     td { span("data-table__name") { +record.adminUsername } }
                                     td { +record.startedAt.toDisplayString() }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (recentOtpActivity.isNotEmpty()) {
+                div("ov-card") {
+                    div("ov-card__section-label") { +"Recent OTP Activity" }
+                    table("data-table") {
+                        thead {
+                            tr {
+                                th { +"Event" }
+                                th { +"IP" }
+                                th { +"Reason" }
+                                th { +"When" }
+                            }
+                        }
+                        tbody {
+                            recentOtpActivity.forEach { record ->
+                                tr {
+                                    td {
+                                        span("data-table__name") {
+                                            +record.eventType.removePrefix("EMAIL_OTP_").lowercase()
+                                        }
+                                    }
+                                    td { +(record.ipAddress ?: "—") }
+                                    td { +(record.reason ?: "—") }
+                                    td { +record.occurredAt.toDisplayString() }
                                 }
                             }
                         }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -845,17 +845,6 @@ internal fun securityPolicyPageImpl(
                         }
                     }
                     label("check-row") {
-                        input(type = InputType.checkBox, name = "requirePasswordless") {
-                            attributes["value"] = "true"
-                            if (!workspace.securityConfig.passwordLoginEnabled) checked = true
-                            if (workspace.isMaster) attributes["disabled"] = "disabled"
-                        }
-                        div("check-row__body") {
-                            span("check-row__label") { +EnglishStrings.AUTH_METHODS_PASSWORDLESS_LABEL }
-                            span("check-row__desc") { +EnglishStrings.AUTH_METHODS_PASSWORDLESS_DESC }
-                        }
-                    }
-                    label("check-row") {
                         input(type = InputType.checkBox, name = "emailOtpSignupEnabled") {
                             attributes["value"] = "true"
                             if (workspace.securityConfig.emailOtpSignupEnabled) checked = true
@@ -863,6 +852,9 @@ internal fun securityPolicyPageImpl(
                         div("check-row__body") {
                             span("check-row__label") { +EnglishStrings.AUTH_METHODS_EMAIL_OTP_SIGNUP_LABEL }
                             span("check-row__desc") { +EnglishStrings.AUTH_METHODS_EMAIL_OTP_SIGNUP_DESC }
+                            if (!workspace.isSmtpReady) {
+                                span("check-row__warn") { +EnglishStrings.AUTH_METHODS_EMAIL_OTP_SMTP_WARN }
+                            }
                         }
                     }
                     div("edit-row") {
@@ -878,6 +870,17 @@ internal fun securityPolicyPageImpl(
                                 }
                             }
                             div("edit-row__hint") { +EnglishStrings.AUTH_METHODS_EMAIL_OTP_LOCKOUT_HINT }
+                        }
+                    }
+                    label("check-row") {
+                        input(type = InputType.checkBox, name = "requirePasswordless") {
+                            attributes["value"] = "true"
+                            if (!workspace.securityConfig.passwordLoginEnabled) checked = true
+                            if (workspace.isMaster) attributes["disabled"] = "disabled"
+                        }
+                        div("check-row__body") {
+                            span("check-row__label") { +EnglishStrings.AUTH_METHODS_PASSWORDLESS_LABEL }
+                            span("check-row__desc") { +EnglishStrings.AUTH_METHODS_PASSWORDLESS_DESC }
                         }
                     }
                 }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -927,7 +927,7 @@ internal fun brandingPageImpl(
                     div("page-header__identity") {
                         h1("page-header__title") { +"Branding" }
                         p("page-header__sub") {
-                            +"Customize the appearance of ${workspace.displayName}'s auth pages."
+                            +"Customize the appearance of ${workspace.displayName}'s auth pages and email identity."
                         }
                     }
                 }
@@ -1079,46 +1079,21 @@ internal fun brandingPageImpl(
                             }
                         }
 
-                        // ── Email Branding (v1.12.0) ────────────────
+                        // ── Email Identity ──────────────────────────
                         val eb = workspace.emailBranding
                         div("ov-card") {
-                            div("ov-card__section-label") { +"Email Branding" }
-                            div("ov-card__desc") {
-                                +"Applied to every transactional email (OTP, magic link, "
-                                +"password reset, invite, account locked). Envelope sender "
-                                +"stays operator-controlled — set From display name only."
-                            }
-                            div("edit-row") {
-                                span("edit-row__label") { +"Brand name" }
-                                input(type = InputType.text, name = "emailBrandName") {
-                                    classes = setOf("edit-row__field")
-                                    value = eb?.brandName ?: ""
-                                    attributes["placeholder"] = workspace.displayName
-                                }
-                            }
-                            div("edit-row") {
-                                span("edit-row__label") { +"Brand color (hex)" }
-                                input(type = InputType.text, name = "emailBrandColor") {
-                                    classes = setOf("edit-row__field", "edit-row__field--mono")
-                                    value = eb?.brandColorHex ?: ""
-                                    attributes["placeholder"] = workspace.theme.accentColor
-                                    attributes["pattern"] = "^#[0-9a-fA-F]{3,6}$"
-                                }
-                            }
-                            div("edit-row") {
-                                span("edit-row__label") { +"Logo URL" }
-                                input(type = InputType.url, name = "emailBrandLogoUrl") {
-                                    classes = setOf("edit-row__field")
-                                    value = eb?.brandLogoUrl ?: ""
-                                    attributes["placeholder"] = workspace.theme.logoUrl ?: "https://example.com/logo.png"
-                                }
-                            }
+                            div("ov-card__section-label") { +"Email Identity" }
                             div("edit-row") {
                                 span("edit-row__label") { +"Support email" }
-                                input(type = InputType.email, name = "emailSupportEmail") {
-                                    classes = setOf("edit-row__field")
-                                    value = eb?.supportEmail ?: ""
-                                    attributes["placeholder"] = "support@example.com"
+                                div {
+                                    input(type = InputType.email, name = "emailSupportEmail") {
+                                        classes = setOf("edit-row__field")
+                                        value = eb?.supportEmail ?: ""
+                                        attributes["placeholder"] = "support@example.com"
+                                    }
+                                    div("edit-row__hint") {
+                                        +"Shown in transactional email footers. Optional."
+                                    }
                                 }
                             }
                             div("edit-row") {
@@ -1131,7 +1106,8 @@ internal fun brandingPageImpl(
                                     }
                                     div("edit-row__hint") {
                                         +"Display name only. The sender address is set in SMTP "
-                                        +"configuration and cannot be changed per workspace."
+                                        +"configuration and cannot be changed per workspace. "
+                                        +"Brand name, color, and logo are inherited from the theme above."
                                     }
                                 }
                             }

--- a/src/main/kotlin/com/kauth/config/BootstrapApiKeys.kt
+++ b/src/main/kotlin/com/kauth/config/BootstrapApiKeys.kt
@@ -23,7 +23,7 @@ fun parseBootstrapApiKeyEntries(json: String): List<ApiKeyBootstrapService.Entry
             name = e.name,
             scopes = e.scopes,
             keyHash = e.keyHash,
-            keyPrefix = e.keyPrefix ?: "kauth_${e.tenant}_bootstrap",
+            keyPrefix = e.keyPrefix,
         )
     }
 }

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -415,60 +415,26 @@ data class ServiceGraph(
             }
 
             // -- Rate limiters ------------------------------------------------
-            val loginLimiter: RateLimiterPort =
+            fun buildRateLimiter(
+                max: Int,
+                windowSecs: Long,
+                prefix: String,
+            ): RateLimiterPort =
                 redisClientHolder?.let {
                     RedisRateLimiter(
                         commands = it.commands,
-                        maxRequests = 5,
-                        windowSeconds = 60,
-                        keyPrefix = "login",
+                        maxRequests = max,
+                        windowSeconds = windowSecs,
+                        keyPrefix = prefix,
                     )
-                } ?: InMemoryRateLimiter(maxRequests = 5, windowSeconds = 60)
-            val registerLimiter: RateLimiterPort =
-                redisClientHolder?.let {
-                    RedisRateLimiter(
-                        commands = it.commands,
-                        maxRequests = 3,
-                        windowSeconds = 300,
-                        keyPrefix = "register",
-                    )
-                } ?: InMemoryRateLimiter(maxRequests = 3, windowSeconds = 300)
-            val tokenLimiter: RateLimiterPort =
-                redisClientHolder?.let {
-                    RedisRateLimiter(
-                        commands = it.commands,
-                        maxRequests = 20,
-                        windowSeconds = 60,
-                        keyPrefix = "token",
-                    )
-                } ?: InMemoryRateLimiter(maxRequests = 20, windowSeconds = 60)
-            val mfaLimiter: RateLimiterPort =
-                redisClientHolder?.let {
-                    RedisRateLimiter(
-                        commands = it.commands,
-                        maxRequests = 5,
-                        windowSeconds = 300,
-                        keyPrefix = "mfa",
-                    )
-                } ?: InMemoryRateLimiter(maxRequests = 5, windowSeconds = 300)
-            val otpEmailLimiter: RateLimiterPort =
-                redisClientHolder?.let {
-                    RedisRateLimiter(
-                        commands = it.commands,
-                        maxRequests = 3,
-                        windowSeconds = 900,
-                        keyPrefix = "otp_email",
-                    )
-                } ?: InMemoryRateLimiter(maxRequests = 3, windowSeconds = 900)
-            val otpIpLimiter: RateLimiterPort =
-                redisClientHolder?.let {
-                    RedisRateLimiter(
-                        commands = it.commands,
-                        maxRequests = 10,
-                        windowSeconds = 900,
-                        keyPrefix = "otp_ip",
-                    )
-                } ?: InMemoryRateLimiter(maxRequests = 10, windowSeconds = 900)
+                } ?: InMemoryRateLimiter(maxRequests = max, windowSeconds = windowSecs)
+
+            val loginLimiter = buildRateLimiter(max = 5, windowSecs = 60, prefix = "login")
+            val registerLimiter = buildRateLimiter(max = 3, windowSecs = 300, prefix = "register")
+            val tokenLimiter = buildRateLimiter(max = 20, windowSecs = 60, prefix = "token")
+            val mfaLimiter = buildRateLimiter(max = 5, windowSecs = 300, prefix = "mfa")
+            val otpEmailLimiter = buildRateLimiter(max = 3, windowSecs = 900, prefix = "otp_email")
+            val otpIpLimiter = buildRateLimiter(max = 10, windowSecs = 900, prefix = "otp_ip")
 
             // -- Session keys (derived from KAUTH_SECRET_KEY) --------------------
             val portalSessionKey: ByteArray =

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -753,6 +753,15 @@ class AdminService(
             return AdminResult.Failure(AdminError.Validation("Name is required."))
         }
 
+        if (resolvedRedirectUris.isEmpty()) {
+            return AdminResult.Failure(
+                AdminError.Validation(
+                    "At least one redirect URI is required. The authorization code flow " +
+                        "(including email-OTP back-channel exchange) needs a registered URI to bind to.",
+                ),
+            )
+        }
+
         if (resolvedAudience != null && resolvedAudience.length > 200) {
             return AdminResult.Failure(AdminError.Validation("Token audience must be 200 characters or fewer."))
         }

--- a/src/main/kotlin/com/kauth/domain/service/AdminService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminService.kt
@@ -36,6 +36,9 @@ import com.kauth.domain.util.SecureTokens
  *
  * Discriminated-union results ([AdminResult]) propagate errors explicitly
  * without exceptions, keeping the web adapter free of try/catch noise.
+ *
+ * TODO(v1.13): extract WorkspaceSettingsService, AdminUserService, and
+ * ApplicationManagementService — three clean dependency clusters already exist.
  */
 class AdminService(
     private val tenantRepository: TenantRepository,

--- a/src/main/kotlin/com/kauth/domain/service/ApiKeyBootstrapService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ApiKeyBootstrapService.kt
@@ -26,8 +26,12 @@ class ApiKeyBootstrapService(
         val name: String,
         val scopes: List<String>,
         val keyHash: String,
-        val keyPrefix: String = "kauth_${tenantSlug}_bootstrap",
+        val keyPrefix: String? = null,
     )
+
+    companion object {
+        internal fun defaultKeyPrefix(tenantSlug: String): String = "kauth_$tenantSlug".take(16)
+    }
 
     sealed class Result {
         data class Provisioned(
@@ -63,13 +67,14 @@ class ApiKeyBootstrapService(
                 )
             }
 
+            val resolvedPrefix = (entry.keyPrefix ?: defaultKeyPrefix(entry.tenantSlug)).take(16)
             val existing = apiKeyRepository.findByTenantAndName(tenant.id, entry.name)
             if (existing == null) {
                 apiKeyRepository.save(
                     ApiKey(
                         tenantId = tenant.id,
                         name = entry.name,
-                        keyPrefix = entry.keyPrefix,
+                        keyPrefix = resolvedPrefix,
                         keyHash = entry.keyHash,
                         scopes = entry.scopes,
                         enabled = true,

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -401,7 +401,7 @@ class AuthService(
 
         if (tenant.emailVerificationRequired && tenant.isSmtpReady && selfServiceService != null) {
             try {
-                selfServiceService.initiateEmailVerification(savedUser.id!!, tenant.id, baseUrl)
+                selfServiceService.initiateEmailVerification(savedUser.id, tenant.id, baseUrl)
             } catch (_: Exception) {
                 // non-fatal
             }

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -18,6 +18,7 @@ import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.util.sha256Hex
+import org.slf4j.LoggerFactory
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.time.Clock
@@ -49,6 +50,8 @@ class EmailOtpService(
     private val roleRepository: RoleRepository? = null,
     private val clock: Clock = Clock.systemUTC(),
 ) {
+    private val log = LoggerFactory.getLogger(EmailOtpService::class.java)
+
     companion object {
         const val OTP_TTL_MINUTES: Long = 10
         const val MAX_ATTEMPTS_PER_CHALLENGE: Int = 5
@@ -109,18 +112,25 @@ class EmailOtpService(
                 ),
             )
 
-        runCatching {
-            emailPort.sendEmailOtpEmail(
-                to = user.email,
-                toName = user.fullName,
-                code = rawCode,
-                expiresInMinutes = OTP_TTL_MINUTES,
-                workspaceName = tenant.emailBranding?.brandName ?: tenant.displayName,
-                tenant = tenant,
+        val deliveryFailure =
+            runCatching {
+                emailPort.sendEmailOtpEmail(
+                    to = user.email,
+                    toName = user.fullName,
+                    code = rawCode,
+                    expiresInMinutes = OTP_TTL_MINUTES,
+                    workspaceName = tenant.emailBranding?.brandName ?: tenant.displayName,
+                    tenant = tenant,
+                )
+            }.exceptionOrNull()
+        if (deliveryFailure != null) {
+            log.warn(
+                "OTP email delivery failed: tenant={} email={} reason={}",
+                tenant.slug,
+                user.email,
+                deliveryFailure.javaClass.simpleName,
             )
         }
-        // SMTP failures are swallowed so the audit trail still records the send attempt and the
-        // BFF response stays uniform — the user can request a resend.
 
         auditLog.record(
             AuditEvent(

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -142,7 +142,6 @@ class EmailOtpService(
                 userAgent = null,
                 details =
                     mapOf(
-                        "source" to "admin_api",
                         "resend_count" to challenge.resendCount.toString(),
                         "originating_client_id" to (originatingClientId ?: ""),
                     ),
@@ -278,6 +277,8 @@ class EmailOtpService(
         )
     }
 
+    // Back-channel issuance — PKCE not required (ADR-15). Scopes are fixed for now;
+    // TODO(v1.13): derive from client.allowedScopes once that field exists.
     private fun issueAuthorizationCodeFor(
         tenant: Tenant,
         userId: UserId,

--- a/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
@@ -261,7 +261,7 @@ class SocialLoginService(
             ),
         )
 
-        grantClientDefaultRoles(tenant.id, newUser.id!!, originatingClientId)
+        grantClientDefaultRoles(tenant.id, newUser.id, originatingClientId)
 
         return issueTokens(newUser, tenant, provider, isNewUser = true, ipAddress, userAgent)
     }

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -37,6 +37,8 @@ info:
     | `user_attributes:write` | Create, update, delete per-user attributes |
     | `claim_mappers:read`    | List tenant claim mappers                 |
     | `claim_mappers:write`   | Create, update, delete claim mappers      |
+    | `auth:send-otp`         | Trigger an email-OTP challenge for a user |
+    | `auth:verify-otp`       | Verify an email-OTP challenge and obtain an authorization code |
 
     ## Custom attributes and JWT claims
 
@@ -305,6 +307,66 @@ components:
             Use a prefix like `custom:department` to avoid collisions.
         includeInAccess: { type: boolean, default: true }
         includeInId:     { type: boolean, default: false }
+
+    SendOtpRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+          description: Applicant email address. Lowercased + trimmed server-side.
+        originatingClientId:
+          type: string
+          description: |
+            OAuth client_id that triggered the send. Required at verify-otp
+            time to bind the authorization code to a registered client. The
+            client must have at least one redirect URI configured.
+
+    SendOtpResponse:
+      type: object
+      required: [challengeId, expiresAt]
+      properties:
+        challengeId:
+          type: string
+          description: Opaque 64-char handle. Pass back unchanged to verify-otp.
+        expiresAt:
+          type: string
+          format: date-time
+          description: ISO-8601 expiry timestamp (10 minutes from issuance).
+
+    VerifyOtpRequest:
+      type: object
+      required: [challengeId, otp]
+      properties:
+        challengeId:
+          type: string
+          description: The opaque handle returned from send-otp.
+        otp:
+          type: string
+          minLength: 6
+          maxLength: 6
+          description: The 6-digit numeric code received in email.
+
+    VerifyOtpResponse:
+      type: object
+      required: [authorizationCode, expiresAt, redirectUri]
+      properties:
+        authorizationCode:
+          type: string
+          description: |
+            Single-use OAuth authorization code bound to the originating
+            client. Exchange at `/protocol/openid-connect/token` using the
+            standard `authorization_code` grant. TTL 60 seconds.
+        expiresAt:
+          type: string
+          format: date-time
+        redirectUri:
+          type: string
+          description: |
+            The redirect URI the code was bound to (the first one registered
+            on the originating client). The caller MUST echo this exact
+            value at the `/token` exchange.
 
   responses:
     Unauthorized:
@@ -1066,6 +1128,105 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
 
+  /auth/send-otp:
+    post:
+      summary: Send an email OTP challenge
+      description: |
+        Generates a 6-digit code (10-minute TTL), persists its SHA-256 hash,
+        and sends a branded email. Returns an opaque `challengeId` the caller
+        forwards to `/auth/verify-otp`.
+
+        Find-or-create semantics are gated by the tenant's
+        `email_otp_signup_enabled` flag (default off). When off and the email
+        doesn't already exist, the response shape is identical to the
+        happy path — no enumeration leak. Response timing is padded
+        toward a constant target to defend against latency-based enumeration.
+
+        Per-email and per-IP rate limits apply (3/email/15min, 10/IP/15min by
+        default).
+
+        `originatingClientId` is required for the verify-otp authorization-code
+        issuance to bind the resulting code to a confidential client. The
+        client must have at least one redirect URI registered.
+      tags: [Auth — Email OTP]
+      security: [{ bearerAuth: [auth:send-otp] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SendOtpRequest" }
+      responses:
+        "202":
+          description: Challenge issued (uniform — same shape for new and returning users)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SendOtpResponse" }
+        "400":
+          description: Invalid email
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404":
+          description: Tenant not found
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+
+  /auth/verify-otp:
+    post:
+      summary: Verify an email OTP challenge
+      description: |
+        Validates the 6-digit code against the stored SHA-256 in constant
+        time. On success, stamps `email_verified=true` on the user, grants
+        any client-default roles configured for `originatingClientId`, and
+        issues a single-use OAuth authorization code (60-second TTL) bound
+        to the originating client. Exchange the code at the standard
+        `/protocol/openid-connect/token` endpoint using the returned
+        `redirectUri`.
+
+        Per-challenge attempt cap is 5; over the cap the challenge is killed.
+        N consecutive failed challenges (per-tenant
+        `email_otp_lockout_threshold`, default 5) lock the user using the
+        tenant's existing lockout window. The lock never leaks back —
+        locked users always get `too_many_attempts`.
+      tags: [Auth — Email OTP]
+      security: [{ bearerAuth: [auth:verify-otp] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/VerifyOtpRequest" }
+      responses:
+        "200":
+          description: Code verified; authorization code issued
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/VerifyOtpResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404":
+          description: Tenant not found
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+        "410":
+          description: Challenge expired
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+        "422":
+          description: Invalid code, too many attempts, or originating client misconfigured
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/ProblemDetail" }
+
 tags:
   - name: Users
     description: User lifecycle management
@@ -1083,3 +1244,8 @@ tags:
     description: Per-user custom key/value metadata (projected into JWTs via claim mappers)
   - name: Claim Mappers
     description: Tenant-level configuration that projects user attributes into issued JWTs
+  - name: Auth — Email OTP
+    description: |
+      Email-OTP passwordless primitive — send a 6-digit code, verify it,
+      and exchange the resulting authorization code at the standard
+      `/token` endpoint. See ADR-15.

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -251,6 +251,55 @@ class ApiOtpRoutesTest {
                 }
             assertEquals(HttpStatusCode.UnprocessableEntity, verify.status)
             assertTrue("""invalid_otp""" in verify.bodyAsText())
+            assertEquals("application/problem+json", verify.headers["Content-Type"])
+        }
+
+    @Test
+    fun `verify-otp rejects a challenge from a different tenant`() =
+        testApplication {
+            application { installApp(AlwaysAllowLimiter(), AlwaysAllowLimiter()) }
+            val otherTenant =
+                tenants.add(
+                    Tenant(
+                        id = TenantId(0),
+                        slug = "other",
+                        displayName = "Other",
+                        issuerUrl = null,
+                    ),
+                )
+            val otherUser =
+                users.add(
+                    com.kauth.domain.model.User(
+                        tenantId = otherTenant.id,
+                        username = "alien",
+                        email = "alien@other.test",
+                        fullName = "Alien",
+                        passwordHash = "x",
+                    ),
+                )
+            challenges.create(
+                com.kauth.domain.model.EmailOtpChallenge(
+                    userId = otherUser.id!!,
+                    tenantId = otherTenant.id,
+                    challengeId = "alien-handle",
+                    codeHash =
+                        com.kauth.domain.util
+                            .sha256Hex("123456"),
+                    expiresAt =
+                        java.time.Instant
+                            .now()
+                            .plusSeconds(600),
+                ),
+            )
+
+            val verify =
+                client.post("/t/zion/api/v1/auth/verify-otp") {
+                    bearerAuth(verifyKey)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"challengeId":"alien-handle","otp":"123456"}""")
+                }
+            assertEquals(HttpStatusCode.UnprocessableEntity, verify.status)
+            assertTrue("""invalid_otp""" in verify.bodyAsText())
         }
 
     private fun io.ktor.server.application.Application.installApp(

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
@@ -364,7 +364,7 @@ class SsoCookieTest {
                     ?: error("KOTAUTH_SSO must be set on MFA challenge success. Set-Cookie: $setCookie")
 
             val payload = parseSsoCookie(ssoValue)
-            assertEquals(alice.id!!.value, payload.userId)
+            assertEquals(alice.id.value, payload.userId)
             assertEquals(true, payload.mfaCompleted, "MFA-completed login must record mfaCompleted=true")
         }
 

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
@@ -151,7 +151,7 @@ class SsoLogoutTest {
         val ssoClear = setCookie.firstOrNull { it.startsWith("KOTAUTH_SSO=") }
         assertTrue(ssoClear != null, "KOTAUTH_SSO clear directive must be present, was: $setCookie")
         assertTrue(
-            ssoClear!!.contains("Max-Age=0", ignoreCase = true) || ssoClear.startsWith("KOTAUTH_SSO=;"),
+            ssoClear.contains("Max-Age=0", ignoreCase = true) || ssoClear.startsWith("KOTAUTH_SSO=;"),
             "KOTAUTH_SSO cookie must be cleared with Max-Age=0, was: $ssoClear",
         )
     }

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -633,6 +633,19 @@ class AdminServiceTest {
     }
 
     @Test
+    fun `updateApplication - rejects when redirect URIs is empty`() {
+        val result =
+            svc.updateApplication(
+                appId = ApplicationId(100),
+                tenantId = TenantId(1),
+                redirectUris = emptyList(),
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertTrue(result.error.message.contains("redirect URI", ignoreCase = true))
+    }
+
+    @Test
     fun `updateApplication - launcherUrl rejected when no redirect URIs registered`() {
         val result =
             svc.updateApplication(

--- a/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServiceTest.kt
@@ -20,6 +20,7 @@ import com.kauth.fakes.FakePasswordHasher
 import com.kauth.fakes.FakePasswordPolicyPort
 import com.kauth.fakes.FakePasswordResetTokenRepository
 import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantEmailBrandingRepository
 import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeUserRepository
 import kotlinx.coroutines.CoroutineScope
@@ -47,6 +48,7 @@ class AdminServiceTest {
     private val evTokenRepo = FakeEmailVerificationTokenRepository()
     private val prTokenRepo = FakePasswordResetTokenRepository()
     private val emailPort = FakeEmailPort()
+    private val emailBranding = FakeTenantEmailBrandingRepository()
 
     private val selfService =
         UserSelfServiceService(
@@ -72,6 +74,7 @@ class AdminServiceTest {
             sessionRepository = sessions,
             selfServiceService = selfService,
             passwordPolicy = passwordPolicy,
+            emailBrandingRepository = emailBranding,
         )
 
     private val tenant =
@@ -1199,5 +1202,85 @@ class AdminServiceTest {
     fun `updateWorkspaceSettings does not fire ADMIN_SECURITY_CONFIG_UPDATED when toggle unchanged`() {
         callUpdateSettings(passwordLoginEnabled = true)
         assertTrue(!auditLog.hasEvent(AuditEventType.ADMIN_SECURITY_CONFIG_UPDATED))
+    }
+
+    @Test
+    fun `updateEmailBranding rejects an invalid hex color`() {
+        val result =
+            svc.updateEmailBranding(
+                tenant.slug,
+                com.kauth.domain.model.TenantEmailBranding(
+                    tenantId = tenant.id,
+                    brandColorHex = "not-a-color",
+                ),
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateEmailBranding rejects a support email without an at sign`() {
+        val result =
+            svc.updateEmailBranding(
+                tenant.slug,
+                com.kauth.domain.model.TenantEmailBranding(
+                    tenantId = tenant.id,
+                    supportEmail = "support-without-at",
+                ),
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateEmailBranding returns NotFound for unknown tenant slug`() {
+        val result =
+            svc.updateEmailBranding(
+                "nope",
+                com.kauth.domain.model
+                    .TenantEmailBranding(tenantId = TenantId(99)),
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.NotFound>(result.error)
+    }
+
+    @Test
+    fun `updateEmailBranding persists sanitised fields on success`() {
+        val result =
+            svc.updateEmailBranding(
+                tenant.slug,
+                com.kauth.domain.model.TenantEmailBranding(
+                    tenantId = tenant.id,
+                    brandName = "  Acme  ",
+                    brandColorHex = "#1FBCFF",
+                    supportEmail = "support@acme.com",
+                    fromDisplayName = "  Acme Support  ",
+                ),
+            )
+        assertIs<AdminResult.Success<com.kauth.domain.model.TenantEmailBranding>>(result)
+        val saved = emailBranding.findByTenantId(tenant.id)!!
+        assertEquals("Acme", saved.brandName)
+        assertEquals("Acme Support", saved.fromDisplayName)
+    }
+
+    @Test
+    fun `updateEmailBranding is a soft no-op when the repository is not wired`() {
+        val withoutRepo =
+            AdminService(
+                tenantRepository = tenants,
+                userRepository = users,
+                applicationRepository = apps,
+                passwordHasher = hasher,
+                auditLog = auditLog,
+                sessionRepository = sessions,
+                selfServiceService = selfService,
+            )
+        val result =
+            withoutRepo.updateEmailBranding(
+                tenant.slug,
+                com.kauth.domain.model
+                    .TenantEmailBranding(tenantId = tenant.id),
+            )
+        assertIs<AdminResult.Success<com.kauth.domain.model.TenantEmailBranding>>(result)
     }
 }

--- a/src/test/kotlin/com/kauth/domain/service/ApiKeyBootstrapServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ApiKeyBootstrapServiceTest.kt
@@ -99,7 +99,7 @@ class ApiKeyBootstrapServiceTest {
                 ApiKey(
                     tenantId = tenant.id,
                     name = "zion-public-bff",
-                    keyPrefix = "kauth_zion_bootstrap",
+                    keyPrefix = "kauth_zion",
                     keyHash = "hash-v1",
                     scopes = listOf(ApiScope.AUTH_SEND_OTP),
                     enabled = false,
@@ -137,6 +137,26 @@ class ApiKeyBootstrapServiceTest {
                 ),
             )
         assertTrue(result is ApiKeyBootstrapService.Result.Failure)
+    }
+
+    @Test
+    fun `default keyPrefix fits the 16-char column ceiling for any tenant slug`() {
+        val veryLong = "very-long-brokerage-name-12345"
+        tenants.add(Tenant(id = TenantId(0), slug = veryLong, displayName = "X", issuerUrl = null))
+        val result =
+            service.ensureBootstrapped(
+                listOf(
+                    ApiKeyBootstrapService.Entry(
+                        tenantSlug = veryLong,
+                        name = "bff",
+                        scopes = listOf(ApiScope.AUTH_SEND_OTP),
+                        keyHash = "h",
+                    ),
+                ),
+            )
+        assertTrue(result is ApiKeyBootstrapService.Result.Provisioned)
+        val saved = apiKeys.findByTenantAndName(tenants.findBySlug(veryLong)!!.id, "bff")!!
+        assertTrue(saved.keyPrefix.length <= 16, "keyPrefix '${saved.keyPrefix}' must fit varchar(16)")
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
@@ -186,8 +186,8 @@ class BackupExportImportTest {
                     parentGroupId = parentGroup.id!!,
                 ),
             )
-        sourceGroups.assignRoleToGroup(parentGroup.id!!, parentRole.id!!)
-        sourceGroups.assignRoleToGroup(childGroup.id!!, childRole.id!!)
+        sourceGroups.assignRoleToGroup(parentGroup.id, parentRole.id)
+        sourceGroups.assignRoleToGroup(childGroup.id!!, childRole.id)
 
         val alice =
             sourceUsers.add(
@@ -220,9 +220,9 @@ class BackupExportImportTest {
         sourceAttrs.upsert(
             UserAttribute(alice.id!!, tenant.id, "department", "engineering", Instant.now()),
         )
-        sourceRoles.assignRoleToUser(alice.id!!, parentRole.id!!)
-        sourceGroups.addUserToGroup(alice.id!!, parentGroup.id!!)
-        sourceGroups.addUserToGroup(bob.id!!, childGroup.id!!)
+        sourceRoles.assignRoleToUser(alice.id, parentRole.id)
+        sourceGroups.addUserToGroup(alice.id, parentGroup.id)
+        sourceGroups.addUserToGroup(bob.id!!, childGroup.id)
 
         sourceMappers.upsert(
             TenantClaimMapper(
@@ -260,7 +260,7 @@ class BackupExportImportTest {
         sourceAudit.add(
             AuditEvent(
                 tenantId = tenant.id,
-                userId = alice.id!!,
+                userId = alice.id,
                 clientId = app.id,
                 eventType = AuditEventType.LOGIN_SUCCESS,
                 ipAddress = "10.0.0.1",
@@ -444,7 +444,7 @@ class BackupExportImportTest {
                 .first { it.username == "alice" }
 
         assertEquals(mapOf("department" to "engineering"), destAttrs.findAll(alice.id!!, newTenantId))
-        val aliceGroups = destGroups.findGroupsForUser(alice.id!!)
+        val aliceGroups = destGroups.findGroupsForUser(alice.id)
         assertEquals(setOf("engineering"), aliceGroups.map { it.name }.toSet())
     }
 

--- a/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
@@ -127,8 +127,22 @@ class BackupExportImportTest {
                     displayName = "Acme Corp",
                     issuerUrl = "https://acme.example.com",
                     tokenExpirySeconds = 7200,
-                    securityConfig = SecurityConfig(magicLinkEnabled = true, mfaPolicy = "required"),
+                    securityConfig =
+                        SecurityConfig(
+                            magicLinkEnabled = true,
+                            mfaPolicy = "required",
+                            emailOtpSignupEnabled = true,
+                            emailOtpLockoutThreshold = 3,
+                        ),
                     theme = TenantTheme.LIGHT,
+                    emailBranding =
+                        com.kauth.domain.model.TenantEmailBranding(
+                            tenantId = TenantId(0),
+                            brandName = "Acme",
+                            brandColorHex = "#1FBCFF",
+                            supportEmail = "support@acme.test",
+                            fromDisplayName = "Acme Support",
+                        ),
                 ),
             )
 
@@ -446,6 +460,22 @@ class BackupExportImportTest {
         assertEquals(mapOf("department" to "engineering"), destAttrs.findAll(alice.id!!, newTenantId))
         val aliceGroups = destGroups.findGroupsForUser(alice.id)
         assertEquals(setOf("engineering"), aliceGroups.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `import preserves OTP security config fields and email branding`() {
+        val export = exportSuccessful(ExportOptions())
+        importer().import(export, newSlug = "acme-staging", currentSchemaVersion = 38)
+        val restored = destTenants.findBySlug("acme-staging")!!
+
+        assertTrue(restored.securityConfig.emailOtpSignupEnabled)
+        assertEquals(3, restored.securityConfig.emailOtpLockoutThreshold)
+
+        val branding = destEmailBranding.findByTenantId(restored.id)!!
+        assertEquals("Acme", branding.brandName)
+        assertEquals("#1FBCFF", branding.brandColorHex)
+        assertEquals("support@acme.test", branding.supportEmail)
+        assertEquals("Acme Support", branding.fromDisplayName)
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
@@ -164,6 +164,46 @@ class EmailOtpServiceTest {
     }
 
     @Test
+    fun `sendOtp swallows SMTP failure but still records the audit event`() {
+        users.add(
+            User(
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.test",
+                fullName = "Alice",
+                passwordHash = "x",
+            ),
+        )
+        email.shouldFail = true
+
+        val result = newService().sendOtp(tenant.slug, "alice@acme.test")
+
+        assertTrue(result is OtpSendResult.Success)
+        assertEquals(AuditEventType.EMAIL_OTP_SENT, audit.events.single().eventType)
+    }
+
+    @Test
+    fun `verifyOtp on the stale handle after resend returns InvalidOtp`() {
+        users.add(
+            User(
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.test",
+                fullName = "Alice",
+                passwordHash = "x",
+            ),
+        )
+        val service = newService()
+        val first = service.sendOtp(tenant.slug, "alice@acme.test") as OtpSendResult.Success
+        service.sendOtp(tenant.slug, "alice@acme.test")
+
+        val result = service.verifyOtp(tenant.slug, first.challengeId, "123456")
+
+        assertTrue(result is OtpVerifyResult.Failure)
+        assertEquals(OtpError.InvalidOtp, result.error)
+    }
+
+    @Test
     fun `sendOtp returns TenantNotFound for unknown slug`() {
         val result = newService().sendOtp("nope", "x@y.test")
         assertTrue(result is OtpSendResult.Failure)

--- a/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/RoleGroupServiceTest.kt
@@ -358,7 +358,7 @@ class RoleGroupServiceTest {
     @Test
     fun `addChildRole - self reference`() {
         val role = (svc.createRole(TenantId(1), "self", null, RoleScope.TENANT, null) as AdminResult.Success).value
-        val result = svc.addChildRole(parentRoleId = role.id!!, childRoleId = role.id!!, tenantId = TenantId(1))
+        val result = svc.addChildRole(parentRoleId = role.id!!, childRoleId = role.id, tenantId = TenantId(1))
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
     }
@@ -371,8 +371,8 @@ class RoleGroupServiceTest {
 
         // a -> b -> c, then try c -> a (would create cycle)
         svc.addChildRole(a.id!!, b.id!!, TenantId(1))
-        svc.addChildRole(b.id!!, c.id!!, TenantId(1))
-        val result = svc.addChildRole(c.id!!, a.id!!, TenantId(1))
+        svc.addChildRole(b.id, c.id!!, TenantId(1))
+        val result = svc.addChildRole(c.id, a.id, TenantId(1))
         assertIs<AdminResult.Failure>(result)
         assertIs<AdminError.Validation>(result.error)
         assertTrue(result.error.message.contains("circular"))
@@ -391,7 +391,7 @@ class RoleGroupServiceTest {
         val parent = (svc.createRole(TenantId(1), "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
         val child = (svc.createRole(TenantId(1), "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
         svc.addChildRole(parent.id!!, child.id!!, TenantId(1))
-        val result = svc.removeChildRole(parent.id!!, child.id!!, TenantId(1))
+        val result = svc.removeChildRole(parent.id, child.id, TenantId(1))
         assertIs<AdminResult.Success<Unit>>(result)
     }
 
@@ -444,7 +444,7 @@ class RoleGroupServiceTest {
     fun `unassignRoleFromUser - success`() {
         val role = (svc.createRole(TenantId(1), "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
         svc.assignRoleToUser(userId = UserId(10), roleId = role.id!!, tenantId = TenantId(1))
-        val result = svc.unassignRoleFromUser(userId = UserId(10), roleId = role.id!!, tenantId = TenantId(1))
+        val result = svc.unassignRoleFromUser(userId = UserId(10), roleId = role.id, tenantId = TenantId(1))
         assertIs<AdminResult.Success<Unit>>(result)
         assertEquals(0, svc.getRolesForUser(UserId(10)).size)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_ROLE_UNASSIGNED))
@@ -455,7 +455,7 @@ class RoleGroupServiceTest {
         val parent = (svc.createRole(TenantId(1), "parent", null, RoleScope.TENANT, null) as AdminResult.Success).value
         val child = (svc.createRole(TenantId(1), "child", null, RoleScope.TENANT, null) as AdminResult.Success).value
         svc.addChildRole(parent.id!!, child.id!!, TenantId(1))
-        svc.assignRoleToUser(UserId(10), parent.id!!, TenantId(1))
+        svc.assignRoleToUser(UserId(10), parent.id, TenantId(1))
         val effective = svc.getEffectiveRolesForUser(UserId(10), TenantId(1))
         assertEquals(2, effective.size, "Should include parent + child")
         assertTrue(effective.any { it.name == "parent" })
@@ -580,7 +580,7 @@ class RoleGroupServiceTest {
         val group = (svc.createGroup(TenantId(1), "eng", null, null) as AdminResult.Success).value
         val role = (svc.createRole(TenantId(1), "admin", null, RoleScope.TENANT, null) as AdminResult.Success).value
         svc.assignRoleToGroup(group.id!!, role.id!!, TenantId(1))
-        val result = svc.unassignRoleFromGroup(group.id!!, role.id!!, TenantId(1))
+        val result = svc.unassignRoleFromGroup(group.id, role.id, TenantId(1))
         assertIs<AdminResult.Success<Unit>>(result)
     }
 
@@ -607,7 +607,7 @@ class RoleGroupServiceTest {
         val result = svc.addUserToGroup(UserId(10), group.id!!, TenantId(1))
         assertIs<AdminResult.Success<Unit>>(result)
         assertEquals(1, svc.getGroupsForUser(UserId(10)).size)
-        assertEquals(1, svc.getUserIdsInGroup(group.id!!).size)
+        assertEquals(1, svc.getUserIdsInGroup(group.id).size)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_MEMBER_ADDED))
     }
 
@@ -615,7 +615,7 @@ class RoleGroupServiceTest {
     fun `removeUserFromGroup - success`() {
         val group = (svc.createGroup(TenantId(1), "eng", null, null) as AdminResult.Success).value
         svc.addUserToGroup(UserId(10), group.id!!, TenantId(1))
-        val result = svc.removeUserFromGroup(UserId(10), group.id!!, TenantId(1))
+        val result = svc.removeUserFromGroup(UserId(10), group.id, TenantId(1))
         assertIs<AdminResult.Success<Unit>>(result)
         assertEquals(0, svc.getGroupsForUser(UserId(10)).size)
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_GROUP_MEMBER_REMOVED))

--- a/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
@@ -198,7 +198,7 @@ class WebhookServiceTest {
         val disabled = svc.listEndpoints(TenantId(1)).first()
         assertEquals(false, disabled.enabled)
 
-        svc.toggleEndpoint(created.id!!, tenantId = TenantId(1), enabled = true)
+        svc.toggleEndpoint(created.id, tenantId = TenantId(1), enabled = true)
         val reenabled = svc.listEndpoints(TenantId(1)).first()
         assertEquals(true, reenabled.enabled)
     }

--- a/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeApiKeyRepository.kt
@@ -20,6 +20,9 @@ class FakeApiKeyRepository : ApiKeyRepository {
     fun all(): List<ApiKey> = store.values.toList()
 
     override fun save(apiKey: ApiKey): ApiKey {
+        require(apiKey.keyPrefix.length <= 16) {
+            "keyPrefix '${apiKey.keyPrefix}' (${apiKey.keyPrefix.length}) exceeds varchar(16)"
+        }
         val k = if (apiKey.id == null) apiKey.copy(id = nextId++) else apiKey
         store[k.id!!] = k
         return k

--- a/src/test/kotlin/com/kauth/fakes/FakeRoleRepositoryDefaultRolesTest.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeRoleRepositoryDefaultRolesTest.kt
@@ -66,7 +66,7 @@ class FakeRoleRepositoryDefaultRolesTest {
     @Test
     fun `setDefaultRolesForClient de-duplicates repeated role ids`() {
         val viewer = role("viewer")
-        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!, viewer.id!!))
+        roles.setDefaultRolesForClient(clientId, listOf(viewer.id!!, viewer.id))
 
         assertEquals(1, roles.findDefaultRolesForClient(clientId).size)
     }

--- a/src/test/kotlin/com/kauth/infrastructure/redis/RedisSessionRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/redis/RedisSessionRepositoryIntegrationTest.kt
@@ -252,10 +252,10 @@ class RedisSessionRepositoryIntegrationTest {
 
         val firstSweep = repo.revokeAllByImpersonator(admin.id!!)
         assertEquals(2, firstSweep)
-        assertTrue(repo.findActiveByImpersonator(admin.id!!).isEmpty())
+        assertTrue(repo.findActiveByImpersonator(admin.id).isEmpty())
 
         // A second call should report zero — already-revoked children are not double-counted.
-        assertEquals(0, repo.revokeAllByImpersonator(admin.id!!))
+        assertEquals(0, repo.revokeAllByImpersonator(admin.id))
     }
 
     private fun newSession(


### PR DESCRIPTION
## What does this PR do?

This pull request is a polish release that finalizes ADR-15 follow-ups, addresses deferred UX review items, and closes OTP observability gaps before the upcoming v1.13.0 hosted-page work. It also fixes an important bug with API key bootstrapping and introduces several enhancements to the admin UI and test coverage.

**Bug fixes and validation improvements:**

- Fixed an overflow bug in the default `keyPrefix` for `KAUTH_BOOTSTRAP_API_KEYS` that could cause silent failures in Postgres for tenant slugs ≥ 3 characters. The default is now truncated to fit the 16-character column, and the in-memory repository enforces this ceiling for better test coverage. [[1]](diffhunk://#diff-26eb7194a190bea1e8fdddd1f045f038fe2c16687388046f3f4bd56119ade7e4L29-R35) [[2]](diffhunk://#diff-9461ba8d86e484bb0e80b1445bc88fdff1c854774bbcadd85000bce70aa1b095L26-R26) [[3]](diffhunk://#diff-26eb7194a190bea1e8fdddd1f045f038fe2c16687388046f3f4bd56119ade7e4R70-R77) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)
- Added validation to prevent saving OAuth clients with zero redirect URIs; admins must now specify at least one. This closes an ADR-15 follow-up and ensures errors surface at save-time, not just use-time. [[1]](diffhunk://#diff-237681a9de2b76fb00f31f7dd8b1bd59c4a7468691583c27c5bb29030488b7f7R756-R764) [[2]](diffhunk://#diff-32f7ac44c9d198566da051af1ac9915953163abdec3e73fffe4188a17bb68ec0R74-R75) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)

**Admin UI and UX enhancements:**

- Added a "Recent OTP activity" panel to the admin user-detail page, mirroring the existing "Recent Impersonations" panel and showing the last 5 OTP-related events. [[1]](diffhunk://#diff-7d10518dd9d0ca2bb19561c3c17423c01e9b1b2329f8cff42cae55730bd495aeR22-R28) [[2]](diffhunk://#diff-7d10518dd9d0ca2bb19561c3c17423c01e9b1b2329f8cff42cae55730bd495aeR50) [[3]](diffhunk://#diff-6d868fd06b5413145d0dac337e8080992d31d5fbbe7994727ef600c2215661e6R181) [[4]](diffhunk://#diff-6d868fd06b5413145d0dac337e8080992d31d5fbbe7994727ef600c2215661e6R198) [[5]](diffhunk://#diff-7d10518dd9d0ca2bb19561c3c17423c01e9b1b2329f8cff42cae55730bd495aeR313-R342) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)
- The audit log filter now includes a dedicated "Email OTP" group for `EMAIL_OTP_*` events, improving event discoverability. [[1]](diffhunk://#diff-89571f4710047b15c21dcf663dadece0a58ccb7aa53687a28a50a23cf696e695L201-R209) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)
- The Auth Methods card reorders options so magic-link and OTP pairs stay grouped, and clarifies the passwordless toggle’s scope. [[1]](diffhunk://#diff-c61dc0bb14b43172d4c97b63f69b62bdc4582bfcfe2683956a381014f3578697L847-L857) [[2]](diffhunk://#diff-c61dc0bb14b43172d4c97b63f69b62bdc4582bfcfe2683956a381014f3578697R875-R885) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)
- Improved the display of bootstrap API keys with an inline info icon and accessible tooltip, replacing the less discoverable title-only tooltip. [[1]](diffhunk://#diff-5824137898b428c898a5cf3b7712f60b3f1a39e35ca220a212996c293a57fccaL538-R548) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)

**Observability and operator feedback:**

- Added a visible warning in the admin UI when Email OTP is enabled but SMTP is not configured, and logs a warning with tenant and email details on failed sends. [[1]](diffhunk://#diff-6c98636927c5832ede822a5b4efc36cd44bc0c0e3dcffbdccf0ad563ceba0731R289-R291) [[2]](diffhunk://#diff-c61dc0bb14b43172d4c97b63f69b62bdc4582bfcfe2683956a381014f3578697R855-R857) [[3]](diffhunk://#diff-c8953e9d47a131fb4a710623cc190052175ed20fc0690d932fd29d2166a06e6fR21) [[4]](diffhunk://#diff-c8953e9d47a131fb4a710623cc190052175ed20fc0690d932fd29d2166a06e6fR53-R54) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R74)

**Other improvements:**

- OpenAPI spec now documents the OTP endpoints and new scopes, and the `/api/docs` Swagger page is complete.
- Cleared 33 unnecessary non-null assertion warnings across the codebase for cleaner builds.
- Minor UI and codebase cleanups, including improved null handling and badge logic. [[1]](diffhunk://#diff-cf4ffcba6d2bd0d8bbd8c0b13f674db6b81ca78f33517dbe1b6e0968ecd45df4L189-R191) [[2]](diffhunk://#diff-5824137898b428c898a5cf3b7712f60b3f1a39e35ca220a212996c293a57fccaL303-R303) [[3]](diffhunk://#diff-f9ac24138adba219f48a631bb34d9e524c8057a065a4ecce3a8fcd8869b21057L404-R404)

**Test coverage:**

- Added regression and service tests for the new validation and keyPrefix logic.

These changes improve reliability, operator experience, and observability, and lay the groundwork for the next major feature set.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
