### PR TITLE
refactored admind bootstrap password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 .gradle/
 build/
+.kotlin/
 
 # IntelliJ IDEA
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.14.1] - 2026-06-12
+
+Closes the published-default admin credential window flagged in the
+2026-06-11 security audit.
+
+> **BREAKING CHANGE**
+>
+> The seeded `admin` user is no longer assigned the documented password
+> `changeme123!`. Operators who scripted around that literal must either
+> set `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` or capture the random password
+> printed once to stdout on first boot. See
+> [ENV_REFERENCE.md](docs/ENV_REFERENCE.md#kauth_bootstrap_admin_password).
+
+### Security
+
+- **Default admin credential is gone** — the publicly-documented
+  `changeme123!` password is removed from the codebase, image, and docs.
+  On a fresh database the seeded `admin` is provisioned from
+  `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` if set, otherwise from a 128-bit
+  cryptographically random password printed once to stdout in a clearly
+  framed banner. The high-entropy ephemeral credential is the rotation
+  gate — only the operator who captured the boot log can use it
+- **`KAUTH_BOOTSTRAP_ADMIN_PASSWORD` fail-fast validation** — must be at
+  least 12 characters with upper, lower, and digit; weak values abort
+  startup with a boxed FATAL message rather than silently seeding a poor
+  credential
+- **Demo mode unchanged** — `KAUTH_DEMO_MODE=true` still provisions a
+  fixed, documented demo password (`Demo1234!`, aligned with the
+  existing demo-tenant users) so demo deployments stay usable. Demo
+  mode is already rejected in production by the quickstart-secret check
+
+### Changed
+
+- Demo banner now displays `admin / Demo1234!` to match the new seeded
+  demo credentials
+- The `CHANGE_PASSWORD` required action introduced in 1.14.0 is **no
+  longer set on the seeded admin**. That flag is paired with an
+  admin-issued `TEMP_PASSWORD` token, which the seed path cannot
+  produce, so it locked the operator out of their own instance. The
+  rotation guarantee is now provided by the unique-per-instance random
+  password itself
+
+---
+
 ## [1.14.0] - 2026-06-11
 
 Security hardening release implementing Tier 1 of an internal security audit.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.14.0"
+version = "1.14.1"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/ENV_REFERENCE.md
+++ b/docs/ENV_REFERENCE.md
@@ -279,9 +279,30 @@ Intended for deployments like `demo.kotauth.com` where visitors should see a pop
 
 | Workspace | Username | Password |
 |---|---|---|
-| Master (admin console) | `admin` | `changeme123!` |
+| Master (admin console) | `admin` | `Demo1234!` |
 | Acme Corp | `sarah.chen` | `Demo1234!` |
 | Startup Labs | `jordan.lee` | `Demo1234!` |
+
+---
+
+## Admin Bootstrap
+
+### `KAUTH_BOOTSTRAP_ADMIN_PASSWORD`
+**Optional.** Default: _unset_
+
+The initial password assigned to the seeded `admin` user when Kotauth boots against a fresh database. The seeded admin can sign in directly with this password and rotate it from Profile → Security after first login — no token-redemption flow is required.
+
+Resolution order:
+
+1. **`KAUTH_BOOTSTRAP_ADMIN_PASSWORD` set** — used as-is. Must be at least 12 characters and contain upper, lower, and digit; otherwise startup fails.
+2. **`KAUTH_DEMO_MODE=true`** — uses the documented demo password (`Demo1234!`). Demo mode is rejected in production by the secret-key check.
+3. **Otherwise** — Kotauth generates a 128-bit random password and prints it once to **stdout** at boot inside a clearly-framed banner. Capture the log on first run and store the password.
+
+```
+KAUTH_BOOTSTRAP_ADMIN_PASSWORD=<a strong operator-chosen password>
+```
+
+The legacy default `changeme123!` is removed. Operators who scripted around it must either set this variable or read the random password from the first-boot log.
 
 ---
 

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -246,7 +246,7 @@ The `-v` flag destroys the database volume. On restart, Flyway re-migrates from 
 
 | Login page | Username | Password |
 |---|---|---|
-| `/admin` (master workspace) | `admin` | `changeme123!` |
+| `/admin` (master workspace) | `admin` | `Demo1234!` |
 | `/t/acme/login` | `sarah.chen` | `Demo1234!` |
 | `/t/startup-labs/login` | `jordan.lee` | `Demo1234!` |
 

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -81,6 +81,8 @@ fun main(args: Array<String> = emptyArray()) {
         password = config.dbPassword,
         poolMaxSize = config.dbPoolMaxSize,
         poolMinIdle = config.dbPoolMinIdle,
+        bootstrapAdminPassword = config.bootstrapAdminPassword,
+        isDemoMode = config.isDemoMode,
     )
 
     val services = ServiceGraph.create(config)

--- a/src/main/kotlin/com/kauth/adapter/web/DemoBanner.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/DemoBanner.kt
@@ -32,7 +32,7 @@ fun BODY.demoBanner() {
             +"Data resets periodically · Admin: "
             code { +"admin" }
             +" / "
-            code { +"changeme123!" }
+            code { +"Demo1234!" }
             +" · Acme: "
             code { +"sarah.chen" }
             +" / "

--- a/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
@@ -52,6 +52,7 @@ data class EnvironmentConfig(
     val ssoSessionTtlSeconds: Long,
     val ssoSessionMaxTtlSeconds: Long,
     val bootstrapApiKeysJson: String?,
+    val bootstrapAdminPassword: String?,
     val trustedProxy: Boolean,
 ) {
     val isHttps: Boolean get() = baseUrl.startsWith("https://")
@@ -75,6 +76,10 @@ data class EnvironmentConfig(
             val ssoTtl = System.getenv("KAUTH_SSO_SESSION_TTL_SECONDS")?.toLongOrNull() ?: 86_400L
             val ssoMaxTtl = System.getenv("KAUTH_SSO_SESSION_MAX_TTL_SECONDS")?.toLongOrNull() ?: 2_592_000L
             validateSsoTtls(ssoTtl, ssoMaxTtl)
+
+            val bootstrapAdminPassword =
+                System.getenv("KAUTH_BOOTSTRAP_ADMIN_PASSWORD")?.takeIf { it.isNotBlank() }
+            bootstrapAdminPassword?.let(::validateBootstrapAdminPassword)
 
             return EnvironmentConfig(
                 baseUrl = baseUrl,
@@ -107,6 +112,7 @@ data class EnvironmentConfig(
                 ssoSessionTtlSeconds = ssoTtl,
                 ssoSessionMaxTtlSeconds = ssoMaxTtl,
                 bootstrapApiKeysJson = System.getenv("KAUTH_BOOTSTRAP_API_KEYS")?.takeIf { it.isNotBlank() },
+                bootstrapAdminPassword = bootstrapAdminPassword,
                 trustedProxy = System.getenv("KAUTH_TRUSTED_PROXY")?.lowercase() == "true",
             )
         }
@@ -308,6 +314,25 @@ data class EnvironmentConfig(
                 exitProcess(1)
             }
             return url
+        }
+
+        private fun validateBootstrapAdminPassword(password: String) {
+            val error =
+                com.kauth.infrastructure.AdminBootstrapPassword
+                    .validateOperatorPassword(password) ?: return
+            System.err.println(
+                """
+                ┌──────────────────────────────────────────────────────────────┐
+                │  FATAL: KAUTH_BOOTSTRAP_ADMIN_PASSWORD is too weak.          │
+                │                                                              │
+                │  $error
+                │                                                              │
+                │  Either set a stronger password or unset the variable to     │
+                │  let Kotauth generate one and print it to stdout at boot.    │
+                └──────────────────────────────────────────────────────────────┘
+                """.trimIndent(),
+            )
+            exitProcess(1)
         }
 
         private fun validateLegacySecret(env: String) {

--- a/src/main/kotlin/com/kauth/infrastructure/AdminBootstrapPassword.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/AdminBootstrapPassword.kt
@@ -1,0 +1,42 @@
+package com.kauth.infrastructure
+
+import com.kauth.domain.util.SecureTokens
+
+object AdminBootstrapPassword {
+    const val DEMO_PASSWORD = "Demo1234!"
+    private const val OPERATOR_MIN_LENGTH = 12
+
+    enum class Source { ENV, DEMO, GENERATED }
+
+    data class Resolution(
+        val password: String,
+        val source: Source,
+    )
+
+    fun resolve(
+        envPassword: String?,
+        isDemoMode: Boolean,
+        generator: () -> String = { SecureTokens.randomHex(16) },
+    ): Resolution =
+        when {
+            !envPassword.isNullOrBlank() -> Resolution(envPassword, Source.ENV)
+            isDemoMode -> Resolution(DEMO_PASSWORD, Source.DEMO)
+            else -> Resolution(generator(), Source.GENERATED)
+        }
+
+    fun validateOperatorPassword(password: String): String? {
+        if (password.length < OPERATOR_MIN_LENGTH) {
+            return "KAUTH_BOOTSTRAP_ADMIN_PASSWORD must be at least $OPERATOR_MIN_LENGTH characters."
+        }
+        if (!password.any { it.isUpperCase() }) {
+            return "KAUTH_BOOTSTRAP_ADMIN_PASSWORD must contain an uppercase letter."
+        }
+        if (!password.any { it.isLowerCase() }) {
+            return "KAUTH_BOOTSTRAP_ADMIN_PASSWORD must contain a lowercase letter."
+        }
+        if (!password.any { it.isDigit() }) {
+            return "KAUTH_BOOTSTRAP_ADMIN_PASSWORD must contain a digit."
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/com/kauth/infrastructure/DatabaseFactory.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/DatabaseFactory.kt
@@ -15,20 +15,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 
-/**
- * Infrastructure concern: database connection pool and schema initialization.
- *
- * Initialization order:
- *   1. Run Flyway migrations — creates / evolves the schema in a versioned, auditable way.
- *   2. Create a HikariCP connection pool and connect Exposed to it.
- *   3. Seed the master-tenant admin user only on a fresh database.
- *
- * SchemaUtils.createMissingTablesAndColumns is intentionally removed — it is
- * development-only tooling that cannot handle ALTER TABLE or constraint changes.
- * Flyway owns the schema from here on.
- */
 object DatabaseFactory {
-    /** CLI-only: connect to the database without running Flyway migrations or seeding. */
     fun connectOnly(config: DbConfig) {
         val dataSource = createDataSource(config.dbUrl, config.dbUser, config.dbPassword, 2, 1)
         Database.connect(dataSource)
@@ -40,8 +27,9 @@ object DatabaseFactory {
         password: String,
         poolMaxSize: Int = 10,
         poolMinIdle: Int = 2,
+        bootstrapAdminPassword: String? = null,
+        isDemoMode: Boolean = false,
     ) {
-        // Step 1: run versioned SQL migrations from src/main/resources/db/migration/
         Flyway
             .configure()
             .dataSource(url, user, password)
@@ -49,13 +37,13 @@ object DatabaseFactory {
             .load()
             .migrate()
 
-        // Step 2: create HikariCP pool and connect Exposed
         val dataSource = createDataSource(url, user, password, poolMaxSize, poolMinIdle)
         Database.connect(dataSource)
 
-        // Step 3: seed the default admin user inside the master tenant (first boot only)
         transaction {
-            seedAdminIfEmpty()
+            seedAdminIfEmpty(
+                AdminBootstrapPassword.resolve(bootstrapAdminPassword, isDemoMode),
+            )
         }
     }
 
@@ -73,107 +61,106 @@ object DatabaseFactory {
                 this.password = password
                 driverClassName = "org.postgresql.Driver"
 
-                // Pool sizing — for coroutine-based apps, size to actual DB concurrency
-                // needs (CPU cores × 2), not thread count. Default 10 is safe for
-                // single-instance and small multi-instance deployments (4 × 10 = 40,
-                // well within PostgreSQL's default max_connections = 100).
                 maximumPoolSize = poolMaxSize
                 minimumIdle = poolMinIdle
 
-                // How long a caller waits for a connection from the pool before timing out.
                 connectionTimeout = 3_000
+                idleTimeout = 300_000
+                maxLifetime = 600_000
+                keepaliveTime = 60_000
+                leakDetectionThreshold = 4_000
 
-                // How long an idle connection stays in the pool before eviction.
-                idleTimeout = 300_000 // 5 minutes
-
-                // Hard ceiling on connection age — prevents stale connections that were
-                // silently terminated by firewalls or network devices.
-                maxLifetime = 600_000 // 10 minutes
-
-                // Periodic keepalive prevents idle connections from being killed by
-                // cloud load balancers or PG idle_in_transaction_session_timeout.
-                keepaliveTime = 60_000 // 1 minute
-
-                // Logs a warning with stack trace if a connection is held longer than
-                // this — invaluable for catching N+1 queries and slow admin operations.
-                leakDetectionThreshold = 4_000 // 4 seconds
-
-                // Connection validation
                 connectionTestQuery = "SELECT 1"
-
-                // Pool name for logging and JMX
                 poolName = "kotauth-pg"
             }
         return HikariDataSource(config)
     }
 
-    /**
-     * Seeds a default admin user into the master tenant on a fresh database.
-     *
-     * Resolves the master tenant from the DB (seeded by V1 migration) so the
-     * admin user is correctly scoped — no hardcoded tenant_id assumptions.
-     *
-     * Credentials are BCrypt-hashed. The default password is intentionally weak
-     * and documented — operators MUST change it before any real deployment.
-     */
-    private fun seedAdminIfEmpty() {
-        if (UsersTable.selectAll().empty()) {
-            val masterTenantId =
-                TenantsTable
-                    .selectAll()
-                    .where { TenantsTable.slug eq "master" }
-                    .firstOrNull()
-                    ?.get(TenantsTable.id)
-                    ?: error("Master tenant not found — V1 migration may not have run correctly.")
+    private fun seedAdminIfEmpty(resolution: AdminBootstrapPassword.Resolution) {
+        if (!UsersTable.selectAll().empty()) return
 
-            val hasher = BcryptPasswordHasher()
-            val adminUserId =
-                UsersTable.insert {
-                    it[tenantId] = masterTenantId
-                    it[username] = "admin"
-                    it[email] = "admin@kauth.local"
-                    it[passwordHash] = hasher.hash("changeme123!")
-                    it[fullName] = "KotAuth Administrator"
-                    it[emailVerified] = false
-                    it[enabled] = true
-                    // The default password is documented and weak — force rotation
-                    // on first login via the CHANGE_PASSWORD required action.
-                    it[requiredActions] = listOf("CHANGE_PASSWORD")
-                } get UsersTable.id
+        val masterTenantId =
+            TenantsTable
+                .selectAll()
+                .where { TenantsTable.slug eq "master" }
+                .firstOrNull()
+                ?.get(TenantsTable.id)
+                ?: error("Master tenant not found — V1 migration may not have run correctly.")
 
-            System.err.println(
-                "[WARN] Seeded default admin user 'admin' with a documented default password. " +
-                    "A password change is enforced on first login.",
-            )
+        val hasher = BcryptPasswordHasher()
+        val adminUserId =
+            UsersTable.insert {
+                it[tenantId] = masterTenantId
+                it[username] = "admin"
+                it[email] = "admin@kauth.local"
+                it[passwordHash] = hasher.hash(resolution.password)
+                it[fullName] = "KotAuth Administrator"
+                it[emailVerified] = false
+                it[enabled] = true
+            } get UsersTable.id
 
-            // Assign admin role (created by V28) to the default admin user
-            val adminRoleId =
-                RolesTable
-                    .selectAll()
-                    .where {
-                        (RolesTable.tenantId eq masterTenantId) and
-                            (RolesTable.name eq "admin") and
-                            (RolesTable.scope eq "tenant")
-                    }.firstOrNull()
-                    ?.get(RolesTable.id)
+        announceSeededAdmin(resolution)
+        assignAdminRole(masterTenantId, adminUserId)
+    }
 
-            if (adminRoleId != null) {
-                val alreadyAssigned =
-                    UserRolesTable
-                        .selectAll()
-                        .where {
-                            (UserRolesTable.userId eq adminUserId) and
-                                (UserRolesTable.roleId eq adminRoleId)
-                        }.count() > 0
+    private fun announceSeededAdmin(resolution: AdminBootstrapPassword.Resolution) {
+        when (resolution.source) {
+            AdminBootstrapPassword.Source.ENV ->
+                System.err.println("[INFO] Seeded admin user from KAUTH_BOOTSTRAP_ADMIN_PASSWORD.")
+            AdminBootstrapPassword.Source.DEMO ->
+                System.err.println(
+                    "[INFO] Seeded admin user with the documented demo password. " +
+                        "KAUTH_DEMO_MODE=true must never be used in production.",
+                )
+            AdminBootstrapPassword.Source.GENERATED -> printGeneratedPasswordBanner(resolution.password)
+        }
+    }
 
-                if (!alreadyAssigned) {
-                    UserRolesTable.insert {
-                        it[userId] = adminUserId
-                        it[roleId] = adminRoleId
-                        it[assignedAt] = java.time.OffsetDateTime.now()
-                    }
-                }
-            }
+    private fun printGeneratedPasswordBanner(password: String) {
+        val box =
+            """
+
+            ┌──────────────────────────────────────────────────────────────┐
+            │  Initial admin password (shown ONCE — store it now):         │
+            │      username: admin                                         │
+            │      password: $password
+            │  Rotate it from Profile → Security after first login.        │
+            │  To skip this banner, set KAUTH_BOOTSTRAP_ADMIN_PASSWORD.    │
+            └──────────────────────────────────────────────────────────────┘
+
+            """.trimIndent()
+        println(box)
+        System.err.println("[WARN] Generated initial admin password — see stdout banner above.")
+    }
+
+    private fun assignAdminRole(
+        masterTenantId: Int,
+        adminUserId: Int,
+    ) {
+        val adminRoleId =
+            RolesTable
+                .selectAll()
+                .where {
+                    (RolesTable.tenantId eq masterTenantId) and
+                        (RolesTable.name eq "admin") and
+                        (RolesTable.scope eq "tenant")
+                }.firstOrNull()
+                ?.get(RolesTable.id) ?: return
+
+        val alreadyAssigned =
+            UserRolesTable
+                .selectAll()
+                .where {
+                    (UserRolesTable.userId eq adminUserId) and
+                        (UserRolesTable.roleId eq adminRoleId)
+                }.count() > 0
+
+        if (alreadyAssigned) return
+
+        UserRolesTable.insert {
+            it[userId] = adminUserId
+            it[roleId] = adminRoleId
+            it[assignedAt] = java.time.OffsetDateTime.now()
         }
     }
 }

--- a/src/test/kotlin/com/kauth/adapter/web/DemoConfigTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/DemoConfigTest.kt
@@ -51,7 +51,7 @@ class DemoConfigTest {
         val html = renderBanner()
 
         assertTrue(html.contains("admin"), "Should show admin username")
-        assertTrue(html.contains("changeme123!"), "Should show admin password")
+        assertTrue(html.contains("Demo1234!"), "Should show admin password")
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/infrastructure/AdminBootstrapPasswordTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/AdminBootstrapPasswordTest.kt
@@ -1,0 +1,97 @@
+package com.kauth.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AdminBootstrapPasswordTest {
+    @Test
+    fun `env password takes precedence over demo and generator`() {
+        val resolution =
+            AdminBootstrapPassword.resolve(
+                envPassword = "OperatorSecret123",
+                isDemoMode = true,
+                generator = { error("generator should not run when env is set") },
+            )
+
+        assertEquals(AdminBootstrapPassword.Source.ENV, resolution.source)
+        assertEquals("OperatorSecret123", resolution.password)
+    }
+
+    @Test
+    fun `blank env password falls through to next source`() {
+        val resolution =
+            AdminBootstrapPassword.resolve(
+                envPassword = "   ",
+                isDemoMode = true,
+                generator = { "should-not-be-used" },
+            )
+
+        assertEquals(AdminBootstrapPassword.Source.DEMO, resolution.source)
+        assertEquals(AdminBootstrapPassword.DEMO_PASSWORD, resolution.password)
+    }
+
+    @Test
+    fun `demo mode uses the fixed demo password when env is unset`() {
+        val resolution =
+            AdminBootstrapPassword.resolve(
+                envPassword = null,
+                isDemoMode = true,
+                generator = { error("generator should not run in demo mode") },
+            )
+
+        assertEquals(AdminBootstrapPassword.Source.DEMO, resolution.source)
+        assertEquals(AdminBootstrapPassword.DEMO_PASSWORD, resolution.password)
+    }
+
+    @Test
+    fun `non-demo non-env path invokes the generator`() {
+        val resolution =
+            AdminBootstrapPassword.resolve(
+                envPassword = null,
+                isDemoMode = false,
+                generator = { "generated-token" },
+            )
+
+        assertEquals(AdminBootstrapPassword.Source.GENERATED, resolution.source)
+        assertEquals("generated-token", resolution.password)
+    }
+
+    @Test
+    fun `default generator produces a 32-char hex string`() {
+        val resolution = AdminBootstrapPassword.resolve(envPassword = null, isDemoMode = false)
+
+        assertEquals(AdminBootstrapPassword.Source.GENERATED, resolution.source)
+        assertEquals(32, resolution.password.length)
+        assertTrue(resolution.password.all { it in "0123456789abcdef" })
+    }
+
+    @Test
+    fun `validate rejects passwords shorter than 12 chars`() {
+        val error = AdminBootstrapPassword.validateOperatorPassword("Abc123!")
+        assertNotNull(error)
+        assertTrue(error.contains("12 characters"))
+    }
+
+    @Test
+    fun `validate rejects passwords without an uppercase letter`() {
+        assertNotNull(AdminBootstrapPassword.validateOperatorPassword("nouppercase123"))
+    }
+
+    @Test
+    fun `validate rejects passwords without a lowercase letter`() {
+        assertNotNull(AdminBootstrapPassword.validateOperatorPassword("NOLOWERCASE123"))
+    }
+
+    @Test
+    fun `validate rejects passwords without a digit`() {
+        assertNotNull(AdminBootstrapPassword.validateOperatorPassword("NoDigitsHereOk"))
+    }
+
+    @Test
+    fun `validate accepts a strong password`() {
+        assertNull(AdminBootstrapPassword.validateOperatorPassword("OperatorSecret123"))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a breaking security change to the admin user bootstrap process. The default, publicly-documented `changeme123!` password is removed. Instead, the seeded `admin` user’s password must be set via the new `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` environment variable (with strict validation), or will be generated as a high-entropy random password and printed once at first boot. Demo mode continues to use a fixed, documented password. Documentation, banners, and tests are updated to reflect these changes.

**Security and Admin Bootstrap Changes**
- Removed the default `changeme123!` admin password. On a fresh database, the seeded `admin` user’s password is now set by `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` (if provided and strong enough), otherwise a secure random password is generated and printed to stdout once. Demo mode (`KAUTH_DEMO_MODE=true`) continues to use the fixed `Demo1234!` password. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R53) [[2]](diffhunk://#diff-0f2c79ffa1933128870dcacc181cbe26fb73033f60ee602dcc3b391cdcf60d77R1-R42) [[3]](diffhunk://#diff-a6b1f10d757743af9783c40ae9939b8f3c0fa96855cfede27a22d09fd12fcb16R30-R46) [[4]](diffhunk://#diff-a6b1f10d757743af9783c40ae9939b8f3c0fa96855cfede27a22d09fd12fcb16L135-R139)
- Added strict validation for `KAUTH_BOOTSTRAP_ADMIN_PASSWORD`: must be at least 12 characters and contain upper, lower, and digit; startup fails fast with a clear error if the requirement is not met. [[1]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R80-R83) [[2]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R319-R337) [[3]](diffhunk://#diff-0f2c79ffa1933128870dcacc181cbe26fb73033f60ee602dcc3b391cdcf60d77R1-R42)
- The `CHANGE_PASSWORD` required action is no longer set on the seeded admin, since the unique random password itself enforces rotation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R53) [[2]](diffhunk://#diff-a6b1f10d757743af9783c40ae9939b8f3c0fa96855cfede27a22d09fd12fcb16L135-R139)

**Documentation and UI Updates**
- Updated all documentation and banners to reference the new admin password logic: demo mode now displays `admin / Demo1234!`, and all references to `changeme123!` are removed. [[1]](diffhunk://#diff-7079314005b77522df62a2954352f395a9387ad3230bf5930f60d0904ff12dd6L282-R308) [[2]](diffhunk://#diff-0e177ae755f8caefd638e7594afdb5d1b8362c2f123900910174c6336a61269dL249-R249) [[3]](diffhunk://#diff-c252393bd77cdbca22ceab81ae344cdd22c90d793eb5f56b3b930308a7425da3L35-R35) [[4]](diffhunk://#diff-d803f902a66f76e6091c80e96206d4547977eb7385dfa6c7de4ff49228dbe082L54-R54)
- Added documentation for the new `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` variable and described the password resolution order.

**Codebase Improvements**
- Refactored bootstrap logic into a new `AdminBootstrapPassword` object for password resolution and validation.
- Updated configuration and database factory to support the new bootstrap admin password flow and demo mode flag. [[1]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R55) [[2]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R115) [[3]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81R84-R85) [[4]](diffhunk://#diff-a6b1f10d757743af9783c40ae9939b8f3c0fa96855cfede27a22d09fd12fcb16L76-R81)

**Note:** This is a breaking change. Operators relying on the old default password must update their deployment scripts to set `KAUTH_BOOTSTRAP_ADMIN_PASSWORD` or capture the initial random password from logs.
Closes #

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [ ] New domain logic has no framework imports (hexagonal architecture constraint)
- [ ] New database changes include a Flyway migration
- [ ] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [ ] Security-sensitive changes (auth flows, token handling, encryption) are noted in the description

## Notes for reviewers

<!-- Anything the reviewer should pay particular attention to, known limitations, or follow-up work. -->
