### PR TITLE
feature/v1.19.0-audit-integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.19.0] - 2026-06-19
+
+Audit integrity + multi-audience introspection. Closes the M9 finding from the
+2026-06-12 security audit and the documented v1.18.0 limitation around
+multi-resource token introspection.
+
+### Security
+
+- **Audit log details are now built with kotlinx.serialization.** Hand-concatenated
+  JSON in `PostgresAuditLogAdapter` was silently corruptible when any detail value
+  contained quotes, backslashes, or control characters. Switched to
+  `buildJsonObject`; values are escaped correctly and the resulting JSONB always
+  round-trips.
+- **HMAC chain over the audit log.** Each row carries a `prev_hash` and `row_hash`
+  derived from an HMAC-SHA256 keyed by `KAUTH_SECRET_KEY`. Tampering with a row or
+  reordering rows breaks the chain and is detected by a new `verify-audit-chain` CLI
+  command. Per-tenant chains; first row in a tenant has `prev_hash = NULL`.
+- **Recommended Postgres role separation** for `audit_log` documented in
+  `docs/operations/audit-log.md` — the app user gets `INSERT, SELECT`; a separate
+  maintenance role keeps `UPDATE/DELETE` for legitimate backups and migrations.
+
+### Changed
+
+- **`AccessTokenClaims.aud` widened from `String` to `List<String>`.** Multi-aud tokens
+  now decode correctly throughout introspection and any future internal `aud`
+  checks. The introspection response (RFC 7662 §2.2) now emits `aud` — a JSON
+  string for one audience, a JSON array for two or more.
+
+### Migrations
+
+- `V52__audit_log_chain.sql` adds `prev_hash`, `row_hash`, `chain_key_id` columns to
+  `audit_log`. Existing rows keep these `NULL`; new rows always populate them.
+
+---
+
 ## [1.18.0] - 2026-06-17
 
 Audience-targeted M2M tokens — RFC 8707 Resource Indicators. Tokens

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.18.0"
+version = "1.19.0"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/operations/audit-log.md
+++ b/docs/operations/audit-log.md
@@ -1,0 +1,105 @@
+# Audit Log Operations
+
+## Overview
+
+The `audit_log` table records security events (logins, token issuance, admin actions, etc.)
+across all tenants. As of v1.19.0, each row carries an HMAC-SHA256 hash chaining it to the
+previous row in the same tenant, forming a tamper-evident ledger.
+
+### Chain columns
+
+| Column | Type | Description |
+|---|---|---|
+| `prev_hash` | `BYTEA` | `row_hash` of the immediately preceding row for the same `tenant_id`. `NULL` for the first row per tenant. |
+| `row_hash` | `BYTEA` | HMAC-SHA256 over the canonical row string (see `AuditChainHasher.kt`). |
+| `chain_key_id` | `VARCHAR(32)` | First 8 hex chars of `sha256(auditMacKey)` — identifies which `KAUTH_SECRET_KEY` signed the chain. |
+
+The MAC key is derived once at startup:
+
+```
+auditMacKey = sha256("$KAUTH_SECRET_KEY|kauth/audit-log/v1")
+```
+
+Rows inserted before v1.19.0 have `NULL` in all three columns ("pre-chain" rows). The
+verifier treats them as a chain reset — they do not constitute a break.
+
+---
+
+## Recommended Postgres Role Separation
+
+Restrict the application user to `INSERT` and `SELECT` only on `audit_log`. A separate
+maintenance role retains `UPDATE` and `DELETE` for legitimate backups and schema migrations.
+
+```sql
+-- Restrict the application user to INSERT and SELECT only on audit_log.
+-- A separate maintenance role retains UPDATE and DELETE for legitimate backups
+-- and schema migrations.
+REVOKE UPDATE, DELETE ON audit_log FROM kauth_app;
+GRANT SELECT, INSERT ON audit_log TO kauth_app;
+
+-- Create a maintenance role for backups and migrations:
+CREATE ROLE kauth_maintenance;
+GRANT SELECT, INSERT, UPDATE, DELETE ON audit_log TO kauth_maintenance;
+```
+
+This does not prevent all tampering (a superuser or DBA can always act directly), but it
+closes the common case of application-level SQL injection or a compromised application
+credential being used to delete or alter rows.
+
+**Do not add a Postgres trigger to hard-block `UPDATE`/`DELETE`** — that would prevent
+`pg_dump`/`pg_restore` during legitimate backup and restore operations.
+
+---
+
+## Verifying Chain Integrity
+
+Use the `verify-audit-chain` CLI command to walk the chain and detect divergences:
+
+```bash
+# Verify all tenants
+KAUTH_SECRET_KEY=... DB_URL=... DB_USER=... DB_PASSWORD=... \
+  java -jar kauth.jar cli verify-audit-chain
+
+# Verify a single tenant
+KAUTH_SECRET_KEY=... DB_URL=... DB_USER=... DB_PASSWORD=... \
+  java -jar kauth.jar cli verify-audit-chain --tenant=acme
+
+# Verify from a specific row onwards
+KAUTH_SECRET_KEY=... DB_URL=... DB_USER=... DB_PASSWORD=... \
+  java -jar kauth.jar cli verify-audit-chain --tenant=acme --from-id=1000
+
+# Quiet mode (no output on success; exit 1 only on divergence)
+KAUTH_SECRET_KEY=... DB_URL=... DB_USER=... DB_PASSWORD=... \
+  java -jar kauth.jar cli verify-audit-chain --quiet
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | Chain is intact for all verified tenants |
+| 1 | At least one divergence detected — see stderr for details |
+| 2 | No rows found (possible config error — check `DB_URL` and tenant slug) |
+
+### Pre-chain rows
+
+Rows with `row_hash IS NULL` were written before v1.19.0. The verifier prints:
+
+```
+tenant=acme id=123: pre-chain (no row_hash, skipped)
+```
+
+and resets the previous-hash tracking. This is expected and does not signal tampering.
+The chain resumes cleanly from the first post-upgrade row.
+
+---
+
+## Rotating KAUTH_SECRET_KEY
+
+If you rotate `KAUTH_SECRET_KEY`, the new key will derive a different `auditMacKey`. Rows
+written under the old key will no longer verify with the new key — `verify-audit-chain`
+will report every post-key-rotation row as a divergence when run with the old key.
+
+The `chain_key_id` column identifies which key signed each row. If you are auditing across
+a key rotation, run `verify-audit-chain` twice: once with the old key for rows matching the
+old `chain_key_id`, and once with the new key for newer rows.

--- a/src/main/kotlin/com/kauth/adapter/persistence/AuditLogTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/AuditLogTable.kt
@@ -18,6 +18,9 @@ object AuditLogTable : Table("audit_log") {
     val userAgent = text("user_agent").nullable()
     val details = jsonb("details").nullable()
     val createdAt = timestampWithTimeZone("created_at")
+    val prevHash = binary("prev_hash").nullable()
+    val rowHash = binary("row_hash").nullable()
+    val chainKeyId = varchar("chain_key_id", 32).nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
@@ -5,9 +5,11 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.WebhookEventType
 import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.service.WebhookService
+import com.kauth.infrastructure.AuditChainHasher
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
-import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 import java.time.OffsetDateTime
@@ -23,34 +25,23 @@ import java.util.TreeMap
  * Optionally accepts a [WebhookService] and fans out webhook events
  * after each successful audit write. The fan-out is fire-and-forget — webhook
  * failures never affect the audit write or the calling auth flow.
+ *
+ * When [auditChainHasher] is provided each row is signed with HMAC-SHA256 and
+ * linked to the previous row's hash, forming a tamper-evident chain per tenant.
  */
 class PostgresAuditLogAdapter(
     private val webhookService: WebhookService? = null,
+    private val auditChainHasher: AuditChainHasher? = null,
 ) : AuditLogPort {
     private val log = LoggerFactory.getLogger(javaClass)
 
     override fun record(event: AuditEvent) {
         try {
             transaction {
-                AuditLogTable.insert {
-                    it[tenantId] = event.tenantId?.value
-                    it[userId] = event.userId?.value
-                    it[clientId] = event.clientId?.value
-                    it[eventType] = event.eventType.name
-                    it[ipAddress] = event.ipAddress
-                    it[userAgent] = event.userAgent
-                    it[details] =
-                        if (event.details.isEmpty()) {
-                            null
-                        } else {
-                            Json.encodeToString(
-                                JsonObject.serializer(),
-                                buildJsonObject {
-                                    TreeMap(event.details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
-                                },
-                            )
-                        }
-                    it[createdAt] = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
+                if (auditChainHasher != null) {
+                    recordWithChain(event, auditChainHasher)
+                } else {
+                    recordSimple(event)
                 }
             }
         } catch (e: Exception) {
@@ -71,6 +62,108 @@ class PostgresAuditLogAdapter(
             log.error("Webhook dispatch failed for event ${event.eventType}: ${e.message}", e)
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Insert strategies
+    // -------------------------------------------------------------------------
+
+    private fun recordSimple(event: AuditEvent) {
+        AuditLogTable.insert {
+            it[tenantId] = event.tenantId?.value
+            it[userId] = event.userId?.value
+            it[clientId] = event.clientId?.value
+            it[eventType] = event.eventType.name
+            it[ipAddress] = event.ipAddress
+            it[userAgent] = event.userAgent
+            it[details] = serializeDetails(event.details)
+            it[createdAt] = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
+        }
+    }
+
+    private fun recordWithChain(
+        event: AuditEvent,
+        hasher: AuditChainHasher,
+    ) {
+        // Serialize advisory lock token: per-tenant or sentinel 0 for system rows
+        val lockToken =
+            if (event.tenantId == null) {
+                "0"
+            } else {
+                "hashtext('kauth/audit/' || ${event.tenantId.value})"
+            }
+        val conn = TransactionManager.current().connection.connection as java.sql.Connection
+        conn.prepareStatement("SELECT pg_advisory_xact_lock($lockToken)").execute()
+
+        // Read previous row hash for this tenant
+        val prevRow =
+            AuditLogTable
+                .select(AuditLogTable.id, AuditLogTable.rowHash, AuditLogTable.chainKeyId)
+                .where {
+                    if (event.tenantId == null) {
+                        AuditLogTable.tenantId.isNull()
+                    } else {
+                        AuditLogTable.tenantId eq event.tenantId.value
+                    }
+                }.orderBy(AuditLogTable.id, SortOrder.DESC)
+                .limit(1)
+                .firstOrNull()
+
+        val prevHash = prevRow?.get(AuditLogTable.rowHash)
+        val detailsJson = serializeDetails(event.details)
+        val createdAt = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
+
+        val inserted =
+            AuditLogTable.insert {
+                it[tenantId] = event.tenantId?.value
+                it[userId] = event.userId?.value
+                it[clientId] = event.clientId?.value
+                it[eventType] = event.eventType.name
+                it[ipAddress] = event.ipAddress
+                it[userAgent] = event.userAgent
+                it[details] = detailsJson
+                it[AuditLogTable.createdAt] = createdAt
+            }
+
+        val insertedId = inserted[AuditLogTable.id]
+        val insertedCreatedAt = inserted[AuditLogTable.createdAt]
+
+        val canonical =
+            hasher.canonicalize(
+                id = insertedId,
+                tenantId = event.tenantId?.value,
+                userId = event.userId?.value,
+                clientId = event.clientId?.value,
+                eventType = event.eventType.name,
+                ipAddress = event.ipAddress,
+                userAgent = event.userAgent,
+                createdAt = insertedCreatedAt,
+                detailsJson = detailsJson,
+                prevHash = prevHash,
+            )
+        val rowHash = hasher.hmac(canonical)
+
+        AuditLogTable.update({ AuditLogTable.id eq insertedId }) {
+            it[AuditLogTable.prevHash] = prevHash
+            it[AuditLogTable.rowHash] = rowHash
+            it[chainKeyId] = hasher.chainKeyId
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun serializeDetails(details: Map<String, String>): String? =
+        if (details.isEmpty()) {
+            null
+        } else {
+            Json.encodeToString(
+                JsonObject.serializer(),
+                buildJsonObject {
+                    TreeMap(details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+                },
+            )
+        }
 
     // -------------------------------------------------------------------------
     // Webhook event mapping

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
@@ -5,11 +5,14 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.WebhookEventType
 import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.service.WebhookService
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.*
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.TreeMap
 
 /**
  * Persistence adapter — audit log (append-only).
@@ -40,9 +43,12 @@ class PostgresAuditLogAdapter(
                         if (event.details.isEmpty()) {
                             null
                         } else {
-                            event.details.entries.joinToString(",", "{", "}") { (k, v) ->
-                                "\"$k\":\"${v.replace("\"", "\\\"")}\""
-                            }
+                            Json.encodeToString(
+                                JsonObject.serializer(),
+                                buildJsonObject {
+                                    TreeMap(event.details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+                                },
+                            )
                         }
                     it[createdAt] = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
                 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapter.kt
@@ -16,19 +16,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.TreeMap
 
-/**
- * Persistence adapter — audit log (append-only).
- *
- * All exceptions are caught and logged locally.
- * Audit failures MUST NOT bubble up to callers (see [AuditLogPort] contract).
- *
- * Optionally accepts a [WebhookService] and fans out webhook events
- * after each successful audit write. The fan-out is fire-and-forget — webhook
- * failures never affect the audit write or the calling auth flow.
- *
- * When [auditChainHasher] is provided each row is signed with HMAC-SHA256 and
- * linked to the previous row's hash, forming a tamper-evident chain per tenant.
- */
+/** Append-only audit log adapter. Audit failures are swallowed per [AuditLogPort]. */
 class PostgresAuditLogAdapter(
     private val webhookService: WebhookService? = null,
     private val auditChainHasher: AuditChainHasher? = null,
@@ -75,7 +63,7 @@ class PostgresAuditLogAdapter(
             it[eventType] = event.eventType.name
             it[ipAddress] = event.ipAddress
             it[userAgent] = event.userAgent
-            it[details] = serializeDetails(event.details)
+            it[details] = serializeAuditDetails(event.details)
             it[createdAt] = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
         }
     }
@@ -84,17 +72,14 @@ class PostgresAuditLogAdapter(
         event: AuditEvent,
         hasher: AuditChainHasher,
     ) {
-        // Serialize advisory lock token: per-tenant or sentinel 0 for system rows
-        val lockToken =
-            if (event.tenantId == null) {
-                "0"
-            } else {
-                "hashtext('kauth/audit/' || ${event.tenantId.value})"
-            }
+        val lockKey =
+            if (event.tenantId == null) 0L else "kauth/audit/${event.tenantId.value}".hashCode().toLong()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
-        conn.prepareStatement("SELECT pg_advisory_xact_lock($lockToken)").execute()
+        conn.prepareStatement("SELECT pg_advisory_xact_lock(?)").use { ps ->
+            ps.setLong(1, lockKey)
+            ps.execute()
+        }
 
-        // Read previous row hash for this tenant
         val prevRow =
             AuditLogTable
                 .select(AuditLogTable.id, AuditLogTable.rowHash, AuditLogTable.chainKeyId)
@@ -109,7 +94,7 @@ class PostgresAuditLogAdapter(
                 .firstOrNull()
 
         val prevHash = prevRow?.get(AuditLogTable.rowHash)
-        val detailsJson = serializeDetails(event.details)
+        val detailsJson = serializeAuditDetails(event.details)
         val createdAt = OffsetDateTime.ofInstant(event.createdAt, ZoneOffset.UTC)
 
         val inserted =
@@ -125,8 +110,8 @@ class PostgresAuditLogAdapter(
             }
 
         val insertedId = inserted[AuditLogTable.id]
-        val insertedCreatedAt = inserted[AuditLogTable.createdAt]
 
+        // Use the createdAt we just persisted, not the Exposed in-memory insert result.
         val canonical =
             hasher.canonicalize(
                 id = insertedId,
@@ -136,7 +121,7 @@ class PostgresAuditLogAdapter(
                 eventType = event.eventType.name,
                 ipAddress = event.ipAddress,
                 userAgent = event.userAgent,
-                createdAt = insertedCreatedAt,
+                createdAt = createdAt,
                 detailsJson = detailsJson,
                 prevHash = prevHash,
             )
@@ -148,22 +133,6 @@ class PostgresAuditLogAdapter(
             it[chainKeyId] = hasher.chainKeyId
         }
     }
-
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    private fun serializeDetails(details: Map<String, String>): String? =
-        if (details.isEmpty()) {
-            null
-        } else {
-            Json.encodeToString(
-                JsonObject.serializer(),
-                buildJsonObject {
-                    TreeMap(details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
-                },
-            )
-        }
 
     // -------------------------------------------------------------------------
     // Webhook event mapping
@@ -210,3 +179,15 @@ class PostgresAuditLogAdapter(
             putAll(event.details)
         }
 }
+
+internal fun serializeAuditDetails(details: Map<String, String>): String? =
+    if (details.isEmpty()) {
+        null
+    } else {
+        Json.encodeToString(
+            JsonObject.serializer(),
+            buildJsonObject {
+                TreeMap(details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+            },
+        )
+    }

--- a/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
+++ b/src/main/kotlin/com/kauth/adapter/token/JwtTokenAdapter.kt
@@ -279,7 +279,7 @@ class JwtTokenAdapter(
             AccessTokenClaims(
                 sub = verified.subject ?: "",
                 iss = verified.issuer ?: "",
-                aud = verified.audience?.firstOrNull() ?: "",
+                aud = verified.audience.orEmpty(),
                 tenantId = TenantId(tenantIdRaw),
                 username = verified.getClaim("username").asString(),
                 email = verified.getClaim("email").asString(),

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -766,6 +766,11 @@ internal fun Route.oauthProtocolRoutes(
                         put("scope", result.scopes.joinToString(" "))
                         put("exp", result.expiresAt)
                         put("client_id", result.clientId ?: "")
+                        when (result.aud.size) {
+                            0 -> Unit
+                            1 -> put("aud", result.aud.first())
+                            else -> put("aud", buildJsonArray { result.aud.forEach { add(it) } })
+                        }
                     },
                 )
         }

--- a/src/main/kotlin/com/kauth/cli/CliRunner.kt
+++ b/src/main/kotlin/com/kauth/cli/CliRunner.kt
@@ -10,6 +10,7 @@ object CliRunner {
             "export-tenant" -> ExportTenantCommand.execute(args.drop(1))
             "import-tenant" -> ImportTenantCommand.execute(args.drop(1))
             "hash-api-key" -> HashApiKeyCommand.execute(args.drop(1))
+            "verify-audit-chain" -> VerifyAuditChainCommand.execute(args.drop(1))
             null, "--help", "-h" -> printUsage()
             else -> {
                 System.err.println("Unknown CLI command: ${args.first()}")
@@ -31,6 +32,8 @@ object CliRunner {
               import-tenant <file> ...           Import an encrypted backup as a new tenant
               hash-api-key [--key=<v>] [--tenant=<slug>]
                                                  Print SHA-256 for KAUTH_BOOTSTRAP_API_KEYS
+              verify-audit-chain [--tenant=<slug>] [--from-id=<n>] [--quiet]
+                                                 Verify HMAC integrity of the audit log chain
 
             Examples:
               java -jar kauth.jar cli generate-secret-key
@@ -39,6 +42,7 @@ object CliRunner {
                 --passphrase-env=KAUTH_BACKUP_PASS --out=acme.json.enc
               KAUTH_BACKUP_PASS=... java -jar kauth.jar cli import-tenant acme.json.enc \
                 --passphrase-env=KAUTH_BACKUP_PASS --new-slug=acme-staging
+              KAUTH_SECRET_KEY=... java -jar kauth.jar cli verify-audit-chain --tenant=acme
 
             Run any command with no arguments to see its detailed usage.
             """.trimIndent(),

--- a/src/main/kotlin/com/kauth/cli/VerifyAuditChainCommand.kt
+++ b/src/main/kotlin/com/kauth/cli/VerifyAuditChainCommand.kt
@@ -22,7 +22,7 @@ object VerifyAuditChainCommand {
         val secretKey = System.getenv("KAUTH_SECRET_KEY")
         if (secretKey == null) {
             System.err.println("KAUTH_SECRET_KEY is required")
-            exitProcess(1)
+            exitProcess(2)
         }
 
         val hasher = AuditChainHasher(secretKey)
@@ -37,13 +37,12 @@ object VerifyAuditChainCommand {
         exitProcess(exit)
     }
 
-    fun runVerification(
+    internal fun runVerification(
         hasher: AuditChainHasher,
         tenantSlug: String?,
         fromId: Int?,
         quiet: Boolean,
     ): Int {
-        // Resolve tenant filter
         val tenantIds: List<Int?> =
             if (tenantSlug != null) {
                 val id =
@@ -58,13 +57,10 @@ object VerifyAuditChainCommand {
                 }
                 listOf(id)
             } else {
-                // Gather all distinct tenant IDs + null (system rows)
-                val distinctTenantIds =
-                    AuditLogTable
-                        .select(AuditLogTable.tenantId)
-                        .groupBy(AuditLogTable.tenantId)
-                        .map { it[AuditLogTable.tenantId] }
-                distinctTenantIds
+                AuditLogTable
+                    .select(AuditLogTable.tenantId)
+                    .groupBy(AuditLogTable.tenantId)
+                    .map { it[AuditLogTable.tenantId] }
             }
 
         if (tenantIds.isEmpty()) {
@@ -83,7 +79,7 @@ object VerifyAuditChainCommand {
         return if (anyDivergence) 1 else 0
     }
 
-    fun verifyTenant(
+    internal fun verifyTenant(
         hasher: AuditChainHasher,
         tenantId: Int?,
         fromId: Int?,
@@ -112,21 +108,18 @@ object VerifyAuditChainCommand {
 
             if (storedRowHash == null) {
                 if (!quiet) println("tenant=$label id=$id: pre-chain (no row_hash, skipped)")
-                // Pre-chain rows don't break the chain; reset previous
                 previousHash = null
                 continue
             }
 
             val storedPrevHash = row[AuditLogTable.prevHash]
 
-            // Check linkage: stored prev_hash must match previous row's row_hash
             if (previousHash != null && !storedPrevHash.contentEquals(previousHash)) {
                 System.err.println("CHAIN BREAK at tenant=$label id=$id: prev_hash mismatch")
                 diverged = true
                 break
             }
 
-            // Recompute HMAC and compare
             val canonical =
                 hasher.canonicalize(
                     id = id,

--- a/src/main/kotlin/com/kauth/cli/VerifyAuditChainCommand.kt
+++ b/src/main/kotlin/com/kauth/cli/VerifyAuditChainCommand.kt
@@ -1,0 +1,167 @@
+package com.kauth.cli
+
+import com.kauth.adapter.persistence.AuditLogTable
+import com.kauth.adapter.persistence.TenantsTable
+import com.kauth.config.DbConfig
+import com.kauth.infrastructure.AuditChainHasher
+import com.kauth.infrastructure.DatabaseFactory
+import com.kauth.infrastructure.toHex
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.system.exitProcess
+
+object VerifyAuditChainCommand {
+    fun execute(args: List<String>) {
+        val tenantSlug = parseArg(args, "--tenant")
+        val fromId = parseArg(args, "--from-id")?.toIntOrNull()
+        val quiet = "--quiet" in args
+
+        val secretKey = System.getenv("KAUTH_SECRET_KEY")
+        if (secretKey == null) {
+            System.err.println("KAUTH_SECRET_KEY is required")
+            exitProcess(1)
+        }
+
+        val hasher = AuditChainHasher(secretKey)
+        val dbConfig = DbConfig.load()
+        DatabaseFactory.connectOnly(dbConfig)
+
+        val exit =
+            transaction {
+                runVerification(hasher, tenantSlug, fromId, quiet)
+            }
+
+        exitProcess(exit)
+    }
+
+    fun runVerification(
+        hasher: AuditChainHasher,
+        tenantSlug: String?,
+        fromId: Int?,
+        quiet: Boolean,
+    ): Int {
+        // Resolve tenant filter
+        val tenantIds: List<Int?> =
+            if (tenantSlug != null) {
+                val id =
+                    TenantsTable
+                        .selectAll()
+                        .where { TenantsTable.slug eq tenantSlug }
+                        .firstOrNull()
+                        ?.get(TenantsTable.id)
+                if (id == null) {
+                    System.err.println("Tenant not found: $tenantSlug")
+                    return 2
+                }
+                listOf(id)
+            } else {
+                // Gather all distinct tenant IDs + null (system rows)
+                val distinctTenantIds =
+                    AuditLogTable
+                        .select(AuditLogTable.tenantId)
+                        .groupBy(AuditLogTable.tenantId)
+                        .map { it[AuditLogTable.tenantId] }
+                distinctTenantIds
+            }
+
+        if (tenantIds.isEmpty()) {
+            if (!quiet) println("No audit_log rows found.")
+            return 2
+        }
+
+        var anyDivergence = false
+
+        for (tid in tenantIds) {
+            val diverged = verifyTenant(hasher, tid, fromId, quiet)
+            if (diverged) anyDivergence = true
+        }
+
+        if (!anyDivergence && !quiet) println("Chain OK")
+        return if (anyDivergence) 1 else 0
+    }
+
+    fun verifyTenant(
+        hasher: AuditChainHasher,
+        tenantId: Int?,
+        fromId: Int?,
+        quiet: Boolean,
+    ): Boolean {
+        val label = tenantId?.toString() ?: "system"
+        var previousHash: ByteArray? = null
+        var diverged = false
+
+        val query =
+            AuditLogTable
+                .selectAll()
+                .where {
+                    if (tenantId == null) AuditLogTable.tenantId.isNull() else AuditLogTable.tenantId eq tenantId
+                }.orderBy(AuditLogTable.id, SortOrder.ASC)
+
+        if (fromId != null) {
+            query.andWhere { AuditLogTable.id greaterEq fromId }
+        }
+
+        var rowCount = 0
+        for (row in query) {
+            rowCount++
+            val id = row[AuditLogTable.id]
+            val storedRowHash = row[AuditLogTable.rowHash]
+
+            if (storedRowHash == null) {
+                if (!quiet) println("tenant=$label id=$id: pre-chain (no row_hash, skipped)")
+                // Pre-chain rows don't break the chain; reset previous
+                previousHash = null
+                continue
+            }
+
+            val storedPrevHash = row[AuditLogTable.prevHash]
+
+            // Check linkage: stored prev_hash must match previous row's row_hash
+            if (previousHash != null && !storedPrevHash.contentEquals(previousHash)) {
+                System.err.println("CHAIN BREAK at tenant=$label id=$id: prev_hash mismatch")
+                diverged = true
+                break
+            }
+
+            // Recompute HMAC and compare
+            val canonical =
+                hasher.canonicalize(
+                    id = id,
+                    tenantId = row[AuditLogTable.tenantId],
+                    userId = row[AuditLogTable.userId],
+                    clientId = row[AuditLogTable.clientId],
+                    eventType = row[AuditLogTable.eventType],
+                    ipAddress = row[AuditLogTable.ipAddress],
+                    userAgent = row[AuditLogTable.userAgent],
+                    createdAt = row[AuditLogTable.createdAt],
+                    detailsJson = row[AuditLogTable.details],
+                    prevHash = storedPrevHash,
+                )
+            val expected = hasher.hmac(canonical)
+
+            if (!expected.contentEquals(storedRowHash)) {
+                System.err.println(
+                    "TAMPERED at tenant=$label id=$id: row_hash mismatch (expected ${expected.toHex()}, got ${storedRowHash.toHex()})",
+                )
+                diverged = true
+                break
+            }
+
+            previousHash = storedRowHash
+        }
+
+        if (rowCount == 0 && !quiet) println("tenant=$label: no rows")
+        return diverged
+    }
+
+    private fun parseArg(
+        args: List<String>,
+        prefix: String,
+    ): String? =
+        args.firstNotNullOfOrNull { arg ->
+            if (arg.startsWith("$prefix=")) arg.removePrefix("$prefix=").takeIf { it.isNotBlank() } else null
+        }
+}

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -76,6 +76,7 @@ import com.kauth.domain.service.UserAttributeService
 import com.kauth.domain.service.WebhookService
 import com.kauth.domain.service.WorkspaceSettingsService
 import com.kauth.infrastructure.AdminClientProvisioning
+import com.kauth.infrastructure.AuditChainHasher
 import com.kauth.infrastructure.BundleTranslation
 import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.DemoSeedService
@@ -262,8 +263,12 @@ data class ServiceGraph(
                     deliveryRepository = webhookDeliveryRepository,
                     scope = applicationScope,
                 )
+            val auditChainHasher = AuditChainHasher(config.secretKey)
             val auditLogAdapter =
-                PostgresAuditLogAdapter(webhookService = webhookService)
+                PostgresAuditLogAdapter(
+                    webhookService = webhookService,
+                    auditChainHasher = auditChainHasher,
+                )
 
             val translationPort: TranslationPort =
                 config.i18nBundleDir

--- a/src/main/kotlin/com/kauth/domain/model/AccessTokenClaims.kt
+++ b/src/main/kotlin/com/kauth/domain/model/AccessTokenClaims.kt
@@ -12,7 +12,7 @@ package com.kauth.domain.model
 data class AccessTokenClaims(
     val sub: String,
     val iss: String,
-    val aud: String,
+    val aud: List<String>,
     val tenantId: TenantId,
     val username: String?,
     val email: String?,

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -682,6 +682,7 @@ class OAuthService(
                 session.clientId?.let {
                     applicationRepository.findById(it)?.clientId
                 },
+            aud = claims.aud,
         )
     }
 
@@ -901,5 +902,6 @@ sealed class IntrospectionResult {
         val scopes: List<String>,
         val expiresAt: Long,
         val clientId: String?,
+        val aud: List<String>,
     ) : IntrospectionResult()
 }

--- a/src/main/kotlin/com/kauth/infrastructure/AuditChainHasher.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/AuditChainHasher.kt
@@ -7,17 +7,7 @@ import java.time.OffsetDateTime
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-/**
- * Computes the HMAC-SHA256 audit chain for append-only tamper detection.
- *
- * The MAC key is derived from KAUTH_SECRET_KEY via a domain-separated SHA-256:
- *   auditMacKey = sha256("$rawSecretKey|kauth/audit-log/v1")
- *
- * Each row carries:
- *   - prev_hash: row_hash of the immediately preceding row for this tenant (null for the first row)
- *   - row_hash: HMAC-SHA256 over the canonical row string
- *   - chain_key_id: first 8 hex chars of sha256(auditMacKey), identifies which key signed the chain
- */
+/** HMAC-SHA256 audit chain — key derived from KAUTH_SECRET_KEY with domain separation. */
 class AuditChainHasher(
     rawSecretKey: String,
 ) {
@@ -36,7 +26,9 @@ class AuditChainHasher(
         detailsJson: String?,
         prevHash: ByteArray?,
     ): ByteArray {
-        fun enc(v: String): String = URLEncoder.encode(v, "UTF-8")
+        // RFC 3986 percent-encoding (spaces → %20, not application/x-www-form +) so external
+        // verifiers built against the spec produce identical canonical bytes.
+        fun enc(v: String): String = URLEncoder.encode(v, "UTF-8").replace("+", "%20")
         val parts =
             listOf(
                 "v1",

--- a/src/main/kotlin/com/kauth/infrastructure/AuditChainHasher.kt
+++ b/src/main/kotlin/com/kauth/infrastructure/AuditChainHasher.kt
@@ -1,0 +1,68 @@
+package com.kauth.infrastructure
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.OffsetDateTime
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Computes the HMAC-SHA256 audit chain for append-only tamper detection.
+ *
+ * The MAC key is derived from KAUTH_SECRET_KEY via a domain-separated SHA-256:
+ *   auditMacKey = sha256("$rawSecretKey|kauth/audit-log/v1")
+ *
+ * Each row carries:
+ *   - prev_hash: row_hash of the immediately preceding row for this tenant (null for the first row)
+ *   - row_hash: HMAC-SHA256 over the canonical row string
+ *   - chain_key_id: first 8 hex chars of sha256(auditMacKey), identifies which key signed the chain
+ */
+class AuditChainHasher(
+    rawSecretKey: String,
+) {
+    private val auditMacKey: ByteArray = sha256("$rawSecretKey|kauth/audit-log/v1".toByteArray(StandardCharsets.UTF_8))
+    val chainKeyId: String = sha256(auditMacKey).toHex().take(8)
+
+    fun canonicalize(
+        id: Int,
+        tenantId: Int?,
+        userId: Int?,
+        clientId: Int?,
+        eventType: String,
+        ipAddress: String?,
+        userAgent: String?,
+        createdAt: OffsetDateTime,
+        detailsJson: String?,
+        prevHash: ByteArray?,
+    ): ByteArray {
+        fun enc(v: String): String = URLEncoder.encode(v, "UTF-8")
+        val parts =
+            listOf(
+                "v1",
+                enc(id.toString()),
+                tenantId?.let { enc(it.toString()) } ?: "-",
+                userId?.let { enc(it.toString()) } ?: "-",
+                clientId?.let { enc(it.toString()) } ?: "-",
+                enc(eventType),
+                ipAddress?.let { enc(it) } ?: "-",
+                userAgent?.let { enc(it) } ?: "-",
+                enc(createdAt.toString()),
+                detailsJson?.let { enc(it) } ?: "-",
+                prevHash?.toHex() ?: "-",
+            )
+        return parts.joinToString("|").toByteArray(StandardCharsets.UTF_8)
+    }
+
+    fun hmac(canonical: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(auditMacKey, "HmacSHA256"))
+        return mac.doFinal(canonical)
+    }
+
+    private companion object {
+        fun sha256(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)
+    }
+}
+
+internal fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/src/main/resources/db/migration/V52__audit_log_chain.sql
+++ b/src/main/resources/db/migration/V52__audit_log_chain.sql
@@ -1,0 +1,8 @@
+-- V52: HMAC audit chain (v1.19.0).
+
+ALTER TABLE audit_log
+    ADD COLUMN prev_hash    BYTEA NULL,
+    ADD COLUMN row_hash     BYTEA NULL,
+    ADD COLUMN chain_key_id VARCHAR(32) NULL;
+
+CREATE INDEX idx_audit_log_tenant_id_id ON audit_log (tenant_id, id DESC);

--- a/src/main/resources/db/migration/V52__audit_log_chain.sql
+++ b/src/main/resources/db/migration/V52__audit_log_chain.sql
@@ -1,5 +1,3 @@
--- V52: HMAC audit chain (v1.19.0).
-
 ALTER TABLE audit_log
     ADD COLUMN prev_hash    BYTEA NULL,
     ADD COLUMN row_hash     BYTEA NULL,

--- a/src/test/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapterDetailsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapterDetailsTest.kt
@@ -1,0 +1,88 @@
+package com.kauth.adapter.persistence
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.util.TreeMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PostgresAuditLogAdapterDetailsTest {
+    private fun serializeDetails(details: Map<String, String>): String? =
+        if (details.isEmpty()) {
+            null
+        } else {
+            Json.encodeToString(
+                JsonObject.serializer(),
+                buildJsonObject {
+                    TreeMap(details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+                },
+            )
+        }
+
+    @Test
+    fun `empty map produces null`() {
+        assertEquals(null, serializeDetails(emptyMap()))
+    }
+
+    @Test
+    fun `values containing double quotes are escaped`() {
+        val result = serializeDetails(mapOf("key" to "value with \"quotes\""))
+        assertNotNull(result)
+        // Must be valid JSON - should contain escaped quotes
+        assertTrue(result.contains("\\\"quotes\\\"") || result.contains("\\u0022"))
+        // Can be decoded back
+        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
+        assertEquals("value with \"quotes\"", (parsed["key"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `values containing backslashes are escaped`() {
+        val result = serializeDetails(mapOf("path" to "C:\\Windows\\System32"))
+        assertNotNull(result)
+        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
+        assertEquals("C:\\Windows\\System32", (parsed["path"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `values containing newlines are escaped`() {
+        val result = serializeDetails(mapOf("line" to "first\nsecond"))
+        assertNotNull(result)
+        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
+        assertEquals("first\nsecond", (parsed["line"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `values containing control characters are escaped`() {
+        val result = serializeDetails(mapOf("ctrl" to "tab\there"))
+        assertNotNull(result)
+        // Must be parseable JSON
+        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
+        assertEquals("tab\there", (parsed["ctrl"] as JsonPrimitive).content)
+    }
+
+    @Test
+    fun `keys are deterministically sorted`() {
+        val result1 = serializeDetails(mapOf("z" to "1", "a" to "2", "m" to "3"))
+        val result2 = serializeDetails(mapOf("m" to "3", "z" to "1", "a" to "2"))
+        assertEquals(result1, result2)
+        // And keys appear in alphabetical order
+        val aIdx = result1!!.indexOf("\"a\"")
+        val mIdx = result1.indexOf("\"m\"")
+        val zIdx = result1.indexOf("\"z\"")
+        assertTrue(aIdx < mIdx && mIdx < zIdx)
+    }
+
+    @Test
+    fun `produces valid JSON string`() {
+        val result = serializeDetails(mapOf("event" to "login", "userId" to "42"))
+        assertNotNull(result)
+        // Should not throw
+        Json.decodeFromString(JsonObject.serializer(), result)
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapterDetailsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/persistence/PostgresAuditLogAdapterDetailsTest.kt
@@ -1,88 +1,100 @@
 package com.kauth.adapter.persistence
 
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import java.util.TreeMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class PostgresAuditLogAdapterDetailsTest {
-    private fun serializeDetails(details: Map<String, String>): String? =
-        if (details.isEmpty()) {
-            null
-        } else {
-            Json.encodeToString(
-                JsonObject.serializer(),
-                buildJsonObject {
-                    TreeMap(details).forEach { (k, v) -> put(k, JsonPrimitive(v)) }
-                },
-            )
-        }
+    private fun roundTrip(value: String): String {
+        val json = serializeAuditDetails(mapOf("k" to value))
+        assertNotNull(json)
+        val parsed = Json.decodeFromString(JsonObject.serializer(), json)
+        return (parsed["k"] as JsonPrimitive).content
+    }
 
     @Test
     fun `empty map produces null`() {
-        assertEquals(null, serializeDetails(emptyMap()))
+        assertEquals(null, serializeAuditDetails(emptyMap()))
     }
 
     @Test
-    fun `values containing double quotes are escaped`() {
-        val result = serializeDetails(mapOf("key" to "value with \"quotes\""))
-        assertNotNull(result)
-        // Must be valid JSON - should contain escaped quotes
-        assertTrue(result.contains("\\\"quotes\\\"") || result.contains("\\u0022"))
-        // Can be decoded back
-        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
-        assertEquals("value with \"quotes\"", (parsed["key"] as JsonPrimitive).content)
+    fun `double quotes round-trip`() {
+        val v = "value with \"quotes\""
+        assertEquals(v, roundTrip(v))
     }
 
     @Test
-    fun `values containing backslashes are escaped`() {
-        val result = serializeDetails(mapOf("path" to "C:\\Windows\\System32"))
-        assertNotNull(result)
-        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
-        assertEquals("C:\\Windows\\System32", (parsed["path"] as JsonPrimitive).content)
+    fun `backslashes round-trip`() {
+        val v = "C:\\Windows\\System32"
+        assertEquals(v, roundTrip(v))
     }
 
     @Test
-    fun `values containing newlines are escaped`() {
-        val result = serializeDetails(mapOf("line" to "first\nsecond"))
-        assertNotNull(result)
-        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
-        assertEquals("first\nsecond", (parsed["line"] as JsonPrimitive).content)
+    fun `newline round-trips`() {
+        val v = "first\nsecond"
+        assertEquals(v, roundTrip(v))
     }
 
     @Test
-    fun `values containing control characters are escaped`() {
-        val result = serializeDetails(mapOf("ctrl" to "tab\there"))
-        assertNotNull(result)
-        // Must be parseable JSON
-        val parsed = Json.decodeFromString(JsonObject.serializer(), result)
-        assertEquals("tab\there", (parsed["ctrl"] as JsonPrimitive).content)
+    fun `tab round-trips`() {
+        val v = "a\tb"
+        assertEquals(v, roundTrip(v))
     }
 
     @Test
-    fun `keys are deterministically sorted`() {
-        val result1 = serializeDetails(mapOf("z" to "1", "a" to "2", "m" to "3"))
-        val result2 = serializeDetails(mapOf("m" to "3", "z" to "1", "a" to "2"))
-        assertEquals(result1, result2)
-        // And keys appear in alphabetical order
-        val aIdx = result1!!.indexOf("\"a\"")
-        val mIdx = result1.indexOf("\"m\"")
-        val zIdx = result1.indexOf("\"z\"")
+    fun `null byte round-trips`() {
+        val v = "a\u0000b"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `unicode line separator U_2028 round-trips`() {
+        val v = "first\u2028second"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `unicode paragraph separator U_2029 round-trips`() {
+        val v = "first\u2029second"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `bmp boundary U_FFFD round-trips`() {
+        val v = "rune \uFFFD ok"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `surrogate pair above BMP round-trips`() {
+        val v = "hi \uD83D\uDE00"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `empty string value round-trips`() {
+        assertEquals("", roundTrip(""))
+    }
+
+    @Test
+    fun `pipe character round-trips`() {
+        val v = "user|agent"
+        assertEquals(v, roundTrip(v))
+    }
+
+    @Test
+    fun `keys are deterministically sorted regardless of input order`() {
+        val a = serializeAuditDetails(mapOf("z" to "1", "a" to "2", "m" to "3"))
+        val b = serializeAuditDetails(mapOf("m" to "3", "z" to "1", "a" to "2"))
+        assertEquals(a, b)
+        assertNotNull(a)
+        val aIdx = a.indexOf("\"a\"")
+        val mIdx = a.indexOf("\"m\"")
+        val zIdx = a.indexOf("\"z\"")
         assertTrue(aIdx < mIdx && mIdx < zIdx)
-    }
-
-    @Test
-    fun `produces valid JSON string`() {
-        val result = serializeDetails(mapOf("event" to "login", "userId" to "42"))
-        assertNotNull(result)
-        // Should not throw
-        Json.decodeFromString(JsonObject.serializer(), result)
     }
 }

--- a/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterAudienceTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/token/JwtTokenAdapterAudienceTest.kt
@@ -124,4 +124,34 @@ class JwtTokenAdapterAudienceTest {
                 .decode(token)
         assertEquals(listOf("payment-api", "ledger-api"), decoded.audience)
     }
+
+    @Test
+    fun `decodeAccessToken returns the full audience list for a multi-aud token`() {
+        val token =
+            adapter.issueClientCredentialsToken(
+                tenant,
+                app(audience = null),
+                listOf("openid"),
+                listOf("payment-api", "ledger-api"),
+            )
+        val claims = adapter.decodeAccessToken(token, adapter.issuerFor(tenant))
+        assertEquals(
+            listOf("payment-api", "ledger-api"),
+            claims?.aud,
+            "decode must surface every audience, not only the first",
+        )
+    }
+
+    @Test
+    fun `decodeAccessToken returns a single-element list for a single-aud token`() {
+        val token =
+            adapter.issueClientCredentialsToken(
+                tenant,
+                app(audience = null),
+                listOf("openid"),
+                listOf("payment-api"),
+            )
+        val claims = adapter.decodeAccessToken(token, adapter.issuerFor(tenant))
+        assertEquals(listOf("payment-api"), claims?.aud)
+    }
 }

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -1713,7 +1713,7 @@ class AuthRoutesTest {
                 AccessTokenClaims(
                     sub = "10",
                     iss = "http://localhost/t/acme",
-                    aud = "spa-app",
+                    aud = listOf("spa-app"),
                     tenantId = TenantId(1),
                     username = "alice",
                     email = "alice@example.com",
@@ -2342,6 +2342,198 @@ class AuthRoutesTest {
         }
 
     // -------------------------------------------------------------------------
+
+    @Test
+    fun `POST introspect emits aud as string for single audience`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-single-aud"
+            sessionRepo.save(
+                Session(
+                    tenantId = TenantId(1),
+                    userId = UserId(10),
+                    clientId = ApplicationId(1),
+                    accessTokenHash = sha256Hex(accessToken),
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+            tokenPort.claimsToReturn =
+                AccessTokenClaims(
+                    sub = "10",
+                    iss = "http://localhost/t/acme",
+                    aud = listOf("my-api"),
+                    tenantId = TenantId(1),
+                    username = "alice",
+                    email = "alice@example.com",
+                    scopes = listOf("openid"),
+                    issuedAt = Instant.now().epochSecond,
+                    expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+                )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/introspect",
+                    formParameters =
+                        Parameters.build {
+                            append("token", accessToken)
+                            append("client_id", "backend-app")
+                            append("client_secret", "secret123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"aud\":\"my-api\"") || body.contains("\"aud\": \"my-api\""))
+        }
+
+    @Test
+    fun `POST introspect emits aud as array for multiple audiences`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-multi-aud"
+            sessionRepo.save(
+                Session(
+                    tenantId = TenantId(1),
+                    userId = UserId(10),
+                    clientId = ApplicationId(1),
+                    accessTokenHash = sha256Hex(accessToken),
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+            tokenPort.claimsToReturn =
+                AccessTokenClaims(
+                    sub = "10",
+                    iss = "http://localhost/t/acme",
+                    aud = listOf("api1", "api2"),
+                    tenantId = TenantId(1),
+                    username = "alice",
+                    email = "alice@example.com",
+                    scopes = listOf("openid"),
+                    issuedAt = Instant.now().epochSecond,
+                    expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+                )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/introspect",
+                    formParameters =
+                        Parameters.build {
+                            append("token", accessToken)
+                            append("client_id", "backend-app")
+                            append("client_secret", "secret123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(
+                body.contains("\"aud\":[") || body.contains("\"aud\": ["),
+                "Multi-aud must be a JSON array, got: $body",
+            )
+            assertTrue(body.contains("api1"))
+            assertTrue(body.contains("api2"))
+        }
+
+    @Test
+    fun `POST introspect omits aud field for empty audience list`() =
+        testApplication {
+            resetFixtures()
+            val accessToken = "test-access-token-empty-aud"
+            sessionRepo.save(
+                Session(
+                    tenantId = TenantId(1),
+                    userId = UserId(10),
+                    clientId = ApplicationId(1),
+                    accessTokenHash = sha256Hex(accessToken),
+                    refreshTokenHash = null,
+                    scopes = "openid",
+                    expiresAt = Instant.now().plusSeconds(3600),
+                ),
+            )
+            tokenPort.claimsToReturn =
+                AccessTokenClaims(
+                    sub = "10",
+                    iss = "http://localhost/t/acme",
+                    aud = emptyList(),
+                    tenantId = TenantId(1),
+                    username = "alice",
+                    email = "alice@example.com",
+                    scopes = listOf("openid"),
+                    issuedAt = Instant.now().epochSecond,
+                    expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+                )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.submitForm(
+                    url = "/t/acme/protocol/openid-connect/introspect",
+                    formParameters =
+                        Parameters.build {
+                            append("token", accessToken)
+                            append("client_id", "backend-app")
+                            append("client_secret", "secret123")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertFalse(body.contains("\"aud\""), "Empty audience must not emit aud field, got: $body")
+        }
+
     // Utility
     // -------------------------------------------------------------------------
 

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -42,6 +42,9 @@ import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.security.MessageDigest
 import java.time.Instant
 import java.util.Base64
@@ -2464,12 +2467,14 @@ class AuthRoutesTest {
 
             assertEquals(HttpStatusCode.OK, response.status)
             val body = response.bodyAsText()
-            assertTrue(
-                body.contains("\"aud\":[") || body.contains("\"aud\": ["),
-                "Multi-aud must be a JSON array, got: $body",
-            )
-            assertTrue(body.contains("api1"))
-            assertTrue(body.contains("api2"))
+            val json =
+                kotlinx.serialization.json.Json
+                    .parseToJsonElement(body)
+                    .jsonObject
+            val audElement = json["aud"]
+            assertNotNull(audElement, "Multi-aud token must emit aud, got: $body")
+            val audArray = audElement.jsonArray.map { it.jsonPrimitive.content }
+            assertEquals(listOf("api1", "api2"), audArray, "aud must be a JSON array with both values in order")
         }
 
     @Test

--- a/src/test/kotlin/com/kauth/cli/VerifyAuditChainCommandTest.kt
+++ b/src/test/kotlin/com/kauth/cli/VerifyAuditChainCommandTest.kt
@@ -4,7 +4,6 @@ import com.kauth.infrastructure.AuditChainHasher
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -13,185 +12,167 @@ class VerifyAuditChainCommandTest {
     private val hasher = AuditChainHasher(secret)
     private val t0 = OffsetDateTime.of(2026, 6, 19, 10, 0, 0, 0, ZoneOffset.UTC)
 
-    // -------------------------------------------------------------------------
-    // Arg parsing
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `parseArg returns null when arg is absent`() {
-        val result = invokeParseArg(emptyList(), "--tenant")
-        assertEquals(null, result)
-    }
-
-    @Test
-    fun `parseArg extracts value`() {
-        val result = invokeParseArg(listOf("--tenant=acme", "--quiet"), "--tenant")
-        assertEquals("acme", result)
-    }
-
-    @Test
-    fun `quiet flag is detected`() {
-        val args = listOf("--quiet", "--tenant=acme")
-        assertTrue("--quiet" in args)
-    }
-
-    @Test
-    fun `from-id is parsed as int`() {
-        val args = listOf("--from-id=42")
-        val raw = invokeParseArg(args, "--from-id")
-        assertEquals(42, raw?.toIntOrNull())
-    }
-
-    // -------------------------------------------------------------------------
-    // Chain verification logic
-    // -------------------------------------------------------------------------
-
     data class SyntheticRow(
         val id: Int,
+        val tenantId: Int?,
+        val userId: Int?,
+        val clientId: Int?,
+        val eventType: String,
+        val ipAddress: String?,
+        val userAgent: String?,
+        val createdAt: OffsetDateTime,
+        val detailsJson: String?,
         val storedPrevHash: ByteArray?,
         val storedRowHash: ByteArray?,
     )
 
-    private fun buildChain(
+    private fun build(
         count: Int,
         tenantId: Int? = 1,
+        startId: Int = 1,
     ): List<SyntheticRow> {
         val rows = mutableListOf<SyntheticRow>()
         var prevHash: ByteArray? = null
-        for (i in 1..count) {
+        for (offset in 0 until count) {
+            val id = startId + offset
+            val createdAt = t0.plusMinutes(id.toLong())
             val canonical =
                 hasher.canonicalize(
-                    id = i,
+                    id = id,
                     tenantId = tenantId,
                     userId = 10,
                     clientId = null,
                     eventType = "LOGIN_SUCCESS",
                     ipAddress = "127.0.0.1",
                     userAgent = null,
-                    createdAt = t0.plusMinutes(i.toLong()),
+                    createdAt = createdAt,
                     detailsJson = null,
                     prevHash = prevHash,
                 )
             val rowHash = hasher.hmac(canonical)
-            rows.add(SyntheticRow(i, prevHash, rowHash))
+            rows.add(
+                SyntheticRow(
+                    id = id,
+                    tenantId = tenantId,
+                    userId = 10,
+                    clientId = null,
+                    eventType = "LOGIN_SUCCESS",
+                    ipAddress = "127.0.0.1",
+                    userAgent = null,
+                    createdAt = createdAt,
+                    detailsJson = null,
+                    storedPrevHash = prevHash,
+                    storedRowHash = rowHash,
+                ),
+            )
             prevHash = rowHash
         }
         return rows
     }
 
-    private fun verifyChain(rows: List<SyntheticRow>): Boolean {
+    /**
+     * Mirrors the per-row check in [VerifyAuditChainCommand.verifyTenant]: returns true if any
+     * row diverges from the recomputed HMAC over its current field values.
+     */
+    private fun verify(rows: List<SyntheticRow>): Boolean {
         var previousHash: ByteArray? = null
-        var diverged = false
         for (row in rows) {
             val storedRowHash =
                 row.storedRowHash ?: run {
                     previousHash = null
-                    continue
-                }
-            if (previousHash != null && !row.storedPrevHash.contentEquals(previousHash)) {
-                diverged = true
-                break
-            }
+                    return@run null
+                } ?: continue
+            if (previousHash != null && !row.storedPrevHash.contentEquals(previousHash)) return true
             val canonical =
                 hasher.canonicalize(
                     id = row.id,
-                    tenantId = 1,
-                    userId = 10,
-                    clientId = null,
-                    eventType = "LOGIN_SUCCESS",
-                    ipAddress = "127.0.0.1",
-                    userAgent = null,
-                    createdAt = t0.plusMinutes(row.id.toLong()),
-                    detailsJson = null,
+                    tenantId = row.tenantId,
+                    userId = row.userId,
+                    clientId = row.clientId,
+                    eventType = row.eventType,
+                    ipAddress = row.ipAddress,
+                    userAgent = row.userAgent,
+                    createdAt = row.createdAt,
+                    detailsJson = row.detailsJson,
                     prevHash = row.storedPrevHash,
                 )
             val expected = hasher.hmac(canonical)
-            if (!expected.contentEquals(storedRowHash)) {
-                diverged = true
-                break
-            }
+            if (!expected.contentEquals(storedRowHash)) return true
             previousHash = storedRowHash
         }
-        return diverged
+        return false
     }
 
     @Test
-    fun `clean chain of 5 rows is verified without divergence`() {
-        val chain = buildChain(5)
-        assertFalse(verifyChain(chain), "Clean chain should not diverge")
+    fun `clean chain of 5 rows verifies cleanly`() {
+        assertFalse(verify(build(5)))
     }
 
     @Test
-    fun `tampered row_hash is detected`() {
-        val chain = buildChain(5).toMutableList()
-        val tampered = chain[2]
-        val badHash = tampered.storedRowHash!!.copyOf()
-        badHash[0] = (badHash[0].toInt() xor 0xFF).toByte()
-        chain[2] = tampered.copy(storedRowHash = badHash)
-        assertTrue(verifyChain(chain), "Tampered hash should cause divergence")
+    fun `mutating eventType without resigning is detected (primary tamper scenario)`() {
+        val chain = build(5).toMutableList()
+        chain[2] = chain[2].copy(eventType = "ADMIN_USER_DELETED")
+        assertTrue(
+            verify(chain),
+            "Editing a field while leaving row_hash intact must be detected — this is the threat the chain defends against.",
+        )
     }
 
     @Test
-    fun `wrong prev_hash is detected`() {
-        val chain = buildChain(5).toMutableList()
-        val row = chain[3]
-        val badPrev = ByteArray(32) { 0xAB.toByte() }
-        chain[3] = row.copy(storedPrevHash = badPrev)
-        assertTrue(verifyChain(chain), "Wrong prev_hash should cause divergence")
+    fun `mutating ipAddress without resigning is detected`() {
+        val chain = build(3).toMutableList()
+        chain[1] = chain[1].copy(ipAddress = "10.0.0.99")
+        assertTrue(verify(chain))
     }
 
     @Test
-    fun `pre-chain rows (null row_hash) are skipped without breaking chain`() {
-        val chain = buildChain(3).toMutableList()
-        // Insert a pre-chain row at position 0
-        val preChainRow = SyntheticRow(0, null, null)
-        val withPreChain = listOf(preChainRow) + chain
-        // The chain should still verify because pre-chain rows reset the tracking
-        // (note: since we built the chain without the pre-chain row, the first chain
-        // row starts with prevHash = null, which is consistent after reset)
-        val result = verifyChain(withPreChain)
-        assertFalse(result, "Pre-chain rows should not cause divergence")
+    fun `mutating userAgent without resigning is detected`() {
+        val chain = build(3).toMutableList()
+        chain[1] = chain[1].copy(userAgent = "MaliciousBot/1.0")
+        assertTrue(verify(chain))
     }
 
     @Test
-    fun `different secret key fails to verify chain`() {
-        val chain = buildChain(3)
-        val differentHasher = AuditChainHasher("completely-different-secret-key-xyz")
-        var diverged = false
-        var prevHash: ByteArray? = null
-        for (row in chain) {
-            val canonical =
-                differentHasher.canonicalize(
-                    id = row.id,
-                    tenantId = 1,
-                    userId = 10,
-                    clientId = null,
-                    eventType = "LOGIN_SUCCESS",
-                    ipAddress = "127.0.0.1",
-                    userAgent = null,
-                    createdAt = t0.plusMinutes(row.id.toLong()),
-                    detailsJson = null,
-                    prevHash = prevHash,
-                )
-            val expected = differentHasher.hmac(canonical)
-            if (!expected.contentEquals(row.storedRowHash)) {
-                diverged = true
-                break
-            }
-            prevHash = row.storedRowHash
-        }
-        assertTrue(diverged, "Wrong key must not verify the chain")
+    fun `directly tampered row_hash is detected`() {
+        val chain = build(5).toMutableList()
+        val bad = chain[2].storedRowHash!!.copyOf()
+        bad[0] = (bad[0].toInt() xor 0xFF).toByte()
+        chain[2] = chain[2].copy(storedRowHash = bad)
+        assertTrue(verify(chain))
     }
 
-    // -------------------------------------------------------------------------
-    // Private reflection helper for arg parsing (tests internal logic)
-    // -------------------------------------------------------------------------
+    @Test
+    fun `forged prev_hash is detected`() {
+        val chain = build(5).toMutableList()
+        chain[3] = chain[3].copy(storedPrevHash = ByteArray(32) { 0xAB.toByte() })
+        assertTrue(verify(chain))
+    }
 
-    private fun invokeParseArg(
-        args: List<String>,
-        prefix: String,
-    ): String? =
-        args.firstNotNullOfOrNull { arg ->
-            if (arg.startsWith("$prefix=")) arg.removePrefix("$prefix=").takeIf { it.isNotBlank() } else null
-        }
+    @Test
+    fun `replayed row spliced between two valid rows is detected`() {
+        val chain = build(4).toMutableList()
+        // Replay row #1 between rows #2 and #3 — id collision aside, the next row's
+        // prev_hash refers to the original row #2 not the replayed copy.
+        chain.add(2, chain[0])
+        assertTrue(
+            verify(chain),
+            "Splicing a copy of an earlier row between two existing rows must break the chain at the next row.",
+        )
+    }
+
+    @Test
+    fun `tampering with tenant A does not affect tenant B chain verdict`() {
+        val a = build(3, tenantId = 1).toMutableList()
+        val b = build(3, tenantId = 2)
+        a[1] = a[1].copy(eventType = "ADMIN_USER_DELETED")
+        assertTrue(verify(a), "Tenant A is tampered; verify must report diverged")
+        assertFalse(verify(b), "Tenant B chain is independent and must verify cleanly")
+    }
+
+    @Test
+    fun `pre-chain rows with null row_hash do not break verification`() {
+        val pre = SyntheticRow(0, 1, null, null, "LEGACY", null, null, t0, null, null, null)
+        val rows = listOf(pre) + build(3)
+        assertFalse(verify(rows))
+    }
 }

--- a/src/test/kotlin/com/kauth/cli/VerifyAuditChainCommandTest.kt
+++ b/src/test/kotlin/com/kauth/cli/VerifyAuditChainCommandTest.kt
@@ -1,0 +1,197 @@
+package com.kauth.cli
+
+import com.kauth.infrastructure.AuditChainHasher
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VerifyAuditChainCommandTest {
+    private val secret = "test-secret-key-for-verify-audit-chain"
+    private val hasher = AuditChainHasher(secret)
+    private val t0 = OffsetDateTime.of(2026, 6, 19, 10, 0, 0, 0, ZoneOffset.UTC)
+
+    // -------------------------------------------------------------------------
+    // Arg parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parseArg returns null when arg is absent`() {
+        val result = invokeParseArg(emptyList(), "--tenant")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `parseArg extracts value`() {
+        val result = invokeParseArg(listOf("--tenant=acme", "--quiet"), "--tenant")
+        assertEquals("acme", result)
+    }
+
+    @Test
+    fun `quiet flag is detected`() {
+        val args = listOf("--quiet", "--tenant=acme")
+        assertTrue("--quiet" in args)
+    }
+
+    @Test
+    fun `from-id is parsed as int`() {
+        val args = listOf("--from-id=42")
+        val raw = invokeParseArg(args, "--from-id")
+        assertEquals(42, raw?.toIntOrNull())
+    }
+
+    // -------------------------------------------------------------------------
+    // Chain verification logic
+    // -------------------------------------------------------------------------
+
+    data class SyntheticRow(
+        val id: Int,
+        val storedPrevHash: ByteArray?,
+        val storedRowHash: ByteArray?,
+    )
+
+    private fun buildChain(
+        count: Int,
+        tenantId: Int? = 1,
+    ): List<SyntheticRow> {
+        val rows = mutableListOf<SyntheticRow>()
+        var prevHash: ByteArray? = null
+        for (i in 1..count) {
+            val canonical =
+                hasher.canonicalize(
+                    id = i,
+                    tenantId = tenantId,
+                    userId = 10,
+                    clientId = null,
+                    eventType = "LOGIN_SUCCESS",
+                    ipAddress = "127.0.0.1",
+                    userAgent = null,
+                    createdAt = t0.plusMinutes(i.toLong()),
+                    detailsJson = null,
+                    prevHash = prevHash,
+                )
+            val rowHash = hasher.hmac(canonical)
+            rows.add(SyntheticRow(i, prevHash, rowHash))
+            prevHash = rowHash
+        }
+        return rows
+    }
+
+    private fun verifyChain(rows: List<SyntheticRow>): Boolean {
+        var previousHash: ByteArray? = null
+        var diverged = false
+        for (row in rows) {
+            val storedRowHash =
+                row.storedRowHash ?: run {
+                    previousHash = null
+                    continue
+                }
+            if (previousHash != null && !row.storedPrevHash.contentEquals(previousHash)) {
+                diverged = true
+                break
+            }
+            val canonical =
+                hasher.canonicalize(
+                    id = row.id,
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    eventType = "LOGIN_SUCCESS",
+                    ipAddress = "127.0.0.1",
+                    userAgent = null,
+                    createdAt = t0.plusMinutes(row.id.toLong()),
+                    detailsJson = null,
+                    prevHash = row.storedPrevHash,
+                )
+            val expected = hasher.hmac(canonical)
+            if (!expected.contentEquals(storedRowHash)) {
+                diverged = true
+                break
+            }
+            previousHash = storedRowHash
+        }
+        return diverged
+    }
+
+    @Test
+    fun `clean chain of 5 rows is verified without divergence`() {
+        val chain = buildChain(5)
+        assertFalse(verifyChain(chain), "Clean chain should not diverge")
+    }
+
+    @Test
+    fun `tampered row_hash is detected`() {
+        val chain = buildChain(5).toMutableList()
+        val tampered = chain[2]
+        val badHash = tampered.storedRowHash!!.copyOf()
+        badHash[0] = (badHash[0].toInt() xor 0xFF).toByte()
+        chain[2] = tampered.copy(storedRowHash = badHash)
+        assertTrue(verifyChain(chain), "Tampered hash should cause divergence")
+    }
+
+    @Test
+    fun `wrong prev_hash is detected`() {
+        val chain = buildChain(5).toMutableList()
+        val row = chain[3]
+        val badPrev = ByteArray(32) { 0xAB.toByte() }
+        chain[3] = row.copy(storedPrevHash = badPrev)
+        assertTrue(verifyChain(chain), "Wrong prev_hash should cause divergence")
+    }
+
+    @Test
+    fun `pre-chain rows (null row_hash) are skipped without breaking chain`() {
+        val chain = buildChain(3).toMutableList()
+        // Insert a pre-chain row at position 0
+        val preChainRow = SyntheticRow(0, null, null)
+        val withPreChain = listOf(preChainRow) + chain
+        // The chain should still verify because pre-chain rows reset the tracking
+        // (note: since we built the chain without the pre-chain row, the first chain
+        // row starts with prevHash = null, which is consistent after reset)
+        val result = verifyChain(withPreChain)
+        assertFalse(result, "Pre-chain rows should not cause divergence")
+    }
+
+    @Test
+    fun `different secret key fails to verify chain`() {
+        val chain = buildChain(3)
+        val differentHasher = AuditChainHasher("completely-different-secret-key-xyz")
+        var diverged = false
+        var prevHash: ByteArray? = null
+        for (row in chain) {
+            val canonical =
+                differentHasher.canonicalize(
+                    id = row.id,
+                    tenantId = 1,
+                    userId = 10,
+                    clientId = null,
+                    eventType = "LOGIN_SUCCESS",
+                    ipAddress = "127.0.0.1",
+                    userAgent = null,
+                    createdAt = t0.plusMinutes(row.id.toLong()),
+                    detailsJson = null,
+                    prevHash = prevHash,
+                )
+            val expected = differentHasher.hmac(canonical)
+            if (!expected.contentEquals(row.storedRowHash)) {
+                diverged = true
+                break
+            }
+            prevHash = row.storedRowHash
+        }
+        assertTrue(diverged, "Wrong key must not verify the chain")
+    }
+
+    // -------------------------------------------------------------------------
+    // Private reflection helper for arg parsing (tests internal logic)
+    // -------------------------------------------------------------------------
+
+    private fun invokeParseArg(
+        args: List<String>,
+        prefix: String,
+    ): String? =
+        args.firstNotNullOfOrNull { arg ->
+            if (arg.startsWith("$prefix=")) arg.removePrefix("$prefix=").takeIf { it.isNotBlank() } else null
+        }
+}

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -880,7 +880,7 @@ class OAuthServiceTest {
             AccessTokenClaims(
                 sub = "10",
                 iss = "https://acme.example.com",
-                aud = "spa-app",
+                aud = listOf("spa-app"),
                 tenantId = TenantId(1),
                 username = "alice",
                 email = "alice@example.com",
@@ -896,6 +896,38 @@ class OAuthServiceTest {
         assertEquals("alice@example.com", result.email)
         assertEquals(listOf("openid", "profile"), result.scopes)
         assertEquals(expiresAt, result.expiresAt)
+    }
+
+    @Test
+    fun `introspectToken Active result carries aud from claims`() {
+        val accessToken = "valid-access-token-multi-aud"
+        sessions.save(
+            Session(
+                tenantId = TenantId(1),
+                userId = UserId(10),
+                clientId = publicClient.id,
+                accessTokenHash = sha256Hex(accessToken),
+                refreshTokenHash = null,
+                scopes = "openid profile",
+                expiresAt = Instant.now().plusSeconds(3600),
+            ),
+        )
+        tokens.claimsToReturn =
+            AccessTokenClaims(
+                sub = "10",
+                iss = "https://acme.example.com",
+                aud = listOf("res1", "res2"),
+                tenantId = TenantId(1),
+                username = "alice",
+                email = "alice@example.com",
+                scopes = listOf("openid", "profile"),
+                issuedAt = Instant.now().epochSecond,
+                expiresAt = Instant.now().plusSeconds(3600).epochSecond,
+            )
+
+        val result = introspectAsBackend(accessToken)
+        assertIs<IntrospectionResult.Active>(result)
+        assertEquals(listOf("res1", "res2"), result.aud)
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/infrastructure/AuditChainHasherTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/AuditChainHasherTest.kt
@@ -1,0 +1,126 @@
+package com.kauth.infrastructure
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AuditChainHasherTest {
+    private val secret = "this-is-a-test-secret-key-for-audit-chain"
+    private val hasher = AuditChainHasher(secret)
+
+    private val sampleTime = OffsetDateTime.of(2026, 6, 19, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    private fun canonical(
+        id: Int = 1,
+        tenantId: Int? = 1,
+        userId: Int? = 10,
+        clientId: Int? = null,
+        eventType: String = "LOGIN_SUCCESS",
+        ipAddress: String? = "127.0.0.1",
+        userAgent: String? = "TestAgent/1.0",
+        createdAt: OffsetDateTime = sampleTime,
+        detailsJson: String? = null,
+        prevHash: ByteArray? = null,
+    ) = hasher.canonicalize(
+        id,
+        tenantId,
+        userId,
+        clientId,
+        eventType,
+        ipAddress,
+        userAgent,
+        createdAt,
+        detailsJson,
+        prevHash,
+    )
+
+    @Test
+    fun `chainKeyId is exactly 8 hex characters`() {
+        val id = hasher.chainKeyId
+        assertEquals(8, id.length)
+        assertTrue(id.all { it.isDigit() || it in 'a'..'f' }, "chainKeyId must be lowercase hex: $id")
+    }
+
+    @Test
+    fun `same inputs produce identical canonical bytes`() {
+        val c1 = canonical()
+        val c2 = canonical()
+        assertTrue(c1.contentEquals(c2), "Canonical form must be deterministic")
+    }
+
+    @Test
+    fun `same inputs produce identical HMAC`() {
+        val h1 = hasher.hmac(canonical())
+        val h2 = hasher.hmac(canonical())
+        assertTrue(h1.contentEquals(h2), "HMAC must be deterministic")
+    }
+
+    @Test
+    fun `changing id changes HMAC`() {
+        val h1 = hasher.hmac(canonical(id = 1))
+        val h2 = hasher.hmac(canonical(id = 2))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    @Test
+    fun `changing tenantId changes HMAC`() {
+        val h1 = hasher.hmac(canonical(tenantId = 1))
+        val h2 = hasher.hmac(canonical(tenantId = 2))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    @Test
+    fun `changing userId changes HMAC`() {
+        val h1 = hasher.hmac(canonical(userId = 1))
+        val h2 = hasher.hmac(canonical(userId = 99))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    @Test
+    fun `changing eventType changes HMAC`() {
+        val h1 = hasher.hmac(canonical(eventType = "LOGIN_SUCCESS"))
+        val h2 = hasher.hmac(canonical(eventType = "LOGIN_FAILED"))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    @Test
+    fun `changing prevHash changes HMAC`() {
+        val prev1 = ByteArray(32) { 0 }
+        val prev2 = ByteArray(32) { 1 }
+        val h1 = hasher.hmac(canonical(prevHash = prev1))
+        val h2 = hasher.hmac(canonical(prevHash = prev2))
+        assertFalse(h1.contentEquals(h2))
+    }
+
+    @Test
+    fun `null tenantId produces dash in canonical string`() {
+        val bytes = canonical(tenantId = null)
+        val s = bytes.toString(Charsets.UTF_8)
+        // format: v1|<id>|<tenantId>|...
+        val parts = s.split("|")
+        assertEquals("-", parts[2])
+    }
+
+    @Test
+    fun `null prevHash produces dash in canonical string`() {
+        val bytes = canonical(prevHash = null)
+        val s = bytes.toString(Charsets.UTF_8)
+        assertTrue(s.endsWith("-"), "Last field should be - for null prevHash, got: $s")
+    }
+
+    @Test
+    fun `different secret keys produce different chain key ids`() {
+        val hasher2 = AuditChainHasher("different-secret-key-entirely")
+        assertNotEquals(hasher.chainKeyId, hasher2.chainKeyId)
+    }
+
+    @Test
+    fun `hmac produces 32 bytes`() {
+        val h = hasher.hmac(canonical())
+        assertEquals(32, h.size, "HMAC-SHA256 must be 32 bytes")
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/AuditChainHasherTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/AuditChainHasherTest.kt
@@ -123,4 +123,28 @@ class AuditChainHasherTest {
         val h = hasher.hmac(canonical())
         assertEquals(32, h.size, "HMAC-SHA256 must be 32 bytes")
     }
+
+    @Test
+    fun `pipe character in fields is URL-encoded so framing cannot be forged`() {
+        val withInjection = canonical(userAgent = "User|Agent|Injected").toString(Charsets.UTF_8)
+        assertFalse(
+            withInjection.contains("Agent|Injected"),
+            "Pipe in field value must be percent-encoded, not appear raw in canonical form",
+        )
+        assertTrue(
+            withInjection.contains("%7C"),
+            "Encoded pipe must appear as %7C: $withInjection",
+        )
+        val baseline = hasher.hmac(canonical(userAgent = "UserAgentInjected"))
+        val injected = hasher.hmac(canonical(userAgent = "User|Agent|Injected"))
+        assertFalse(baseline.contentEquals(injected), "Pipe injection must not produce a matching HMAC")
+    }
+
+    @Test
+    fun `URL encoder uses RFC 3986 percent encoding for spaces`() {
+        val bytes = canonical(userAgent = "Mozilla 5.0")
+        val s = bytes.toString(Charsets.UTF_8)
+        assertTrue(s.contains("Mozilla%205.0"), "Space must encode as %20 (RFC 3986), got: $s")
+        assertFalse(s.contains("Mozilla+5.0"), "Space must NOT encode as + (application/x-www-form): $s")
+    }
 }


### PR DESCRIPTION
## What does this PR do?

This pull request introduces significant security and auditability improvements to the audit log system, addressing an external audit finding and a previous limitation around multi-audience token introspection. The most important changes are the addition of HMAC hash chaining for the audit log, improved JSON serialization to prevent silent data corruption, support for multi-audience tokens, and a new CLI tool to verify audit log integrity. Documentation and migration steps are also included.

**Audit Log Integrity and Security Enhancements:**

- **HMAC chain over the audit log:** Each row in `audit_log` now includes `prev_hash`, `row_hash`, and `chain_key_id` columns, forming a per-tenant, tamper-evident HMAC-SHA256 chain. Tampering or reordering is detectable with the new `verify-audit-chain` CLI command. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R44) `AuditLogTable.kt` [[2]](diffhunk://#diff-73f6e4c2cf9ab9a9872755ae48907cd5033ecd0f0c72572efa017cbba4b32778R21-R23) `PostgresAuditLogAdapter.kt` [[3]](diffhunk://#diff-d9965608d46ec28704ccfb34c838b81aba929bd6c82fc564006c251488699501L8-R32) [[4]](diffhunk://#diff-d9965608d46ec28704ccfb34c838b81aba929bd6c82fc564006c251488699501R54-R136) [[5]](diffhunk://#diff-d9965608d46ec28704ccfb34c838b81aba929bd6c82fc564006c251488699501R182-R193) `ServiceGraph.kt` [[6]](diffhunk://#diff-4dc97af69fea7b2ee8936fa4202da0199207b76db1b2b4f49711ba904ec85f49R79) [[7]](diffhunk://#diff-4dc97af69fea7b2ee8936fa4202da0199207b76db1b2b4f49711ba904ec85f49R266-R271) `VerifyAuditChainCommand.kt` [[8]](diffhunk://#diff-e15e7395bddf7262287dd93e7ae73311494f283d27cd7a80a8e47d3bd34657a3R1-R160)

- **Audit log JSON serialization hardened:** Audit log details are now serialized using `kotlinx.serialization` instead of manual string concatenation, preventing silent corruption when values contain quotes, backslashes, or control characters. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R44) `PostgresAuditLogAdapter.kt` [[2]](diffhunk://#diff-d9965608d46ec28704ccfb34c838b81aba929bd6c82fc564006c251488699501L8-R32) [[3]](diffhunk://#diff-d9965608d46ec28704ccfb34c838b81aba929bd6c82fc564006c251488699501R182-R193)

- **Recommended Postgres role separation:** Documentation now recommends restricting the application user to `INSERT` and `SELECT` only on `audit_log`, with a separate maintenance role for `UPDATE`/`DELETE`, reducing risk from SQL injection or credential compromise. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R44) `audit-log.md` [[2]](diffhunk://#diff-b2352683252dbc5e0c4f81f848eaceb8b62c8cfdfb2c8c9fa125392fe9806bc7R1-R105)

**Token Introspection and Audience Handling:**

- **Multi-audience token support:** The `aud` claim in `AccessTokenClaims` is now a `List<String>`, and the introspection endpoint emits a JSON string for a single audience or a JSON array for multiple audiences, following RFC 7662. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R44) `JwtTokenAdapter.kt` [[2]](diffhunk://#diff-c585ccfb1966382b1bdc94d70d05ecd59c56b81393080a98dd18c6bd10ebc183L282-R282) `OAuthProtocolRoutes.kt` [[3]](diffhunk://#diff-8a148607ffd951392e0b4bb9cc742cdbdb52b875ecf0429337cc68215b396976R769-R773)

**Operational Tooling and Documentation:**

- **New CLI for audit chain verification:** Added `verify-audit-chain` command to the CLI, allowing operators to check audit log integrity per tenant or globally, with clear exit codes and support for key rotation scenarios. (`CliRunner.kt` [[1]](diffhunk://#diff-0e8cc0bb0579e51780b599eaa337d03320b5ab7c7d61c8e2785d68d0e04acb69R13) [[2]](diffhunk://#diff-0e8cc0bb0579e51780b599eaa337d03320b5ab7c7d61c8e2785d68d0e04acb69R35-R36) [[3]](diffhunk://#diff-0e8cc0bb0579e51780b599eaa337d03320b5ab7c7d61c8e2785d68d0e04acb69R45) `VerifyAuditChainCommand.kt` [[4]](diffhunk://#diff-e15e7395bddf7262287dd93e7ae73311494f283d27cd7a80a8e47d3bd34657a3R1-R160) `audit-log.md` [[5]](diffhunk://#diff-b2352683252dbc5e0c4f81f848eaceb8b62c8cfdfb2c8c9fa125392fe9806bc7R1-R105)

- **Documentation updates:** The new audit log chain, CLI usage, and operational recommendations are fully documented in `docs/operations/audit-log.md`. (`audit-log.md` [docs/operations/audit-log.mdR1-R105](diffhunk://#diff-b2352683252dbc5e0c4f81f848eaceb8b62c8cfdfb2c8c9fa125392fe9806bc7R1-R105))

These changes collectively strengthen audit log integrity, make tampering evident, support modern OAuth features, and provide clear operational guidance and tooling.

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix
- [x] New feature
## How was this tested?

<!-- Describe how you verified the change works correctly. -->

- [x] Added / updated unit tests
- [x] Added / updated integration tests

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes (or run `./gradlew ktlintFormat` to auto-fix)
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration
