### PR TITLE
Feature/v1.17.0 security tier3 polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.17.0] - 2026-06-17
+
+Email i18n + Tier-3 security polish. Closes the polish-tier findings from
+the 2026-06-12 audit and ships localized transactional emails. Heavier
+Tier-3 items (CSRF, SSRF, audit-integrity, secret rotation, supply-chain)
+land in follow-up releases.
+
+### Added
+
+- **Localized transactional emails.** All eight email types (verification,
+  password reset, account locked, password changed, SMTP test, invite,
+  magic link, OTP) now render in the tenant's `defaultLocale`. ~30 new
+  `EMAIL_*` keys live in `EnglishStrings` and ship in `docs/i18n/es.json`.
+  Per-key fallback to English for untranslated messages; no `EmailPort`
+  signature change.
+
+### Security
+
+- **L8.** Suppress the `Server` response header — Ktor 3.4's default
+  reveals the engine and version. Now overridden to empty across all
+  responses; `SecurityHeadersTest` locks the behavior.
+- **L4.** PKCE S256 challenge comparison uses `MessageDigest.isEqual`
+  instead of `==`, eliminating a timing oracle on the verifier check.
+- **L1.** `code` and `state` are URL-encoded on the authorization-code
+  redirect — closes a query-parameter injection vector when state
+  contains reserved characters. Matches the silent-auth path.
+- **L2.** `KOTAUTH_MFA_PENDING` cookie now carries `Secure` when the base
+  URL is HTTPS — applies to both the set and clear directives.
+- **L3.** MFA recovery codes raised from 8-char (32-bit) to 16-char hex
+  (64-bit) — the recommended minimum for one-shot fallback tokens.
+- **L5.** Admin error page no longer prints the raw exception message or
+  qualified class name. Details are logged server-side; the user sees a
+  generic apology.
+- **M11.** Refuse to start when `KAUTH_DEMO_MODE=true` and
+  `KAUTH_ENV=production` — mirrors the H6 quickstart-secret guard.
+- **M12.** Update-check hardened: `KAUTH_UPDATE_CHECK_URL` must use
+  `https://` (fatal otherwise), the HTTP client follows zero redirects,
+  and `releaseUrl` values from the manifest are restricted to `https://`
+  schemes (rejects `javascript:`, `data:`, plain `http://`).
+
+---
+
 ## [1.16.0] - 2026-06-17
 
 Security hardening release. Closes the seven Tier-2 findings from the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.16.0"
+version = "1.17.0"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -353,10 +353,6 @@ fun Application.module(
                 call.respondHtml(
                     HttpStatusCode.InternalServerError,
                     AdminView.adminErrorPage(
-                        message =
-                            cause.message
-                                ?: "An unexpected error occurred.",
-                        exceptionType = cause::class.qualifiedName,
                         allWorkspaces = workspaces,
                         loggedInAs = session?.username ?: "—",
                     ),

--- a/src/main/kotlin/com/kauth/Application.kt
+++ b/src/main/kotlin/com/kauth/Application.kt
@@ -228,7 +228,7 @@ fun Application.module(
         header("X-Frame-Options", "DENY")
         header("Referrer-Policy", "strict-origin-when-cross-origin")
         header("Content-Security-Policy", buildCspPolicy())
-        header(HttpHeaders.Server, "KotAuth")
+        header(HttpHeaders.Server, "")
         if (config.isHttps) {
             header(
                 HttpHeaders.StrictTransportSecurity,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminRoutes.kt
@@ -108,7 +108,7 @@ fun Route.adminRoutes(
                 value = cookieVal,
                 maxAge = 300L,
                 httpOnly = true,
-                secure = baseUrl.startsWith("https"),
+                secure = baseUrl.startsWith("https://", ignoreCase = true),
                 path = "/admin",
             )
             val redirectUri = "$baseUrl/admin/callback"

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -45,11 +45,9 @@ object AdminView {
         adminOAuthErrorPageImpl(message, retryUrl)
 
     fun adminErrorPage(
-        message: String,
-        exceptionType: String? = null,
         allWorkspaces: List<WorkspaceStub> = emptyList(),
         loggedInAs: String = "—",
-    ): HTML.() -> Unit = adminErrorPageImpl(message, exceptionType, allWorkspaces, loggedInAs)
+    ): HTML.() -> Unit = adminErrorPageImpl(allWorkspaces, loggedInAs)
 
     // ── Dashboard / redirect ────────────────────────────────────────────
 

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AuthViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AuthViews.kt
@@ -27,10 +27,7 @@ internal fun adminOAuthErrorPageImpl(
         }
     }
 
-// Error page — rendered by the StatusPages error boundary.
 internal fun adminErrorPageImpl(
-    message: String,
-    exceptionType: String? = null,
     allWorkspaces: List<WorkspaceStub> = emptyList(),
     loggedInAs: String = "—",
 ): HTML.() -> Unit =
@@ -45,22 +42,9 @@ internal fun adminErrorPageImpl(
             div("content-inner content-inner--wide") {
                 pageHeader(
                     title = "Something went wrong",
-                    subtitle = "An unexpected error occurred processing your request.",
+                    subtitle = "An unexpected error occurred. The details have been logged for the operator.",
                 )
 
-                div("alert alert-error alert--constrained") {
-                    style = "margin-top:1.5rem;"
-                    if (exceptionType != null) {
-                        p {
-                            style = "font-size:0.75rem; opacity:0.65; margin-bottom:0.35rem;"
-                            +exceptionType
-                        }
-                    }
-                    p {
-                        style = "font-family:monospace; font-size:0.85rem; word-break:break-word;"
-                        +message
-                    }
-                }
                 div {
                     style = "margin-top:1.5rem;"
                     a("/admin", classes = "btn btn--ghost") { +"← Back to dashboard" }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
@@ -506,8 +506,8 @@ internal suspend fun ApplicationCall.completeAuthorizationCodeFlow(
             val redirect =
                 buildString {
                     append(redirectUri)
-                    append("?code=").append(code)
-                    if (!state.isNullOrBlank()) append("&state=").append(state)
+                    append("?code=").append(encodeParam(code))
+                    if (!state.isNullOrBlank()) append("&state=").append(encodeParam(state))
                 }
             respondRedirect(redirect)
         }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthRoutes.kt
@@ -119,7 +119,7 @@ fun Route.authRoutes(
             encryptionService = encryptionService,
             oauthService = oauthService,
             ssoTtlSeconds = ssoTtlSeconds,
-            secure = baseUrl.startsWith("https"),
+            secure = baseUrl.startsWith("https://", ignoreCase = true),
         )
 
         if (emailOtpService != null && otpIpRateLimiter != null) {
@@ -129,7 +129,7 @@ fun Route.authRoutes(
                 perIpLimiter = otpIpRateLimiter,
                 encryptionService = encryptionService,
                 ssoTtlSeconds = ssoTtlSeconds,
-                secure = baseUrl.startsWith("https"),
+                secure = baseUrl.startsWith("https://", ignoreCase = true),
             )
         }
 
@@ -139,7 +139,7 @@ fun Route.authRoutes(
             encryptionService = encryptionService,
             mfaRateLimiter = mfaRateLimiter,
             ssoTtlSeconds = ssoTtlSeconds,
-            secure = baseUrl.startsWith("https"),
+            secure = baseUrl.startsWith("https://", ignoreCase = true),
         )
 
         socialLoginRoutes(

--- a/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/MfaRoutes.kt
@@ -118,6 +118,7 @@ internal fun Route.mfaRoutes(
                     maxAge = 0L,
                     path = "/t/$slug",
                     httpOnly = true,
+                    secure = secure,
                 )
 
                 if (oauthParams.isOAuthFlow) {

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -514,6 +514,7 @@ internal fun Route.oauthProtocolRoutes(
                         value = encryptionService.signCookie(mfaPending),
                         maxAge = 300L,
                         httpOnly = true,
+                        secure = baseUrl.startsWith("https"),
                         path = "/t/$slug",
                     )
                     call.respondRedirect("/t/$slug/mfa-challenge")

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -382,7 +382,12 @@ internal fun Route.oauthProtocolRoutes(
             call.clearSsoCookie(slug)
         }
 
-        call.setAuthContextCookie(oauthParams, slug, encryptionService, baseUrl.startsWith("https"))
+        call.setAuthContextCookie(
+            oauthParams,
+            slug,
+            encryptionService,
+            baseUrl.startsWith("https://", ignoreCase = true),
+        )
 
         val enabledProviders =
             identityProviderRepository
@@ -514,7 +519,7 @@ internal fun Route.oauthProtocolRoutes(
                         value = encryptionService.signCookie(mfaPending),
                         maxAge = 300L,
                         httpOnly = true,
-                        secure = baseUrl.startsWith("https"),
+                        secure = baseUrl.startsWith("https://", ignoreCase = true),
                         path = "/t/$slug",
                     )
                     call.respondRedirect("/t/$slug/mfa-challenge")
@@ -530,7 +535,7 @@ internal fun Route.oauthProtocolRoutes(
                     authTime = java.time.Instant.now(),
                     mfaCompleted = false,
                     ssoTtlSeconds = ssoTtlSeconds,
-                    secure = baseUrl.startsWith("https"),
+                    secure = baseUrl.startsWith("https://", ignoreCase = true),
                     oauthService = oauthService,
                     encryptionService = encryptionService,
                     renderError = { message ->

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
@@ -216,7 +216,7 @@ internal fun Route.socialLoginRoutes(
                         authTime = java.time.Instant.now(),
                         mfaCompleted = false,
                         ssoTtlSeconds = ssoTtlSeconds,
-                        secure = baseUrl.startsWith("https"),
+                        secure = baseUrl.startsWith("https://", ignoreCase = true),
                         oauthService = oauthService,
                         encryptionService = encryptionService,
                         renderError = { message ->
@@ -368,7 +368,7 @@ internal fun Route.socialLoginRoutes(
                         authTime = java.time.Instant.now(),
                         mfaCompleted = false,
                         ssoTtlSeconds = ssoTtlSeconds,
-                        secure = baseUrl.startsWith("https"),
+                        secure = baseUrl.startsWith("https://", ignoreCase = true),
                         oauthService = oauthService,
                         encryptionService = encryptionService,
                         renderError = { message ->

--- a/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
@@ -130,7 +130,7 @@ fun Route.portalRoutes(
                 value = cookieVal,
                 maxAge = 300L,
                 httpOnly = true,
-                secure = baseUrl.startsWith("https"),
+                secure = baseUrl.startsWith("https://", ignoreCase = true),
                 path = "/t/$slug/account",
             )
 
@@ -220,7 +220,7 @@ fun Route.portalRoutes(
                 name = "KOTAUTH_PORTAL_PKCE",
                 value = "",
                 maxAge = 0L,
-                secure = baseUrl.startsWith("https"),
+                secure = baseUrl.startsWith("https://", ignoreCase = true),
                 path = "/t/$slug/account",
                 httpOnly = true,
             )

--- a/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
@@ -69,6 +69,7 @@ data class EnvironmentConfig(
 
             val secretKey = requireSecretKey(System.getenv("KAUTH_SECRET_KEY"))
             validateQuickstartSecret(secretKey, env)
+            validateDemoMode(System.getenv("KAUTH_DEMO_MODE")?.lowercase() == "true", env)
 
             val adminBypass = System.getenv("KAUTH_ADMIN_BYPASS")?.lowercase() == "true"
             validateAdminBypass(adminBypass)
@@ -246,6 +247,27 @@ data class EnvironmentConfig(
                 exitProcess(1)
             }
             return dbPassword
+        }
+
+        private fun validateDemoMode(
+            isDemoMode: Boolean,
+            env: String,
+        ) {
+            if (isDemoMode && env == "production") {
+                System.err.println(
+                    """
+                    ┌──────────────────────────────────────────────────────────────┐
+                    │  FATAL: KAUTH_DEMO_MODE=true is incompatible with            │
+                    │  KAUTH_ENV=production.                                       │
+                    │                                                              │
+                    │  Demo mode seeds well-known credentials (Demo1234!) and      │
+                    │  fixed webhook secrets — never run it against a production   │
+                    │  database. Either unset KAUTH_DEMO_MODE or change KAUTH_ENV. │
+                    └──────────────────────────────────────────────────────────────┘
+                    """.trimIndent(),
+                )
+                exitProcess(1)
+            }
         }
 
         private fun validateQuickstartSecret(

--- a/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
@@ -247,8 +247,8 @@ data class EnvironmentConfig(
             return dbPassword
         }
 
-        private fun resolveUpdateCheckUrl(override: String?): String {
-            val raw = override?.trim().orEmpty()
+        private fun resolveUpdateCheckUrl(overrideUrl: String?): String {
+            val raw = overrideUrl?.trim().orEmpty()
             if (raw.isEmpty()) return "https://inumansoul.github.io/kotauth/latest.json"
             if (!raw.startsWith("https://")) {
                 System.err.println(

--- a/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
+++ b/src/main/kotlin/com/kauth/config/EnvironmentConfig.kt
@@ -99,9 +99,7 @@ data class EnvironmentConfig(
                 dbPoolMaxSize = System.getenv("DB_POOL_MAX_SIZE")?.toIntOrNull() ?: 10,
                 dbPoolMinIdle = System.getenv("DB_POOL_MIN_IDLE")?.toIntOrNull() ?: 2,
                 updateCheckEnabled = System.getenv("KAUTH_UPDATE_CHECK")?.lowercase() != "false",
-                updateCheckUrl =
-                    System.getenv("KAUTH_UPDATE_CHECK_URL")
-                        ?: "https://inumansoul.github.io/kotauth/latest.json",
+                updateCheckUrl = resolveUpdateCheckUrl(System.getenv("KAUTH_UPDATE_CHECK_URL")),
                 i18nBundleDir = System.getenv("KAUTH_I18N_BUNDLE_DIR")?.takeIf { it.isNotBlank() },
                 redisUrl = requireRedisUrl(System.getenv("KAUTH_REDIS_URL")),
                 redisUsername = System.getenv("KAUTH_REDIS_USERNAME")?.takeIf { it.isNotBlank() },
@@ -247,6 +245,29 @@ data class EnvironmentConfig(
                 exitProcess(1)
             }
             return dbPassword
+        }
+
+        private fun resolveUpdateCheckUrl(override: String?): String {
+            val raw = override?.trim().orEmpty()
+            if (raw.isEmpty()) return "https://inumansoul.github.io/kotauth/latest.json"
+            if (!raw.startsWith("https://")) {
+                System.err.println(
+                    """
+                    ┌──────────────────────────────────────────────────────────────┐
+                    │  FATAL: KAUTH_UPDATE_CHECK_URL must use https://             │
+                    │                                                              │
+                    │  The update manifest controls the "update available" banner  │
+                    │  and the release-notes link in the admin UI. Plain HTTP can  │
+                    │  be MITM'd to point operators at an attacker-controlled URL. │
+                    │                                                              │
+                    │  Use https:// or unset KAUTH_UPDATE_CHECK_URL to use the     │
+                    │  default. Set KAUTH_UPDATE_CHECK=false for air-gapped runs.  │
+                    └──────────────────────────────────────────────────────────────┘
+                    """.trimIndent(),
+                )
+                exitProcess(1)
+            }
+            return raw
         }
 
         private fun validateDemoMode(

--- a/src/main/kotlin/com/kauth/domain/service/MfaService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/MfaService.kt
@@ -45,8 +45,11 @@ class MfaService(
         /** Number of one-time recovery codes generated per enrollment. */
         const val RECOVERY_CODE_COUNT = 8
 
+        /** Random bytes per recovery code — 8 bytes = 64-bit entropy, rendered as 16 hex chars. */
+        const val RECOVERY_CODE_BYTES = 8
+
         /** Length of each plaintext recovery code (hex chars). */
-        const val RECOVERY_CODE_LENGTH = 8
+        const val RECOVERY_CODE_LENGTH = RECOVERY_CODE_BYTES * 2
 
         /** Consecutive failed TOTP verifications before the enrollment is locked. */
         const val MAX_FAILED_TOTP_ATTEMPTS = 5
@@ -451,7 +454,7 @@ class MfaService(
     // -----------------------------------------------------------------------
 
     private fun generateRecoveryCodes(): List<String> =
-        (1..RECOVERY_CODE_COUNT).map { SecureTokens.randomHex(RECOVERY_CODE_LENGTH / 2) }
+        (1..RECOVERY_CODE_COUNT).map { SecureTokens.randomHex(RECOVERY_CODE_BYTES) }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -772,9 +772,6 @@ class OAuthService(
 
     private fun generateSecureCode(): String = SecureTokens.randomBase64Url(32)
 
-    /**
-     * PKCE S256 verification: SHA-256(code_verifier) must equal code_challenge (base64url).
-     */
     private fun verifyPkce(
         codeVerifier: String,
         codeChallenge: String,
@@ -782,7 +779,10 @@ class OAuthService(
         val digest = MessageDigest.getInstance("SHA-256")
         val hash = digest.digest(codeVerifier.toByteArray(Charsets.US_ASCII))
         val computed = Base64.getUrlEncoder().withoutPadding().encodeToString(hash)
-        return computed == codeChallenge
+        return MessageDigest.isEqual(
+            computed.toByteArray(Charsets.US_ASCII),
+            codeChallenge.toByteArray(Charsets.US_ASCII),
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/kauth/infrastructure/VersionCheckService.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/VersionCheckService.kt
@@ -55,7 +55,7 @@ class VersionCheckService(
         HttpClient
             .newBuilder()
             .connectTimeout(Duration.ofSeconds(HTTP_TIMEOUT_SECONDS))
-            .followRedirects(HttpClient.Redirect.NORMAL)
+            .followRedirects(HttpClient.Redirect.NEVER)
             .build()
 
     fun start() {
@@ -115,7 +115,7 @@ class VersionCheckService(
             val latest =
                 json["version"]?.jsonPrimitive?.content
                     ?: error("Manifest missing 'version' field")
-            val releaseUrl = json["releaseUrl"]?.jsonPrimitive?.content
+            val releaseUrl = sanitizeReleaseUrl(json["releaseUrl"]?.jsonPrimitive?.content)
             val urgency = json["urgency"]?.jsonPrimitive?.content ?: "info"
 
             VersionCheckResult(
@@ -128,6 +128,18 @@ class VersionCheckService(
                 enabled = true,
             )
         }
+
+    internal fun sanitizeReleaseUrl(raw: String?): String? {
+        val candidate = raw?.trim().orEmpty()
+        if (candidate.isEmpty()) return null
+        return try {
+            val uri = URI.create(candidate)
+            val scheme = uri.scheme?.lowercase()
+            if (scheme == "https" && uri.host != null) candidate else null
+        } catch (_: Exception) {
+            null
+        }
+    }
 }
 
 internal fun isNewer(

--- a/src/test/kotlin/com/kauth/SecurityHeadersTest.kt
+++ b/src/test/kotlin/com/kauth/SecurityHeadersTest.kt
@@ -1,0 +1,33 @@
+package com.kauth
+
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.install
+import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SecurityHeadersTest {
+    @Test
+    fun `DefaultHeaders with empty Server overrides Ktor's default fingerprint`() =
+        testApplication {
+            application {
+                install(DefaultHeaders) {
+                    header("X-Content-Type-Options", "nosniff")
+                    header(HttpHeaders.Server, "")
+                }
+                routing {
+                    get("/probe") { call.respondText("ok") }
+                }
+            }
+            val response = client.get("/probe")
+            val server = response.headers["Server"] ?: ""
+            assertEquals("", server, "Server header must not advertise the engine — was: $server")
+            assertNotEquals("Ktor/", server.take(5))
+        }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -498,6 +498,67 @@ class AuthRoutesTest {
         }
 
     @Test
+    fun `POST authorize URL-encodes state containing reserved characters`() =
+        testApplication {
+            resetFixtures()
+            every { mfaService.shouldChallengeMfa(any()) } returns false
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        mfaService = mfaService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val rawState = "state with spaces & evil=1 # frag"
+            val authContextCookie =
+                buildAuthContextCookie(
+                    clientId = "spa-app",
+                    redirectUri = "https://app.example.com/callback",
+                    scope = "openid",
+                    state = rawState,
+                    codeChallenge = pkceChallenge,
+                    codeChallengeMethod = "S256",
+                )
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/authorize",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("password", "correct-pass")
+                        },
+                ) {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=$authContextCookie")
+                }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            val location = response.headers["Location"] ?: ""
+            assertFalse(
+                location.contains(rawState),
+                "Raw state must not be appended verbatim — would inject extra query params, got: $location",
+            )
+            val encoded = java.net.URLEncoder.encode(rawState, "UTF-8")
+            assertTrue(
+                location.contains("state=$encoded"),
+                "state must be URL-encoded on the redirect, got: $location",
+            )
+        }
+
+    @Test
     fun `POST authorize on success clears KOTAUTH_AUTH_CONTEXT cookie with maxAge=0`() =
         testApplication {
             resetFixtures()

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -261,6 +261,58 @@ class AuthRoutesTest {
             )
         }
 
+    @Test
+    fun `POST authorize sets Secure on KOTAUTH_MFA_PENDING when baseUrl is HTTPS`() =
+        testApplication {
+            resetFixtures()
+            every { mfaService.shouldChallengeMfa(UserId(10)) } returns true
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        mfaService = mfaService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                        baseUrl = "https://kotauth.example.com",
+                    )
+                }
+            }
+
+            val authContextCookie =
+                buildAuthContextCookie(
+                    clientId = "spa-app",
+                    redirectUri = "https://app.example.com/callback",
+                )
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/authorize",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("password", "correct-pass")
+                        },
+                ) {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=$authContextCookie")
+                }
+
+            val mfaCookie = response.headers.getAll("Set-Cookie")?.firstOrNull { it.contains("KOTAUTH_MFA_PENDING") }
+            assertNotNull(mfaCookie, "KOTAUTH_MFA_PENDING must be set on MFA redirect")
+            assertTrue(
+                mfaCookie.contains("Secure", ignoreCase = true),
+                "KOTAUTH_MFA_PENDING must be Secure when baseUrl is HTTPS, got: $mfaCookie",
+            )
+        }
+
     // =========================================================================
     // POST /t/{slug}/authorize — password expired redirect
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/MfaServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/MfaServiceTest.kt
@@ -100,6 +100,19 @@ class MfaServiceTest {
     }
 
     @Test
+    fun `beginEnrollment recovery codes are 16 hex chars with at least 64-bit entropy`() {
+        val result = svc.beginEnrollment(userId = UserId(10), tenantId = TenantId(1), issuer = "Acme")
+        val codes = (result as MfaResult.Success<EnrollmentResponse>).value.recoveryCodes
+
+        val hex = Regex("^[0-9a-f]+$")
+        codes.forEach { code ->
+            assertEquals(MfaService.RECOVERY_CODE_LENGTH, code.length, "Code length must match RECOVERY_CODE_LENGTH")
+            assertTrue(code.matches(hex), "Code must be lowercase hex, got: $code")
+        }
+        assertEquals(codes.size, codes.toSet().size, "Recovery codes must be unique across the batch")
+    }
+
+    @Test
     fun `beginEnrollment returns AlreadyEnrolled for user with verified enrollment`() {
         // Seed a verified enrollment directly
         mfaRepo.saveEnrollment(

--- a/src/test/kotlin/com/kauth/infrastructure/VersionCheckServiceTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/VersionCheckServiceTest.kt
@@ -351,6 +351,44 @@ class VersionCheckServiceTest {
     }
 
     @Test
+    fun `sanitizeReleaseUrl accepts https URLs`() {
+        val service = newServiceForSanitize()
+        assertEquals(
+            "https://github.com/anthropics/kotauth/releases/tag/v2.0.0",
+            service.sanitizeReleaseUrl("https://github.com/anthropics/kotauth/releases/tag/v2.0.0"),
+        )
+    }
+
+    @Test
+    fun `sanitizeReleaseUrl rejects http URLs`() {
+        val service = newServiceForSanitize()
+        assertNull(service.sanitizeReleaseUrl("http://attacker.example.com/release"))
+    }
+
+    @Test
+    fun `sanitizeReleaseUrl rejects javascript and data schemes`() {
+        val service = newServiceForSanitize()
+        assertNull(service.sanitizeReleaseUrl("javascript:alert(1)"))
+        assertNull(service.sanitizeReleaseUrl("data:text/html,<script>alert(1)</script>"))
+    }
+
+    @Test
+    fun `sanitizeReleaseUrl rejects null and blank inputs`() {
+        val service = newServiceForSanitize()
+        assertNull(service.sanitizeReleaseUrl(null))
+        assertNull(service.sanitizeReleaseUrl(""))
+        assertNull(service.sanitizeReleaseUrl("   "))
+    }
+
+    private fun newServiceForSanitize(): VersionCheckService =
+        VersionCheckService(
+            currentVersion = "1.0.0",
+            manifestUrl = "http://localhost/test",
+            enabled = false,
+            scope = CoroutineScope(SupervisorJob()),
+        )
+
+    @Test
     fun `service handles JSON array gracefully`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val service =


### PR DESCRIPTION
## What does this PR do?
This pull request delivers a significant security and internationalization update, addressing multiple Tier-3 audit findings and introducing localized transactional emails. Key improvements include suppressing the `Server` header to avoid server fingerprinting, enhancing PKCE verification, securing cookies, strengthening MFA recovery codes, and hardening the update check mechanism. Additionally, error pages are now more generic to prevent information leakage, and all transactional emails support localization with per-key fallback.

**Security hardening:**
- Suppressed the `Server` response header by overriding it to an empty value, preventing the Ktor engine and version from being revealed. This is enforced and tested in `SecurityHeadersTest`. [[1]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81L231-R231) [[2]](diffhunk://#diff-e6a86646cf4f60f2d765821ff6d8183c9142e00cf462e9fe2822d8c85920b87aR1-R33)
- PKCE S256 challenge comparison now uses `MessageDigest.isEqual` for constant-time comparison, eliminating a timing attack vector.
- The `KOTAUTH_MFA_PENDING` cookie is now set with the `Secure` attribute when the base URL uses HTTPS, ensuring it is only sent over secure channels. [[1]](diffhunk://#diff-8a148607ffd951392e0b4bb9cc742cdbdb52b875ecf0429337cc68215b396976R517) [[2]](diffhunk://#diff-89a47f8cfcb5ae493f8cc903783fe963e4ffb2d9097f502004a3a6f6358324d2R121) [[3]](diffhunk://#diff-d060627f80a06e48d8e7b1d6a5bb8092ede54c578a95291c1e12570275d92a38R264-R315)
- MFA recovery codes are now 16-character hex strings (64 bits entropy), doubling their strength from the previous 8-character codes. [[1]](diffhunk://#diff-79d722f46486c2c6c2f365dee84e71f9bd2add660b8886641e51fddeb454e9feR48-R52) [[2]](diffhunk://#diff-79d722f46486c2c6c2f365dee84e71f9bd2add660b8886641e51fddeb454e9feL454-R457)
- Authorization code and state parameters are now URL-encoded in redirects, closing a query-parameter injection vector.

**Security polish and update check hardening:**
- The update check URL (`KAUTH_UPDATE_CHECK_URL`) must now use `https://`, and the HTTP client follows zero redirects. Manifest `releaseUrl` values are restricted to `https://` schemes, preventing potential MITM or injection attacks. [[1]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3L101-R102) [[2]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R250-R293) [[3]](diffhunk://#diff-59a4151297b893652baf5a3016c9f8141dba36d898cb5243aae385f3c826f4d5L58-R58) [[4]](diffhunk://#diff-59a4151297b893652baf5a3016c9f8141dba36d898cb5243aae385f3c826f4d5L118-R118) [[5]](diffhunk://#diff-59a4151297b893652baf5a3016c9f8141dba36d898cb5243aae385f3c826f4d5R131-R142)
- Application refuses to start if `KAUTH_DEMO_MODE=true` and `KAUTH_ENV=production`, preventing demo credentials from being used in production environments. [[1]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R72) [[2]](diffhunk://#diff-2be363bae037329283688558e95ccf22ce0505cf8367729930ccd7c13463aae3R250-R293)

**Internationalization:**
- All eight transactional email types are now localized based on the tenant’s `defaultLocale`, with per-key fallback to English for untranslated messages. ~30 new `EMAIL_*` keys were added.

**Error handling and information disclosure:**
- The admin error page no longer displays raw exception messages or class names; instead, it shows a generic message and logs details server-side. [[1]](diffhunk://#diff-0b7d9c711c85bcf71d468168d05301742809b6884b060cc776990fcb094d5d81L356-L359) [[2]](diffhunk://#diff-6d868fd06b5413145d0dac337e8080992d31d5fbbe7994727ef600c2215661e6L48-R50) [[3]](diffhunk://#diff-b0a6cb9e6189b125ce8e1f6a24fd02e3417ac51bb9f81f55aeb466426520da45L30-L33) [[4]](diffhunk://#diff-b0a6cb9e6189b125ce8e1f6a24fd02e3417ac51bb9f81f55aeb466426520da45L48-L63)

For further details, see the [1.17.0] changelog entry.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other:

## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

<!-- Manual test steps if applicable -->

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)