### PR TITLE
Add React SPA-direct and BFF integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ For a public demo deployment (seeded workspaces + reset cron), set `KAUTH_DEMO_M
 ## Integration guides
 
 - [Quickstart](docs/deploy/quickstart.md) — local evaluation
+- [React SPA — browser-direct OIDC](docs/guides/react-spa-direct.md) — simplest path; tokens in the browser
+- [React SPA — BFF pattern](docs/guides/react-bff-pattern.md) — recommended for production; tokens stay server-side
+- [React SPA with TanStack Router](docs/guides/react-spa-tanstack-router.md) — `beforeLoad` route guards on top of either pattern
 - [Production deployment](docs/deploy/production.md) — TLS, backups, upgrades
-- [React SPA with TanStack Router](docs/guides/react-spa-tanstack-router.md)
 - Generic OIDC *(coming soon)*
 
 ---

--- a/docs/guides/react-bff-pattern.md
+++ b/docs/guides/react-bff-pattern.md
@@ -1,0 +1,468 @@
+# Integrating Kotauth with a React SPA (BFF Pattern)
+
+This guide walks through adding Kotauth authentication to a React SPA using the **Backend-For-Frontend (BFF) pattern**. The browser never touches OIDC; instead, a thin backend handles the token exchange, stores access/refresh tokens server-side, and exposes session-cookie-authenticated endpoints to the SPA.
+
+This is the **recommended pattern for production deployments** of any non-trivial size, because the access token never reaches JavaScript. If an XSS lands, the attacker still cannot exfiltrate the bearer token — they only see an opaque `HTTP-only` session cookie that the browser will not surface to script.
+
+**Stack:** React 18+, Vite (dev proxy), any backend that can speak OIDC. The backend example below is Kotlin/Ktor (Kotauth's native stack), but the pattern translates to Express, FastAPI, ASP.NET Core, Spring Boot, anything that can do an Authorization Code + PKCE exchange and set a cookie.
+
+## When to use this pattern
+
+Pick BFF when **any** of these are true:
+
+- You're shipping a customer-facing or regulated app where XSS-driven token theft is unacceptable
+- You already run a backend that needs to call internal APIs on the user's behalf
+- You want centrally-managed token refresh (one server-side flow, not N tabs)
+- You need to apply additional authorization, rate limiting, or audit logging at the gateway
+
+Pick the [browser-direct SPA pattern](react-spa-direct.md) instead when:
+
+- The app is a small internal tool with no separate backend
+- You want the simplest possible deployment (static SPA + Kotauth, nothing else)
+
+## The architecture
+
+```
+┌──────────┐     ┌──────────┐     ┌─────────┐
+│  Browser │────▶│   BFF    │────▶│ Kotauth │
+│  (SPA)   │     │ (Kotlin) │     │         │
+└──────────┘     └──────────┘     └─────────┘
+     │                 │
+     │  HTTP-only      │   Sessions in
+     │  session cookie │   Redis (TTL-bounded)
+     ▼                 ▼
+```
+
+- The browser holds an **opaque session ID** in an HTTP-only cookie
+- The BFF holds the **access and refresh tokens**, keyed by that session ID, in Redis
+- The BFF forwards downstream API calls with `Authorization: Bearer <access_token>` and refreshes transparently when the access token nears expiry
+- Login is a browser navigation to `/auth/login` (not a programmatic SDK call); logout is `POST /auth/logout` then a navigation
+
+## Prerequisites
+
+- Kotauth running locally or on a server
+- A workspace created in Kotauth with an application registered as **`confidential`** (BFF clients have a backend, so they have a real client secret)
+- A backend you can deploy alongside the SPA — this guide uses Kotlin/Ktor; the patterns translate directly
+- Redis available to the BFF (for server-side session storage)
+
+## 1. Register the BFF as a confidential application
+
+In the Kotauth admin console:
+
+1. Navigate to your workspace → **Applications** → **New Application**
+2. Set **Access Type** to `confidential` — the BFF holds a client secret server-side
+3. Under **Redirect URIs**, add:
+   ```
+   http://localhost:5173/api/auth/callback
+   https://app.yourdomain.com/api/auth/callback
+   ```
+   The callback is served by the BFF, not the SPA. In dev, Vite proxies `/api/*` to the BFF (see step 4), so the URL host is the SPA host.
+4. Under **Post-Logout Redirect URIs**, add:
+   ```
+   http://localhost:5173/
+   https://app.yourdomain.com/
+   ```
+5. Copy the **Client ID** and **Client Secret** — the BFF needs both
+
+## 2. The SPA side
+
+The SPA does **not** install an OIDC library. It only needs `fetch` + state management.
+
+### Vite proxy config
+
+The SPA dev server proxies `/api/*` to the BFF so cookies flow on the same origin without CORS:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET ?? "http://localhost:8088";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      "/api": { target: apiProxyTarget, changeOrigin: false },
+    },
+  },
+});
+```
+
+`changeOrigin: false` preserves the browser's `Origin` header so the BFF's same-origin check works during dev. In production, Caddy/nginx/Traefik does the same routing — the SPA and BFF live on the same hostname.
+
+### Fetch wrapper
+
+Every API call rides the session cookie:
+
+```ts
+// src/lib/api.ts
+const LOGIN_URL = "/api/auth/login";
+
+let onUnauthenticated = () => {
+  if (typeof window !== "undefined") {
+    window.location.assign(LOGIN_URL);
+  }
+};
+
+export function setUnauthenticatedHandler(handler: () => void): void {
+  onUnauthenticated = handler;
+}
+
+export class ApiError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+
+  if (response.status === 401) {
+    onUnauthenticated();
+    throw new ApiError(401, "Not authenticated");
+  }
+
+  if (!response.ok) {
+    throw new ApiError(response.status, `${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+```
+
+Three things to notice:
+
+1. **`credentials: "include"`** — the browser sends the session cookie on every request to the same origin.
+2. **No `Authorization` header** — the SPA never sees the access token. The cookie is the only credential.
+3. **401 handler is centralized** — when the session expires, the browser hard-navigates to `/api/auth/login`, which the BFF turns into a Kotauth authorize redirect.
+
+### Session query
+
+Use TanStack Query (or your state library of choice) to fetch the current session on mount:
+
+```ts
+// src/auth/session.ts
+import { apiFetch } from "../lib/api";
+
+export interface SessionIdentity {
+  sub: string;
+  email: string;
+  name?: string;
+  scopes: string[];
+}
+
+export async function fetchSession(): Promise<SessionIdentity | null> {
+  try {
+    return await apiFetch<SessionIdentity>("/api/auth/me");
+  } catch (e) {
+    if (e instanceof Error && (e as { status?: number }).status === 401) {
+      return null;
+    }
+    throw e;
+  }
+}
+```
+
+```tsx
+// src/auth/useSession.ts
+import { useQuery } from "@tanstack/react-query";
+import { fetchSession } from "./session";
+
+export function useSession() {
+  return useQuery({
+    queryKey: ["session"],
+    queryFn: fetchSession,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 401) return false;
+      return failureCount < 2;
+    },
+    staleTime: 60_000,
+  });
+}
+```
+
+The query returns the user identity or `null`. No tokens, no expiry timestamps, no PKCE state — just "who is this person?"
+
+### Route protection
+
+Two options. Pick by app shape.
+
+**Implicit (admin-style):** the root layout requires a session; if 401 lands, `onUnauthenticated` triggers and the SPA hard-navigates to `/api/auth/login`.
+
+```tsx
+// src/App.tsx
+import { useSession } from "./auth/useSession";
+
+export function App() {
+  const session = useSession();
+  if (session.isPending) return <p>Loading…</p>;
+  if (!session.data) return null; // 401 handler already redirected
+  return <Shell user={session.data}>{/* protected app */}</Shell>;
+}
+```
+
+**Explicit (public-style):** wrap routes that need auth in a `<SessionGate>` so unauthenticated users see a splash before the redirect:
+
+```tsx
+// src/auth/SessionGate.tsx
+import { type ReactNode, useEffect } from "react";
+import { useSession } from "./useSession";
+
+export function SessionGate({ children }: { children: ReactNode }) {
+  const session = useSession();
+
+  useEffect(() => {
+    if (session.isError || session.data === null) {
+      window.location.assign("/api/auth/login");
+    }
+  }, [session.isError, session.data]);
+
+  if (session.isPending || !session.data) return <p>Redirecting to sign-in…</p>;
+  return <>{children}</>;
+}
+```
+
+### Logout
+
+```ts
+// src/auth/logout.ts
+import { apiFetch } from "../lib/api";
+
+export async function logout(): Promise<void> {
+  await apiFetch<{ ok: boolean }>("/api/auth/logout", { method: "POST" });
+  window.location.assign("/api/auth/login?prompt=login");
+}
+```
+
+`POST /api/auth/logout` clears the server-side session and the cookie. The follow-up navigation forces a fresh login (`prompt=login` tells Kotauth to re-prompt even if the SSO cookie is still valid).
+
+That's everything the SPA needs. No OIDC library, no token storage, no refresh logic. The whole frontend auth surface is `useSession()`, `apiFetch()`, and a logout button.
+
+## 3. The BFF side
+
+The BFF needs four endpoints. The Kotlin/Ktor sketch below is the shape Kotauth itself encourages — production-grade Kotlin code, deployable as a sidecar to the SPA.
+
+### Configuration
+
+```kotlin
+data class BffConfig(
+    val kotauthBaseUrl: String,
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val postLoginRedirect: String,
+    val postLogoutRedirect: String,
+    val cookieSecure: Boolean,
+    val allowedOrigins: List<String>,
+)
+```
+
+### `GET /auth/login` — start the flow
+
+```kotlin
+get("/auth/login") {
+    val state = secureRandomBase64(32)
+    val codeVerifier = secureRandomBase64(64)
+    val codeChallenge = sha256Base64Url(codeVerifier)
+
+    sessionStore.savePending(state, codeVerifier, ttlSeconds = 300)
+
+    val authorizeUrl = URLBuilder("${config.kotauthBaseUrl}/oauth2/authorize").apply {
+        parameters.append("response_type", "code")
+        parameters.append("client_id", config.clientId)
+        parameters.append("redirect_uri", config.redirectUri)
+        parameters.append("scope", "openid profile email offline_access")
+        parameters.append("state", state)
+        parameters.append("code_challenge", codeChallenge)
+        parameters.append("code_challenge_method", "S256")
+        call.request.queryParameters["prompt"]?.let { parameters.append("prompt", it) }
+    }.buildString()
+
+    call.respondRedirect(authorizeUrl, permanent = false)
+}
+```
+
+The PKCE verifier stays in Redis keyed by `state`. The browser only sees the redirect.
+
+### `GET /auth/callback` — exchange code for tokens
+
+```kotlin
+get("/auth/callback") {
+    val state = call.request.queryParameters["state"]
+        ?: return@get call.respond(HttpStatusCode.BadRequest)
+    val code = call.request.queryParameters["code"]
+        ?: return@get call.respond(HttpStatusCode.BadRequest)
+
+    val pending = sessionStore.takePending(state)
+        ?: return@get call.respond(HttpStatusCode.BadRequest, "state mismatch")
+
+    val tokens = kotauthClient.exchangeCode(
+        code = code,
+        codeVerifier = pending.codeVerifier,
+        redirectUri = config.redirectUri,
+        clientId = config.clientId,
+        clientSecret = config.clientSecret,
+    )
+
+    val identity = kotauthClient.fetchUserInfo(tokens.accessToken)
+    val sessionId = sessionStore.create(
+        accessToken = tokens.accessToken,
+        refreshToken = tokens.refreshToken,
+        accessTokenExpiresAt = tokens.expiresAt,
+        identity = identity,
+    )
+
+    call.setSessionCookie(sessionId, config.cookieSecure)
+    call.respondRedirect(config.postLoginRedirect, permanent = false)
+}
+
+fun ApplicationCall.setSessionCookie(sessionId: String, secure: Boolean) {
+    response.cookies.append(
+        Cookie(
+            name = "bff_session",
+            value = sessionId,
+            maxAge = 60 * 60 * 24 * 7,
+            path = "/",
+            secure = secure,
+            httpOnly = true,
+            extensions = mapOf("SameSite" to "Lax"),
+        ),
+    )
+}
+```
+
+The cookie is **`httpOnly`** (unreachable from JavaScript), **`SameSite=Lax`** (mitigates CSRF on cross-site GETs), and **`secure`** in production (HTTPS only).
+
+### `GET /auth/me` — return the current identity
+
+```kotlin
+get("/auth/me") {
+    val sessionId = call.request.cookies["bff_session"]
+        ?: return@get call.respond(HttpStatusCode.Unauthorized)
+    val session = sessionStore.get(sessionId)
+        ?: return@get call.respond(HttpStatusCode.Unauthorized)
+
+    if (session.accessTokenExpiresAt.isBefore(Instant.now())) {
+        sessionStore.refresh(sessionId, kotauthClient)
+    }
+
+    call.respond(
+        HttpStatusCode.OK,
+        MeDto(
+            sub = session.identity.sub,
+            email = session.identity.email,
+            name = session.identity.name,
+            scopes = session.scopes,
+        ),
+    )
+}
+```
+
+The refresh happens on the BFF, transparently. The SPA never sees an expired-token error during normal use.
+
+### `POST /auth/logout` — clear session
+
+```kotlin
+post("/auth/logout") {
+    if (!call.requireSameOrigin(config.allowedOrigins)) return@post
+    val sessionId = call.request.cookies["bff_session"]
+    sessionId?.let { sessionStore.delete(it) }
+    call.clearSessionCookie(config.cookieSecure)
+    call.respond(HttpStatusCode.OK, mapOf("ok" to true))
+}
+
+suspend fun ApplicationCall.requireSameOrigin(allowed: List<String>): Boolean {
+    val origin = request.headers["Origin"] ?: request.headers["Referer"]
+    if (origin == null || allowed.none { origin.startsWith(it) }) {
+        respond(HttpStatusCode.Forbidden, mapOf("error" to "csrf-rejected"))
+        return false
+    }
+    return true
+}
+```
+
+Notice the CSRF defense: **Origin/Referer validation**, not a custom token header. Because the SPA and BFF are same-origin (production) or proxied through the same Vite dev server (development), the browser sends `Origin` automatically. Cross-site POSTs from an attacker page lack the right `Origin` and get a 403. No double-submit cookie, no `<meta name="csrf-token">`, no header to forget.
+
+### Forwarding API calls (optional)
+
+If your BFF also proxies downstream API calls (e.g. to a separate microservice), inject the access token from the server-side session:
+
+```kotlin
+get("/api/orders/{id}") {
+    val session = requireSession() ?: return@get
+    val response = httpClient.get("$ordersApiUrl/${call.parameters["id"]}") {
+        header("Authorization", "Bearer ${session.accessToken}")
+    }
+    call.respondText(response.bodyAsText(), ContentType.Application.Json, response.status)
+}
+```
+
+The SPA only ever sees opaque cookie auth. The bearer token lives in BFF memory and Redis.
+
+## 4. Production deployment
+
+Two services behind one origin:
+
+```
+https://app.yourdomain.com/         → SPA static files (Caddy/nginx)
+https://app.yourdomain.com/api/*    → BFF (proxied)
+```
+
+Caddy snippet:
+
+```caddyfile
+app.yourdomain.com {
+    handle /api/* {
+        reverse_proxy bff:8080
+    }
+    handle {
+        root * /var/www/spa
+        try_files {path} /index.html
+        file_server
+    }
+}
+```
+
+The BFF stays internal; only the SPA origin is publicly exposed. Set `cookieSecure = true` and `SameSite=Lax` in production.
+
+## What this pattern gives you (security)
+
+| Concern | Browser-direct SPA | BFF |
+|---|---|---|
+| Access token reachable from JS | Yes — `localStorage` or `sessionStorage` | **No** — server-side only |
+| XSS leads to token theft | Yes | **No** — attacker can only ride the session via the existing cookie origin |
+| PKCE verifier handling | Browser stores it in `sessionStorage` | Server stores it in Redis (per-state, short TTL) |
+| Refresh token handling | Browser holds it (if `offline_access` is granted) | Server-side refresh, transparent to the SPA |
+| Token expiry UX | SPA must detect, decide silent renew vs. logout | SPA never sees an expired token |
+| Logout completeness | SPA must clear local storage + call Kotauth | One `POST /auth/logout`, both layers cleared |
+| CSRF defense | Bearer in `Authorization` header is naturally CSRF-immune | Origin/Referer validation on state-changing endpoints |
+| Multi-tab consistency | Per-tab token state; refresh races possible | One session, all tabs in sync |
+
+The cost is an extra hop per API call and a backend you have to run, monitor, and deploy. For anything beyond a small internal tool, that cost is the right trade.
+
+## Common issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `credentials: 'include'` requests don't send the cookie | The SPA and BFF are on different origins and the BFF doesn't set `Access-Control-Allow-Credentials: true` | Either proxy `/api/*` through the SPA origin (recommended), or set proper CORS headers + `SameSite=None; Secure` on the cookie |
+| Login redirects loop | `Origin` header from the post-login redirect doesn't match `allowedOrigins` | Verify the BFF's `allowedOrigins` includes the SPA's exact origin |
+| Cookie not set in dev | Vite proxy is dropping `Set-Cookie` | Ensure `changeOrigin: false` in the Vite proxy config |
+| `POST /auth/logout` returns 403 | CSRF check rejected the request | The SPA must POST from the same origin; check the `Origin` header in dev tools |
+| Sessions disappear on BFF restart | Sessions are in memory, not Redis | Wire up a Redis-backed session store (the example assumes Redis) |
+
+## Where next
+
+- [Browser-direct SPA pattern](react-spa-direct.md) — the simpler alternative without a backend
+- [TanStack Router integration](react-spa-tanstack-router.md) — `beforeLoad` route guards (composable with this pattern's session query)
+- [Production deployment](../deploy/production.md) — Kotauth in production

--- a/docs/guides/react-spa-direct.md
+++ b/docs/guides/react-spa-direct.md
@@ -1,0 +1,279 @@
+# Integrating Kotauth with a React SPA (Browser-Direct OIDC)
+
+This guide walks through adding Kotauth authentication to a React SPA where **the browser talks to Kotauth directly** — Authorization Code + PKCE, tokens stored in the browser, `Authorization: Bearer` on every API request.
+
+It is router-agnostic. The patterns work with React Router, TanStack Router, or no router at all. If you specifically want TanStack's `beforeLoad` integration, see the [TanStack Router guide](react-spa-tanstack-router.md) after reading this one.
+
+**Stack:** React 18+, [`react-oidc-context`](https://github.com/authts/react-oidc-context) (wraps [`oidc-client-ts`](https://github.com/authts/oidc-client-ts)), Vite. Both libraries are framework-neutral OIDC implementations.
+
+## When to use this pattern
+
+Pick browser-direct OIDC when:
+
+- The SPA is the only client talking to Kotauth — there is no separate backend doing user-facing work
+- You want the simplest possible deployment: a static-hosted SPA + Kotauth, nothing in between
+- You're comfortable with access tokens being reachable from JavaScript (the XSS trade-off)
+
+Pick the [BFF pattern](react-bff-pattern.md) instead when:
+
+- Tokens must never be reachable from JavaScript (high-value targets, regulated industries)
+- You already have a backend that needs to authenticate calls (avoid double-handling identity)
+- You want centrally-managed token refresh, not per-tab refresh in the browser
+
+## Prerequisites
+
+- Kotauth running locally (`docker compose up`) or on a server
+- A workspace created in the Kotauth admin console (e.g. slug `my-app`)
+- Node.js 18+
+
+## 1. Register the SPA as an application in Kotauth
+
+In the Kotauth admin console:
+
+1. Navigate to your workspace → **Applications** → **New Application**
+2. Set the name (e.g. `web-spa`)
+3. Set **Access Type** to `public` — SPAs use PKCE, not a client secret
+4. Under **Redirect URIs**, add:
+   ```
+   http://localhost:5173/
+   https://app.yourdomain.com/
+   ```
+   The redirect URI is where Kotauth sends the user after login. `react-oidc-context` handles the callback in-place at the application root — no separate `/callback` route is needed unless you want one.
+5. Under **Post-Logout Redirect URIs**, add the same origins
+6. Copy the **Client ID** from the application detail page
+
+## 2. Install dependencies
+
+```bash
+npm install oidc-client-ts react-oidc-context
+```
+
+`react-oidc-context` is the React wrapper; `oidc-client-ts` is the underlying OIDC protocol implementation. Both are framework-neutral and maintained by the OpenID Foundation Authts working group.
+
+## 3. Configure the OIDC client
+
+Create `src/auth/oidcConfig.ts`:
+
+```ts
+import { WebStorageStateStore } from "oidc-client-ts";
+import type { AuthProviderProps } from "react-oidc-context";
+
+export const oidcConfig: AuthProviderProps = {
+  authority: import.meta.env.VITE_KOTAUTH_AUTHORITY,
+  client_id: import.meta.env.VITE_KOTAUTH_CLIENT_ID,
+  redirect_uri: import.meta.env.VITE_KOTAUTH_REDIRECT_URI,
+  response_type: "code",
+  scope: "openid profile email",
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
+  onSigninCallback: () => {
+    window.history.replaceState({}, document.title, window.location.pathname);
+  },
+};
+```
+
+| Key | What it does |
+|---|---|
+| `authority` | Kotauth issuer URL. The library fetches `${authority}/.well-known/openid-configuration` and auto-discovers all endpoints. For a single-workspace Kotauth, this is `https://auth.example.com`; for a multi-workspace deployment, point at `https://auth.example.com/t/<workspace-slug>`. |
+| `client_id` | The public client ID you copied in step 1. |
+| `redirect_uri` | Where Kotauth sends the user after login. Must exactly match one of the URIs registered on the application. |
+| `response_type: "code"` | Authorization Code flow. PKCE is enabled automatically by `oidc-client-ts` for public clients. |
+| `scope` | `openid` is required; `profile` and `email` request the corresponding ID-token claims. Add custom scopes you defined on the application. |
+| `userStore` | Where access tokens and ID tokens live. `localStorage` survives a tab close; `sessionStorage` does not. Both are JavaScript-accessible — see [security trade-offs](#security-trade-offs). |
+| `onSigninCallback` | Strips the `?code=...&state=...` query params after a successful login so the URL is clean. |
+
+Environment variables in `.env`:
+
+```env
+VITE_KOTAUTH_AUTHORITY=http://localhost:8080/t/my-app
+VITE_KOTAUTH_CLIENT_ID=web-spa
+VITE_KOTAUTH_REDIRECT_URI=http://localhost:5173/
+```
+
+## 4. Wrap the app with the auth provider
+
+In `src/main.tsx`:
+
+```tsx
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { AuthProvider } from "react-oidc-context";
+import { oidcConfig } from "./auth/oidcConfig";
+import { RequireAuth } from "./auth/RequireAuth";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <AuthProvider {...oidcConfig}>
+      <RequireAuth>
+        <App />
+      </RequireAuth>
+    </AuthProvider>
+  </StrictMode>,
+);
+```
+
+`<AuthProvider>` exposes the `useAuth()` hook anywhere inside the tree. `<RequireAuth>` (defined next) gates the protected portion of the app.
+
+## 5. Gate the app with `<RequireAuth>`
+
+Create `src/auth/RequireAuth.tsx`:
+
+```tsx
+import { type ReactNode } from "react";
+import { useAuth } from "react-oidc-context";
+import { Login } from "./Login";
+
+export function RequireAuth({ children }: { children: ReactNode }) {
+  const auth = useAuth();
+
+  if (auth.isLoading) {
+    return <p>Signing you in…</p>;
+  }
+
+  if (auth.error) {
+    return <p>Sign-in failed: {auth.error.message}</p>;
+  }
+
+  if (!auth.isAuthenticated) {
+    return <Login />;
+  }
+
+  return <>{children}</>;
+}
+```
+
+And `src/auth/Login.tsx`:
+
+```tsx
+import { useAuth } from "react-oidc-context";
+
+export function Login() {
+  const auth = useAuth();
+  return (
+    <button onClick={() => void auth.signinRedirect()}>
+      Sign in
+    </button>
+  );
+}
+```
+
+`auth.signinRedirect()` navigates the browser to Kotauth's `/oauth2/authorize` with the PKCE challenge. After the user authenticates, Kotauth redirects back to `redirect_uri` with `?code=...&state=...`. `react-oidc-context` detects the callback on mount, exchanges the code for tokens (using the PKCE verifier it stored in `sessionStorage` before redirecting), and updates `auth.isAuthenticated` to `true`.
+
+You do not need a separate `/callback` route — the provider handles the callback in-place because `redirect_uri` points at the app root.
+
+## 6. Attach the access token to API requests
+
+Create an API client that pulls the token from the auth hook on every render:
+
+```ts
+// src/api/useClient.ts
+import { useAuth } from "react-oidc-context";
+import { useMemo } from "react";
+import { ApiClient } from "./client";
+
+export function useClient(): ApiClient | null {
+  const auth = useAuth();
+  const token = auth.user?.access_token;
+  return useMemo(() => (token ? new ApiClient(token) : null), [token]);
+}
+```
+
+```ts
+// src/api/client.ts
+const API_BASE = import.meta.env.VITE_API_URL;
+
+export class ApiClient {
+  constructor(private readonly token: string) {}
+
+  async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const res = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+        ...init.headers,
+      },
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.json() as Promise<T>;
+  }
+}
+```
+
+Usage from a component:
+
+```tsx
+function Profile() {
+  const client = useClient();
+  const { data } = useQuery({
+    queryKey: ["profile"],
+    queryFn: () => client!.request<UserProfile>("/me"),
+    enabled: client !== null,
+  });
+  return <p>{data?.email}</p>;
+}
+```
+
+A new client instance is built whenever the token changes (after silent refresh or sign-in). This keeps every request bound to the current token without subscribing to mutation events.
+
+## 7. Logout
+
+```tsx
+function Logout() {
+  const auth = useAuth();
+  return (
+    <button onClick={() => void auth.signoutRedirect()}>
+      Sign out
+    </button>
+  );
+}
+```
+
+`auth.signoutRedirect()` navigates to Kotauth's `/oauth2/logout`, which clears the SSO cookie on Kotauth's side, then redirects back to the post-logout URI. The library also clears local OIDC state.
+
+If you want a local-only logout (clear tokens but keep the Kotauth SSO session), use `auth.removeUser()` instead.
+
+## 8. Token refresh
+
+For a longer-lived session without forcing the user back through the login page when the access token expires, enable silent refresh in `oidcConfig`:
+
+```ts
+export const oidcConfig: AuthProviderProps = {
+  // ... existing fields
+  automaticSilentRenew: true,
+  // The library spawns a hidden iframe at this URL to do `prompt=none` re-auth.
+  // Default is fine; override only if you need a dedicated route.
+  silent_redirect_uri: import.meta.env.VITE_KOTAUTH_REDIRECT_URI,
+};
+```
+
+Silent renew uses a hidden iframe pointed at Kotauth with `prompt=none`. If the user still has an active SSO session, Kotauth issues a fresh code without UI; the library exchanges it for a new access token. If the SSO session has expired, the iframe returns an error and `react-oidc-context` surfaces it on `auth.error` — at which point you redirect to login.
+
+Silent renew has known limitations in browsers that block third-party cookies (Safari, Firefox in private mode). For those, the refresh token grant is the fallback — set `scope: "openid profile email offline_access"` in `oidcConfig` to request a refresh token, and the library will use it instead of the iframe.
+
+## Security trade-offs
+
+Browser-direct OIDC stores the access token in `localStorage` (or `sessionStorage`). Any JavaScript running on the page can read it. This means:
+
+- **An XSS vulnerability becomes a token-theft vulnerability.** Defense-in-depth: ship a strict CSP that blocks inline scripts, audit third-party packages, treat any DOM injection sink (`innerHTML`, `dangerouslySetInnerHTML`) as a security review surface.
+- **The refresh token, if used, also lives in storage.** Same risk.
+- **Token revocation requires both Kotauth-side cleanup and a local clear.** `signoutRedirect()` does both; a logout that only clears Kotauth (or only clears local) creates a stale state.
+
+The BFF pattern eliminates these by keeping tokens off the browser entirely. If your threat model includes "attacker exfiltrates user tokens via XSS," prefer [BFF](react-bff-pattern.md).
+
+## Common issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `redirect_uri_mismatch` from Kotauth | The redirect URI in `oidcConfig` doesn't exactly match what's registered on the application | Update the application in the admin console; URIs are matched character-for-character including trailing slashes |
+| `auth.isAuthenticated` flips to `false` on every page load | Tokens are in `sessionStorage` and a new tab starts a fresh session | Use `localStorage` for cross-tab persistence (the default in this guide) |
+| `?code=...` stays in the URL after login | Missing `onSigninCallback` in `oidcConfig` | Add the `window.history.replaceState` snippet from step 3 |
+| API calls return 401 after a few minutes | Access token expired and silent renew isn't enabled | Set `automaticSilentRenew: true` in `oidcConfig` |
+| Silent renew fails in Safari | Third-party cookie blocking breaks the iframe flow | Add `offline_access` to `scope` so the library uses the refresh token grant instead |
+| Multi-workspace deployment hits the wrong tenant | `authority` is set to the base URL, not the tenant-scoped issuer | Set `authority` to `${KOTAUTH_URL}/t/${WORKSPACE_SLUG}` |
+
+## Where next
+
+- [TanStack Router integration](react-spa-tanstack-router.md) — `beforeLoad` route guards on top of this guide
+- [BFF pattern](react-bff-pattern.md) — same flow, but tokens never reach the browser
+- [Environment variable reference](../ENV_REFERENCE.md) — every variable Kotauth reads at startup


### PR DESCRIPTION
## Summary

Two new React integration guides that complement the existing TanStack Router guide. Both are router-agnostic; the TanStack guide stays as the framework-specific layer on top.

- **[`react-spa-direct.md`](docs/guides/react-spa-direct.md)** — Authorization Code + PKCE in the browser via [`react-oidc-context`](https://github.com/authts/react-oidc-context). Patterns drawn from a real SPA shipping this shape today: `<AuthProvider>` wrapper, `<RequireAuth>` gate, `useClient()` hook that attaches `Authorization: Bearer`, `signinRedirect()` / `signoutRedirect()` for nav. Calls out the XSS / token-storage trade-off honestly.
- **[`react-bff-pattern.md`](docs/guides/react-bff-pattern.md)** — Backend-For-Frontend with HTTP-only session cookies. Frontend has zero OIDC dependencies; all token handling lives on the BFF (Vite proxy → BFF → Kotauth, sessions in Redis, Origin/Referer CSRF). Includes a working Kotlin/Ktor backend sketch — Kotauth's native stack — for the four endpoints (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`). Comparison table against SPA-direct on every dimension that matters (token exposure, XSS, refresh, logout, CSRF, multi-tab).

The README "Integration guides" list now surfaces all three React patterns and orders them by complexity / production-readiness.

## Why these two together

The choice between SPA-direct and BFF is the most-asked question Kotauth adopters have once they get past "how do I install it." Shipping both as side-by-side guides — with a clear "when to use which" decision matrix at the top — lets evaluators reach the right answer on first read instead of hand-rolling the BFF endpoints from scratch when their threat model demands it.

## Test plan

- [x] Render check on both files (Markdown valid, code fences balanced, internal links resolve to existing files)
- [x] Cross-links between the three guides (SPA-direct ↔ BFF ↔ TanStack) all work
- [x] Operator validates the Kotlin/Ktor BFF sketch compiles and runs end-to-end against a Kotauth instance (manual)
- [x] Operator follows the SPA-direct guide against a fresh Vite app and reaches `/admin` (manual)