### PR TITLE
Simplify README + sweep related docs for staleness, filler, and cross-file duplication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,79 +38,21 @@ The application starts on `http://localhost:8080`. Database migrations run autom
 
 ### Makefile targets
 
-All developer workflows are available via `make`. Run `make help` to see the full list.
-
-| Target | What it does |
-| --- | --- |
-| `make up` | Build from source and start all services (dev) |
-| `make up-fresh` | Rebuild from scratch, no layer cache |
-| `make down` | Stop and remove containers |
-| `make nuke` | Stop containers and wipe volumes (destroys the database) |
-| `make logs` | Follow app container logs |
-| `make health` | Probe the local health endpoint |
-| `make test` | Run the unit/integration test suite |
-| `make e2e` | Run E2E browser smoke tests (Playwright, headless) |
-| `make e2e-headed` | Run E2E tests with a visible browser (debugging) |
-| `make lint` | Run ktlint check |
-| `make lint-fix` | Auto-fix lint issues |
-| `make css` | Compile all four CSS bundles (admin, auth, portal-sidenav, portal-tabnav) |
-| `make build` | Full CI-equivalent build — CSS + lint + tests + fat JAR |
-| `make jar` | Build fat JAR only, skipping tests (faster iteration) |
-| `make version` | Generate `version.properties` (required before running from IDE) |
-
-### Typical dev loop
-
-```bash
-make up              # start the stack
-# make changes...
-make test            # run tests
-make lint            # check formatting
-make logs            # tail the app logs
-make nuke && make up # reset everything from scratch
-```
-
----
-
-## Project Structure
-
-```bash
-src/main/kotlin/com/kauth/
-  Application.kt          — Entry point and composition root
-  domain/
-    model/                — Pure data classes (no framework imports)
-    port/                 — Interface contracts (Repository, EmailPort, etc.)
-    service/              — Business logic (AuthService, OAuthService, etc.)
-  adapter/
-    web/                  — Ktor HTTP route handlers
-    persistence/          — PostgreSQL adapters (Exposed ORM)
-    token/                — JWT adapter, password hasher
-    email/                — SMTP adapter
-    social/               — Google / GitHub OAuth adapters
-  infrastructure/         — Cross-cutting: encryption, rate limiting, TOTP, key generation
-
-src/test/kotlin/          — Unit tests and fakes (no database required)
-src/main/resources/
-  db/migration/           — Flyway SQL migrations (V1–V52)
-  openapi/v1.yaml         — OpenAPI 3.1 specification
-```
+Run `make help` for the full list. Common loop: `make up` → edit → `make test` → `make lint` → `make logs`. To reset state: `make nuke && make up`.
 
 ---
 
 ## Architecture
 
-Kotauth follows [hexagonal architecture](https://alistair.cockburn.us/hexagonal-architecture/). The key rule is:
+Hexagonal (Ports & Adapters). The domain layer (`domain/model`, `domain/port`, `domain/service`) has zero framework dependencies — tests run in-memory without Docker, a database, or HTTP. See [CLAUDE.md](CLAUDE.md) for the full directory layout, and [docs/adr/](docs/adr/) for decision records.
 
-**The domain layer has zero dependencies on any framework, database, or HTTP library.**
+When adding a feature:
 
-Domain services (`AuthService`, `OAuthService`, etc.) depend only on port interfaces — never on Ktor, Exposed, or any other adapter. This makes them testable in complete isolation.
-
-When adding a new feature:
-
-1. Model the domain entity in `domain/model/`
+1. Model the entity in `domain/model/`
 2. Define the port interface in `domain/port/`
 3. Write the business logic in `domain/service/`
-4. Implement the adapter in `adapter/persistence/` (database), `adapter/web/` (HTTP), etc.
-5. Wire everything together in `Application.kt`
+4. Implement the adapter in `adapter/persistence/`, `adapter/web/`, etc.
+5. Wire it up in `Application.kt`
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ src/main/kotlin/com/kauth/
 
 src/test/kotlin/          — Unit tests and fakes (no database required)
 src/main/resources/
-  db/migration/           — Flyway SQL migrations (V1–V21)
+  db/migration/           — Flyway SQL migrations (V1–V52)
   openapi/v1.yaml         — OpenAPI 3.1 specification
 ```
 
@@ -238,12 +238,15 @@ Good areas to contribute:
 - **Documentation improvements** — typos, clarity, new deployment guides
 - **Bug fixes** — always welcome
 
-Out of scope for V1 (don't start these without discussion first):
+Larger items already on the roadmap — start with a discussion issue before opening a PR:
 
 - LDAP / SAML federation
 - WebAuthn / Passkeys
+- Magic links / SMS OTP
 - Multi-region / distributed PostgreSQL
 - Prometheus metrics
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for the planned phases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 > Identity infrastructure for modern applications. Self-hosted, container-native, developer-first.
 
-Kotauth is an open-source authentication and identity platform that bridges the gap between enterprise IAM systems (Keycloak, Okta) and developer-friendly SaaS tools (Clerk, Auth0). Full OAuth2/OIDC compliance. Runs in Docker. Up in minutes.
+Kotauth is an open-source authentication and identity platform that bridges the gap between enterprise IAM (Keycloak, Okta) and developer-friendly SaaS (Clerk, Auth0). Full OAuth2/OIDC compliance. Multi-tenant. Runs in Docker. Up in minutes.
 
 **[Live demo](https://demo.kotauth.com)** · **[Documentation](https://kotauth.com)** · **[Roadmap](docs/ROADMAP.md)**
 
 ---
 
-## Try it — one command
+## Try it
 
 You need Docker and Docker Compose. Nothing else.
 
@@ -22,177 +22,86 @@ curl -O https://raw.githubusercontent.com/inumansoul/kotauth/main/docker-compose
 docker compose up -d
 ```
 
-Open **http://localhost:8080/admin** — demo data is pre-loaded with two workspaces, users, roles, and applications. Credentials are shown in the banner.
+Open **http://localhost:8080/admin**. Demo data is pre-loaded with two workspaces, users, roles, and applications; credentials are shown in the banner.
 
-For configuration knobs (set your own `KAUTH_SECRET_KEY`, point at an external DB, enable Redis), see the [quickstart guide](docs/deploy/quickstart.md).
-
----
-
-## Build from source
-
-For contributors or anyone who wants to run from the cloned repo.
-
-```bash
-git clone https://github.com/inumansoul/kotauth.git
-cd kotauth
-make up
-```
-
-`make up` builds the image from the local Dockerfile and starts the full stack. Run `make help` for the rest (test, lint, logs, nuke, …). For the fast inner loop — host JVM against Docker-hosted Postgres + Redis — use `make run`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full developer guide.
-
----
-
-## Docker images
-
-Images are published to GitHub Container Registry on every tagged release.
-
-| Tag | Description |
-|---|---|
-| `ghcr.io/inumansoul/kotauth:latest` | Latest stable release |
-| `ghcr.io/inumansoul/kotauth:1` | Latest patch in the `1.x` line |
-| `ghcr.io/inumansoul/kotauth:1.1` | Latest patch in `1.1.x` |
-| `ghcr.io/inumansoul/kotauth:1.1.2` | Exact version pin |
-
-Pre-release tags (e.g. `1.1.0-rc1`) are published but do not move the `latest` or major/minor tags.
-
-```bash
-docker pull ghcr.io/inumansoul/kotauth:latest
-```
+For configuration knobs — set your own `KAUTH_SECRET_KEY`, point at an external database, enable Redis — see the [quickstart guide](docs/deploy/quickstart.md).
 
 ---
 
 ## Features
 
-- **OAuth2 / OIDC provider** — Authorization Code + PKCE, Client Credentials, refresh token rotation, token introspection & revocation
-- **Multi-tenancy** — Isolated workspaces, each with its own users, apps, settings, and RS256 signing keys
+- **OAuth2 / OIDC provider** — Authorization Code + PKCE, Client Credentials, refresh token rotation, token introspection & revocation, RFC 8707 resource indicators
+- **Multi-tenancy** — Isolated workspaces, each with its own users, applications, settings, and RS256 signing keys
 - **RBAC** — Roles, groups, composite role inheritance, JWT `realm_access` / `resource_access` claims
 - **MFA** — TOTP (RFC 6238), recovery codes, per-tenant policy (optional / required / required for admins)
 - **Social login** — Google and GitHub OAuth2, with automatic account linking
 - **User self-service** — Email verification, password reset, session management, MFA enrollment
-- **Admin console** — Full web UI for workspace settings, users, applications, audit logs, webhooks
+- **Admin console** — Web UI for workspaces, users, applications, audit logs, webhooks, branding
 - **REST API v1** — 30+ endpoints, API key authentication, OpenAPI 3.1 spec with Swagger UI
 - **Webhooks** — HMAC-signed event delivery with exponential backoff retry
-- **Audit logging** — 30+ immutable event types, append-only, queryable via API and admin UI
-- **Security** — bcrypt passwords, AES-256-GCM secrets at rest, rate limiting on login/register/token endpoints (IP-based), security response headers, per-tenant RS256 key pairs
+- **Audit logging** — 30+ immutable event types with per-tenant HMAC chain, queryable via API and admin UI
+- **Security** — bcrypt passwords, AES-256-GCM secrets at rest, sliding-window rate limiting, security response headers, per-tenant RS256 key pairs, file-based secret injection (`*_FILE`)
 
 ---
 
-## Environment variables
+## Integrate your app
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `KAUTH_BASE_URL` | **Yes** | — | Public base URL. Used in OIDC tokens and discovery docs. Must be `https://` in production. |
-| `KAUTH_SECRET_KEY` | Recommended | Random (ephemeral) | 32+ char hex string. Used for AES-256-GCM encryption and session signing. If not set, SMTP config is unavailable and sessions don't survive restarts. |
-| `KAUTH_ENV` | No | `development` | Set to `production` to enable HTTPS enforcement and strict startup validation. |
-| `KAUTH_DEMO_MODE` | No | `false` | Set to `true` to seed demo data and show a demo banner. For showcase deployments. |
-| `DB_URL` | No | Auto-constructed | PostgreSQL JDBC URL. When not set, constructed from `DB_HOST`, `DB_PORT`, and `DB_NAME`. Set directly for external/managed databases (RDS, Supabase, Neon). |
-| `DB_USER` | **Yes** | — | PostgreSQL username. |
-| `DB_PASSWORD` | **Yes** | — | PostgreSQL password. |
+| Pattern | When to use | Guide |
+|---|---|---|
+| **React SPA — browser-direct OIDC** | Internal tools, small apps, no separate backend | [docs/guides/react-spa-direct.md](docs/guides/react-spa-direct.md) |
+| **React SPA — BFF pattern** | Production-grade, no tokens in JavaScript | [docs/guides/react-bff-pattern.md](docs/guides/react-bff-pattern.md) |
+| **TanStack Router route guards** | Composes on top of either pattern above | [docs/guides/react-spa-tanstack-router.md](docs/guides/react-spa-tanstack-router.md) |
+| **Any OIDC client library** | Generic OIDC consumer — discovery at `/t/<workspace>/.well-known/openid-configuration` | *(coming soon)* |
 
-For the full reference including per-tenant SMTP and security policy configuration, see [docs/ENV_REFERENCE.md](docs/ENV_REFERENCE.md).
+The full REST API is documented at `http://localhost:8080/api/docs` (Swagger UI); the raw OpenAPI 3.1 spec lives at `src/main/resources/openapi/v1.yaml`.
 
 ---
 
-## Production deployment
+## Deploy
 
-The full walkthrough — TLS via Caddy, external database, Redis sidecar, file-based secrets, backups, upgrades, security checklist — is in [`docs/deploy/production.md`](docs/deploy/production.md).
-
-The shape of it:
+**Production** — TLS via Caddy, external database, Redis sidecar, backups, upgrades, security checklist: [docs/deploy/production.md](docs/deploy/production.md).
 
 ```bash
 mkdir kotauth && cd kotauth
 curl -O https://raw.githubusercontent.com/inumansoul/kotauth/main/docker-compose.prod.yml
 curl --create-dirs -o docker/Caddyfile \
   https://raw.githubusercontent.com/inumansoul/kotauth/main/docker/Caddyfile
-
 # fill in .env: KAUTH_BASE_URL, KAUTH_SECRET_KEY, DB_PASSWORD, DOMAIN, ACME_EMAIL
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-Minimum requirements: 512 MB RAM, 1 vCPU, PostgreSQL 14+. Already have a managed Postgres? Set `DB_URL` in `.env` — Kotauth uses it directly. To enable the Redis sidecar, add `--profile redis`.
+Minimum requirements: 512 MB RAM, 1 vCPU, PostgreSQL 14+. Managed Postgres? Set `DB_URL` and Kotauth uses it directly. Redis sidecar? Add `--profile redis`.
 
-For a public demo deployment (seeded workspaces + reset cron), set `KAUTH_DEMO_MODE=true` — see [`docs/deploy/production.md#11-demo-deployment`](docs/deploy/production.md#11-demo-deployment).
+**Build from source** — `git clone … && make up` builds the image from the local Dockerfile and starts the full stack. See [CONTRIBUTING.md](CONTRIBUTING.md) for the inner loop (`make run` boots the JVM on the host against Docker-hosted Postgres for sub-second restarts).
 
----
+**Docker images** are published to GitHub Container Registry on every tagged release:
 
-## Integration guides
-
-- [Quickstart](docs/deploy/quickstart.md) — local evaluation
-- [React SPA — browser-direct OIDC](docs/guides/react-spa-direct.md) — simplest path; tokens in the browser
-- [React SPA — BFF pattern](docs/guides/react-bff-pattern.md) — recommended for production; tokens stay server-side
-- [React SPA with TanStack Router](docs/guides/react-spa-tanstack-router.md) — `beforeLoad` route guards on top of either pattern
-- [Production deployment](docs/deploy/production.md) — TLS, backups, upgrades
-- Generic OIDC *(coming soon)*
-
----
-
-## API reference
-
-Swagger UI is available at:
-
-```
-http://localhost:8080/api/docs
-```
-
-The raw OpenAPI 3.1 spec is at `src/main/resources/openapi/v1.yaml`.
-
----
-
-## Concepts
-
-Kotauth maps IAM complexity to five concepts:
-
-| Kotauth | Traditional IAM equivalent |
+| Tag | Description |
 |---|---|
-| **Workspace** | Realm / Tenant |
-| **Application** | OAuth2 Client |
-| **User** | Identity / Principal |
-| **Role / Group** | Role / Policy |
-| **API Key** | Service credential |
+| `ghcr.io/inumansoul/kotauth:latest` | Latest stable release |
+| `ghcr.io/inumansoul/kotauth:1` | Latest patch in the `1.x` line |
+| `ghcr.io/inumansoul/kotauth:1.19` | Latest patch in `1.19.x` |
+| `ghcr.io/inumansoul/kotauth:1.19.2` | Exact version pin |
 
-Each workspace is a fully isolated identity directory. The same email address can exist in multiple workspaces — they are completely independent.
-
----
-
-## Architecture
-
-Kotauth is built on [hexagonal architecture](https://alistair.cockburn.us/hexagonal-architecture/) (Ports & Adapters). The domain layer has zero framework dependencies — all I/O goes through typed port interfaces.
-
-```
-domain/
-  model/      — Pure data classes (User, Tenant, Session, …)
-  port/       — Interface contracts (TenantRepository, EmailPort, …)
-  service/    — Business logic (AuthService, OAuthService, MfaService, …)
-
-adapter/
-  web/        — Ktor HTTP routes
-  persistence/— PostgreSQL + Exposed ORM
-  token/      — JWT signing, password hashing
-  email/      — SMTP delivery
-  social/     — Google / GitHub OAuth adapters
-
-infrastructure/
-              — Cross-cutting: key provisioning, rate limiting, encryption
-```
-
-Key decisions are documented as ADRs in [docs/adr/](docs/adr/).
+Pre-release tags (e.g. `1.19.0-rc1`) are published but do not move the `latest` or major/minor tags. The full env-variable reference is at [docs/ENV_REFERENCE.md](docs/ENV_REFERENCE.md).
 
 ---
 
-## Tech stack
+## Under the hood
 
-- **Runtime:** Kotlin, Ktor 2, JVM 17
-- **Database:** PostgreSQL 15, Exposed ORM, Flyway migrations
-- **Tokens:** RS256 JWT (per-tenant key pairs), bcrypt, AES-256-GCM
-- **Container:** Multi-stage Docker build, ~120 MB runtime image
+**Stack:** Kotlin 2.3.20, Ktor 3.4.2, Exposed 0.61.0 (ORM), PostgreSQL 15, JVM 17, Gradle 8.14. The runtime image is ~120 MB; the JAR runs as an unprivileged user.
+
+**Architecture:** [hexagonal (Ports & Adapters)](https://alistair.cockburn.us/hexagonal-architecture/) — the domain layer (`domain/model`, `domain/port`, `domain/service`) has zero framework dependencies, so business logic is testable in-memory without Docker, a database, or HTTP. Adapters (`adapter/web`, `adapter/persistence`, `adapter/token`, `adapter/email`, `adapter/social`) sit at the edge.
+
+**Multi-tenancy** maps the standard IAM vocabulary to a workspace-first model: a **Workspace** is a Realm/Tenant; an **Application** is an OAuth2 Client; a **User** is an Identity scoped to one workspace. Workspaces are fully isolated — the same email can exist in many workspaces independently.
+
+Architectural decisions are recorded as ADRs in [docs/adr/](docs/adr/). Consult them before changing patterns like the migration strategy, sealed result types, audit logging chain, or secret hashing.
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
----
+See [CONTRIBUTING.md](CONTRIBUTING.md). Issues and PRs welcome.
 
 ## License
 

--- a/docs/ENV_REFERENCE.md
+++ b/docs/ENV_REFERENCE.md
@@ -41,16 +41,11 @@ See [`docs/deploy/production.md#7-file-based-secrets`](deploy/production.md#7-fi
 ### `KAUTH_BASE_URL`
 **Required.**
 
-The public base URL of the Kotauth instance. Used as the OIDC issuer (`iss` claim), in OIDC discovery documents, OAuth2 redirect URI validation, and email links.
+Public base URL. Used as the OIDC issuer (`iss` claim), in discovery documents, redirect-URI validation, and email links. Must be `https://` in production; `http://localhost` is allowed in development. No trailing slash.
 
 ```
 KAUTH_BASE_URL=https://auth.yourdomain.com
 ```
-
-Rules:
-- Must start with `https://` when `KAUTH_ENV=production`. The server refuses to start otherwise.
-- HTTP is allowed for `localhost` in development mode.
-- No trailing slash.
 
 ---
 
@@ -61,8 +56,8 @@ Controls startup validation strictness.
 
 | Value | Behavior |
 |---|---|
-| `development` | HTTP allowed, default secrets tolerated, startup warnings printed, welcome page shows live health details |
-| `production` | HTTPS required, default JWT secret rejected, strict cookie flags enforced, welcome page hides health details |
+| `development` | Lax: HTTP allowed, default secrets tolerated, warnings printed |
+| `production` | Strict: HTTPS required, quickstart secret rejected, strict cookie flags |
 
 ```
 KAUTH_ENV=production
@@ -71,22 +66,13 @@ KAUTH_ENV=production
 ---
 
 ### `KAUTH_SECRET_KEY`
-**Required.** The server refuses to start without it.
+**Required.**
 
-A 32+ character string used for:
-- AES-256-GCM encryption of secrets at rest (SMTP passwords, TOTP secrets, RSA private keys)
-- HMAC-SHA256 signing of session cookies and short-lived auth state cookies
+32+ character secret used for AES-256-GCM encryption of secrets at rest (SMTP credentials, TOTP secrets, RSA private keys) and HMAC-SHA256 signing of session cookies. Generate: `openssl rand -hex 32`. Also accepts `KAUTH_SECRET_KEY_FILE` (see [File-based secret injection](#file-based-secret-injection-_file)).
 
 ```
-KAUTH_SECRET_KEY=<output of: openssl rand -hex 32>
+KAUTH_SECRET_KEY=<openssl rand -hex 32 output>
 ```
-
-Generate one:
-```bash
-openssl rand -hex 32
-```
-
-Also accepts `KAUTH_SECRET_KEY_FILE` (see [File-based secret injection](#file-based-secret-injection-_file)).
 
 ---
 
@@ -161,26 +147,18 @@ DB_USER=kotauth
 ### `DB_PASSWORD`
 **Required.**
 
-PostgreSQL password. The server refuses to start when unset — there is no
-default fallback.
+PostgreSQL password. Also accepts `DB_PASSWORD_FILE` (see [File-based secret injection](#file-based-secret-injection-_file)).
 
 ```
 DB_PASSWORD=changeme
 ```
-
-Also accepts `DB_PASSWORD_FILE` (see [File-based secret injection](#file-based-secret-injection-_file)).
 
 ---
 
 ### `KAUTH_TRUSTED_PROXY`
 **Optional.** Default: `false`
 
-When `true`, Kotauth honors `X-Forwarded-For` / `X-Forwarded-Proto` headers
-to resolve client IPs. **Only enable this behind a reverse proxy that
-overwrites these headers** (the bundled Caddy production overlay sets it
-automatically). On a directly-exposed instance, leaving this off is what
-prevents clients from spoofing their IP to bypass per-IP rate limits on
-login, token, MFA, and OTP endpoints.
+When `true`, Kotauth trusts `X-Forwarded-For` / `X-Forwarded-Proto` headers for client-IP resolution. **Only enable behind a reverse proxy that overwrites these headers** — on a directly-exposed instance, this lets clients spoof their IP to bypass per-IP rate limits on login, token, MFA, and OTP endpoints. The bundled Caddy production setup sets it automatically.
 
 ```
 KAUTH_TRUSTED_PROXY=true
@@ -191,9 +169,7 @@ KAUTH_TRUSTED_PROXY=true
 ### `DB_POOL_MAX_SIZE`
 **Optional.** Default: `10`
 
-Maximum number of connections in the HikariCP connection pool. For coroutine-based apps, size to actual DB concurrency needs rather than thread count. A value of `CPU cores × 2` is a good starting point.
-
-When running multiple Kotauth instances, ensure the total across all instances stays within PostgreSQL's `max_connections` (default 100). For example, 4 instances × 10 = 40 connections.
+Maximum HikariCP pool size. When running multiple Kotauth instances, ensure the total stays within PostgreSQL's `max_connections` (default 100).
 
 ```
 DB_POOL_MAX_SIZE=10
@@ -204,7 +180,7 @@ DB_POOL_MAX_SIZE=10
 ### `DB_POOL_MIN_IDLE`
 **Optional.** Default: `2`
 
-Minimum number of idle connections maintained in the pool. Keeps a small number of connections warm to avoid cold-start latency on the first requests after an idle period.
+Minimum idle connections kept warm.
 
 ```
 DB_POOL_MIN_IDLE=2
@@ -214,7 +190,7 @@ DB_POOL_MIN_IDLE=2
 
 ## Redis
 
-Optional sidecar for distributed rate limiting and sessions. Single-instance deployments can leave all of these unset. See [REDIS.md](REDIS.md) for the full operator guide.
+Optional sidecar for distributed rate limiting and sessions. Single-instance deployments can leave these unset. See [REDIS.md](REDIS.md) for the operator guide.
 
 ### `KAUTH_REDIS_URL`
 **Optional.** Default: _unset_ (Redis disabled — in-memory limiter, Postgres sessions)
@@ -287,31 +263,24 @@ The cookie carries its own `expiresAt` timestamp in the signed payload, so this 
 ### `KAUTH_SSO_SESSION_MAX_TTL_SECONDS`
 **Optional.** Default: `2592000` (30 days)
 
-Operator-side ceiling. `KAUTH_SSO_SESSION_TTL_SECONDS` must be `≤` this value or the server refuses to start (fail-fast at `EnvironmentConfig.load`). Use it to enforce a policy "no SSO session may live longer than X" without trusting individual deployments to keep the per-instance TTL under control.
+Operator ceiling on `KAUTH_SSO_SESSION_TTL_SECONDS`. The server refuses to start unless `TTL ≤ MAX_TTL` and both are `≥ 60`.
 
 ```
 KAUTH_SSO_SESSION_MAX_TTL_SECONDS=2592000
 ```
-
-Validation: both values must be `≥ 60` and `ttl ≤ maxTtl`. Misconfiguration prints a `FATAL` banner and exits.
 
 ---
 
 ## Demo Mode
 
 ### `KAUTH_DEMO_MODE`
-**Optional.** Default: `false` (disabled)
+**Optional.** Default: `false`
 
-When set to `true`, activates demo mode for public showcase deployments:
-
-1. **Seed data** — On startup, `DemoSeedService` creates two pre-populated workspaces ("Acme Corp" and "Startup Labs") with users, applications, roles, groups, webhooks, and audit log entries. Idempotent — skipped if the data already exists.
-2. **Demo banner** — A sticky amber banner is rendered on every page showing demo credentials and a reset notice.
+When `true`, seeds two demo workspaces (`Acme Corp`, `Startup Labs`) with users, applications, roles, groups, webhooks, and audit log entries, and shows a sticky credential banner. Seed is idempotent. Intended for public showcase deployments paired with an hourly reset (see [Demo deployment](#example-env--demo-deployment)).
 
 ```
 KAUTH_DEMO_MODE=true
 ```
-
-Intended for deployments like `demo.kotauth.com` where visitors should see a populated instance. Not intended for production. Pair with an hourly database reset (see [Demo deployment](#example-env--demo-deployment) below).
 
 **Seeded credentials:**
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Kotauth — Product Roadmap
 
-> Last updated: 2026-03-21
-> Status: V1.1.0
+> Last updated: 2026-06-23
+> Status: v1.19.2
 
 ---
 

--- a/docs/deploy/production.md
+++ b/docs/deploy/production.md
@@ -207,21 +207,15 @@ services:
 
 ## 11. Demo deployment
 
-Run a public showcase instance (e.g. `demo.yourdomain.com`) with pre-seeded workspaces:
+For a public showcase (e.g. `demo.yourdomain.com`), set `KAUTH_DEMO_MODE=true` in `.env`. The seed and credentials are documented in [quickstart](quickstart.md#demo-credentials).
 
-```env
-KAUTH_DEMO_MODE=true
-```
-
-Restart and the demo seed runs on startup, creating two workspaces with users, applications, roles, and audit log entries. A sticky banner exposes the demo credentials on every page.
-
-Hourly reset (the only sensible cadence for a public demo):
+For periodic reset (hourly is typical for public demos):
 
 ```cron
 0 * * * * cd /opt/kotauth && docker compose -f docker-compose.prod.yml down -v && docker compose -f docker-compose.prod.yml up -d
 ```
 
-`-v` wipes `kotauth_db_data`. Flyway re-migrates from scratch and `DemoSeedService` re-creates the demo data.
+`-v` wipes `kotauth_db_data`; Flyway re-migrates and the demo seed runs again.
 
 ## 12. Security checklist
 

--- a/docs/deploy/production.md
+++ b/docs/deploy/production.md
@@ -1,7 +1,5 @@
 # Production deployment
 
-This guide takes you from a fresh Linux server to a running Kotauth instance behind HTTPS, with backups, secrets management, and an upgrade path.
-
 ## Prerequisites
 
 - Docker and Docker Compose on a Linux host
@@ -11,7 +9,7 @@ This guide takes you from a fresh Linux server to a running Kotauth instance beh
 
 ## 1. Pull the files
 
-You don't need to clone the repo. Fetch the production compose file, the Caddy config, and the env template:
+No repo clone required:
 
 ```bash
 mkdir kotauth && cd kotauth
@@ -24,7 +22,7 @@ curl -o .env https://raw.githubusercontent.com/inumansoul/kotauth/main/.env.exam
 
 ## 2. Configure `.env`
 
-Open `.env` and fill in every value. Nothing should be left blank in production.
+Fill every value:
 
 ```env
 KAUTH_BASE_URL=https://auth.yourdomain.com
@@ -39,7 +37,7 @@ DOMAIN=auth.yourdomain.com
 ACME_EMAIL=you@yourdomain.com
 ```
 
-`KAUTH_SECRET_KEY` is the most important value — it encrypts every secret at rest (SMTP credentials, TOTP enrolments, RSA private keys) and signs session cookies. Generate it with `openssl rand -hex 32` or `docker run --rm ghcr.io/inumansoul/kotauth:latest cli generate-secret-key`. Lose it and you lose every encrypted value in the database.
+`KAUTH_SECRET_KEY` encrypts every secret at rest (SMTP credentials, TOTP enrolments, RSA private keys) and signs session cookies. Generate it with `openssl rand -hex 32`. Never reuse it across environments.
 
 ## 3. Start
 
@@ -47,7 +45,7 @@ ACME_EMAIL=you@yourdomain.com
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-Three services come up: `app` (Kotauth), `db` (PostgreSQL 15), and `caddy` (Let's Encrypt TLS). Caddy obtains a certificate on first boot via the ACME HTTP-01 challenge, which is why port `80` has to be reachable.
+Three services: `app`, `db` (PostgreSQL 15), `caddy` (Let's Encrypt TLS via ACME HTTP-01).
 
 ## 4. Verify
 
@@ -79,7 +77,7 @@ In `.env`:
 KAUTH_REDIS_URL=redis://redis:6379
 ```
 
-Kotauth's Redis path fails closed — if Redis becomes unreachable, auth requests are rejected rather than falling back to per-replica state.
+The Redis path fails closed: if Redis becomes unreachable, auth requests are rejected rather than falling back to per-replica state.
 
 ## 6. Use a managed database
 
@@ -91,13 +89,11 @@ DB_USER=kotauth
 DB_PASSWORD=<the managed-db password>
 ```
 
-The bundled `db` service still starts but receives no traffic — Flyway runs against the external database. If you want to remove the idle container entirely, comment out the `db` service block and the `depends_on: db` line in `docker-compose.prod.yml`.
-
-Flyway runs all migrations automatically. Point it at an empty database.
+Flyway runs against the external database. The bundled `db` service still starts but receives no traffic — to remove the idle container, comment out the `db` service block and its `depends_on: db` line in `docker-compose.prod.yml`.
 
 ## 7. File-based secrets
 
-For Docker Swarm, Kubernetes mounted secrets, or systemd `LoadCredential=`, every sensitive variable accepts a `<NAME>_FILE` form. The file's contents are read and trimmed at startup. `<NAME>_FILE` wins over `<NAME>` when both are set.
+For Docker Swarm, Kubernetes mounted secrets, or systemd `LoadCredential=`, every sensitive variable accepts a `<NAME>_FILE` form (contents read and trimmed at startup; `<NAME>_FILE` takes precedence over `<NAME>`).
 
 Supported variables:
 
@@ -140,10 +136,8 @@ Named volumes:
 | Volume | Contents |
 |---|---|
 | `kotauth_db_data` | PostgreSQL data — every tenant, user, session, audit row |
-| `caddy_data` | TLS certificates and ACME state |
-| `caddy_config` | Caddy runtime config |
-
-Only `kotauth_db_data` matters for backups. Caddy state is regenerable.
+| `caddy_data` | TLS certificates and ACME state (regenerable) |
+| `caddy_config` | Caddy runtime config (regenerable) |
 
 ```bash
 docker exec kotauth-db pg_dump -U kotauth kotauth_db > backup_$(date +%Y%m%d).sql
@@ -162,7 +156,7 @@ docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-Flyway runs new migrations before the server accepts traffic. If a migration fails, the container exits and the previous version remains in place. Take a database backup before crossing a major version.
+Flyway auto-migrates before accepting traffic; a failed migration halts the container and leaves the previous version running. Take a backup before major version bumps.
 
 Pin a specific image tag instead of tracking `latest`:
 
@@ -174,7 +168,7 @@ services:
 
 ## 10. Reverse proxy alternatives
 
-The bundled `caddy` service handles TLS for a single-domain single-host deployment. If you already run your own reverse proxy (nginx, Traefik, an L7 load balancer), remove the `caddy` service from `docker-compose.prod.yml` and proxy your existing edge to port `8080`.
+If you already run your own reverse proxy (nginx, Traefik, an L7 load balancer), remove the `caddy` service from `docker-compose.prod.yml` and proxy your existing edge to port `8080`.
 
 ### nginx
 

--- a/docs/deploy/quickstart.md
+++ b/docs/deploy/quickstart.md
@@ -1,24 +1,22 @@
 # Quickstart
 
-Run Kotauth locally in one command. Bundled PostgreSQL, demo data pre-loaded, no `.env` file required.
-
-You need Docker and Docker Compose. Nothing else.
+Requires Docker and Docker Compose.
 
 ```bash
 curl -O https://raw.githubusercontent.com/inumansoul/kotauth/main/docker-compose.yml
 docker compose up -d
 ```
 
-Open **http://localhost:8080/admin** and sign in with the credentials shown in the demo banner.
+Open **http://localhost:8080/admin**, sign in with the credentials shown in the demo banner.
 
 ## What you get
 
 - Kotauth on port `8080` (HTTP)
 - PostgreSQL 15 (named volume `kotauth_db_data`)
 - Demo mode on — two seeded workspaces (Acme Corp, Startup Labs) with users, roles, applications, and audit log entries
-- `KAUTH_UPDATE_CHECK=false` so the demo banner doesn't network out
+- `KAUTH_UPDATE_CHECK=false` so the banner doesn't network out
 
-The defaults are unsafe (well-known secret key, hardcoded password). They're fine for local evaluation. When you're ready to run a real instance, see [`production.md`](production.md).
+The defaults are unsafe for anything beyond local evaluation. See [`production.md`](production.md) when you're ready to deploy.
 
 ## Demo credentials
 
@@ -30,30 +28,24 @@ The defaults are unsafe (well-known secret key, hardcoded password). They're fin
 
 ## Customizing the defaults
 
-Every value in `docker-compose.yml` uses the `${VAR:-default}` pattern. To override, either:
+Every value in `docker-compose.yml` uses `${VAR:-default}` substitution. Override by dropping a `.env` file next to `docker-compose.yml` or exporting the var in your shell:
 
-- Drop a `.env` file in the same directory as `docker-compose.yml`:
+```env
+KAUTH_BASE_URL=http://my-host:8080
+KAUTH_SECRET_KEY=<openssl rand -hex 32>
+KAUTH_DEMO_MODE=false
+DB_PASSWORD=<your password>
+```
 
-  ```env
-  KAUTH_BASE_URL=http://my-host:8080
-  KAUTH_SECRET_KEY=<openssl rand -hex 32>
-  KAUTH_DEMO_MODE=false
-  DB_PASSWORD=<your password>
-  ```
+Full variable list: [`../ENV_REFERENCE.md`](../ENV_REFERENCE.md).
 
-- Or export the var in your shell before `docker compose up`.
-
-The full list of supported variables is in [`../ENV_REFERENCE.md`](../ENV_REFERENCE.md).
-
-## Enabling Redis (optional)
-
-Redis is opt-in. Activate the `redis` profile:
+## Redis (optional)
 
 ```bash
 docker compose --profile redis up -d
 ```
 
-The Redis sidecar moves rate-limit state and short-lived auth cookies off Postgres. Useful when running more than one Kotauth replica or sustaining high login traffic. Not needed for a single-instance evaluation.
+Moves rate-limit state and session cookies off Postgres. Enable for multi-replica setups or high login traffic.
 
 ## Stopping
 

--- a/docs/guides/react-bff-pattern.md
+++ b/docs/guides/react-bff-pattern.md
@@ -8,17 +8,14 @@ This is the **recommended pattern for production deployments**. If an XSS lands,
 
 ## When to use this pattern
 
-Pick BFF when **any** of these are true:
+Use BFF when any of these are true:
 
-- You're shipping a customer-facing or regulated app where XSS-driven token theft is unacceptable
-- You already run a backend that needs to call internal APIs on the user's behalf
+- The app is customer-facing or regulated; XSS-driven token theft is unacceptable
+- You already run a backend that calls internal APIs on the user's behalf
 - You want centrally-managed token refresh (one server-side flow, not N tabs)
-- You need to apply additional authorization, rate limiting, or audit logging at the gateway
+- You need extra authorization, rate limiting, or audit logging at the gateway
 
-Pick the [browser-direct SPA pattern](react-spa-direct.md) instead when:
-
-- The app is a small internal tool with no separate backend
-- You want the simplest possible deployment (static SPA + Kotauth, nothing else)
+For small internal tools with no backend, the [browser-direct SPA pattern](react-spa-direct.md) is simpler.
 
 ## The architecture
 

--- a/docs/guides/react-bff-pattern.md
+++ b/docs/guides/react-bff-pattern.md
@@ -1,8 +1,8 @@
 # Integrating Kotauth with a React SPA (BFF Pattern)
 
-This guide walks through adding Kotauth authentication to a React SPA using the **Backend-For-Frontend (BFF) pattern**. The browser never touches OIDC; instead, a thin backend handles the token exchange, stores access/refresh tokens server-side, and exposes session-cookie-authenticated endpoints to the SPA.
+Add Kotauth authentication to a React SPA using the **Backend-For-Frontend (BFF) pattern**: a thin backend handles the OIDC token exchange, stores access and refresh tokens server-side, and exposes session-cookie-authenticated endpoints to the SPA. The browser never sees a bearer token.
 
-This is the **recommended pattern for production deployments** of any non-trivial size, because the access token never reaches JavaScript. If an XSS lands, the attacker still cannot exfiltrate the bearer token — they only see an opaque `HTTP-only` session cookie that the browser will not surface to script.
+This is the **recommended pattern for production deployments**. If an XSS lands, the attacker cannot exfiltrate tokens — only an opaque `HTTP-only` session cookie that the browser will not surface to script.
 
 **Stack:** React 18+, Vite (dev proxy), any backend that can speak OIDC. The backend example below is Kotlin/Ktor (Kotauth's native stack), but the pattern translates to Express, FastAPI, ASP.NET Core, Spring Boot, anything that can do an Authorization Code + PKCE exchange and set a cookie.
 
@@ -141,11 +141,7 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
 }
 ```
 
-Three things to notice:
-
-1. **`credentials: "include"`** — the browser sends the session cookie on every request to the same origin.
-2. **No `Authorization` header** — the SPA never sees the access token. The cookie is the only credential.
-3. **401 handler is centralized** — when the session expires, the browser hard-navigates to `/api/auth/login`, which the BFF turns into a Kotauth authorize redirect.
+`credentials: 'include'` sends the session cookie on every same-origin request. The SPA never sets `Authorization` because it has no token. 401s route through one handler that hard-navigates to `/api/auth/login`.
 
 ### Session query
 
@@ -191,8 +187,6 @@ export function useSession() {
   });
 }
 ```
-
-The query returns the user identity or `null`. No tokens, no expiry timestamps, no PKCE state — just "who is this person?"
 
 ### Route protection
 
@@ -245,13 +239,11 @@ export async function logout(): Promise<void> {
 }
 ```
 
-`POST /api/auth/logout` clears the server-side session and the cookie. The follow-up navigation forces a fresh login (`prompt=login` tells Kotauth to re-prompt even if the SSO cookie is still valid).
-
-That's everything the SPA needs. No OIDC library, no token storage, no refresh logic. The whole frontend auth surface is `useSession()`, `apiFetch()`, and a logout button.
+`POST /api/auth/logout` clears the server-side session and the cookie; `prompt=login` forces re-auth on the next navigation even if the Kotauth SSO cookie is still valid.
 
 ## 3. The BFF side
 
-The BFF needs four endpoints. The Kotlin/Ktor sketch below is the shape Kotauth itself encourages — production-grade Kotlin code, deployable as a sidecar to the SPA.
+Four endpoints. The Kotlin/Ktor sketch below mirrors what Kotauth itself runs.
 
 ### Configuration
 
@@ -292,8 +284,6 @@ get("/auth/login") {
     call.respondRedirect(authorizeUrl, permanent = false)
 }
 ```
-
-The PKCE verifier stays in Redis keyed by `state`. The browser only sees the redirect.
 
 ### `GET /auth/callback` — exchange code for tokens
 
@@ -342,7 +332,7 @@ fun ApplicationCall.setSessionCookie(sessionId: String, secure: Boolean) {
 }
 ```
 
-The cookie is **`httpOnly`** (unreachable from JavaScript), **`SameSite=Lax`** (mitigates CSRF on cross-site GETs), and **`secure`** in production (HTTPS only).
+`httpOnly` keeps the cookie unreachable from JavaScript; `SameSite=Lax` blocks cross-site CSRF on state-changing requests; `secure` is required in production.
 
 ### `GET /auth/me` — return the current identity
 
@@ -369,7 +359,7 @@ get("/auth/me") {
 }
 ```
 
-The refresh happens on the BFF, transparently. The SPA never sees an expired-token error during normal use.
+Refresh happens on the BFF; the SPA never sees an expired token during normal use.
 
 ### `POST /auth/logout` — clear session
 

--- a/docs/guides/react-spa-direct.md
+++ b/docs/guides/react-spa-direct.md
@@ -1,8 +1,8 @@
 # Integrating Kotauth with a React SPA (Browser-Direct OIDC)
 
-This guide walks through adding Kotauth authentication to a React SPA where **the browser talks to Kotauth directly** — Authorization Code + PKCE, tokens stored in the browser, `Authorization: Bearer` on every API request.
+Add Kotauth authentication to a React SPA where **the browser talks to Kotauth directly** — Authorization Code + PKCE, tokens stored in the browser, `Authorization: Bearer` on every API request.
 
-It is router-agnostic. The patterns work with React Router, TanStack Router, or no router at all. If you specifically want TanStack's `beforeLoad` integration, see the [TanStack Router guide](react-spa-tanstack-router.md) after reading this one.
+The patterns work with React Router, TanStack Router, or no router. For TanStack's `beforeLoad` integration, see the [TanStack Router guide](react-spa-tanstack-router.md) after reading this one.
 
 **Stack:** React 18+, [`react-oidc-context`](https://github.com/authts/react-oidc-context) (wraps [`oidc-client-ts`](https://github.com/authts/oidc-client-ts)), Vite. Both libraries are framework-neutral OIDC implementations.
 
@@ -157,9 +157,7 @@ export function Login() {
 }
 ```
 
-`auth.signinRedirect()` navigates the browser to Kotauth's `/oauth2/authorize` with the PKCE challenge. After the user authenticates, Kotauth redirects back to `redirect_uri` with `?code=...&state=...`. `react-oidc-context` detects the callback on mount, exchanges the code for tokens (using the PKCE verifier it stored in `sessionStorage` before redirecting), and updates `auth.isAuthenticated` to `true`.
-
-You do not need a separate `/callback` route — the provider handles the callback in-place because `redirect_uri` points at the app root.
+`auth.signinRedirect()` navigates to Kotauth's `/oauth2/authorize` with PKCE. On the return, `react-oidc-context` exchanges the code for tokens using the stored PKCE verifier and sets `auth.isAuthenticated = true` — no separate `/callback` route needed because `redirect_uri` points at the app root.
 
 ## 6. Attach the access token to API requests
 
@@ -214,7 +212,7 @@ function Profile() {
 }
 ```
 
-A new client instance is built whenever the token changes (after silent refresh or sign-in). This keeps every request bound to the current token without subscribing to mutation events.
+The `useMemo` rebuilds the client when the token changes, keeping every request bound to the current token.
 
 ## 7. Logout
 
@@ -229,13 +227,11 @@ function Logout() {
 }
 ```
 
-`auth.signoutRedirect()` navigates to Kotauth's `/oauth2/logout`, which clears the SSO cookie on Kotauth's side, then redirects back to the post-logout URI. The library also clears local OIDC state.
-
-If you want a local-only logout (clear tokens but keep the Kotauth SSO session), use `auth.removeUser()` instead.
+`auth.signoutRedirect()` navigates to Kotauth's `/oauth2/logout` (clears the SSO cookie), then redirects to the post-logout URI; the library clears local OIDC state. For local-only logout (clear tokens but keep the Kotauth SSO session), use `auth.removeUser()`.
 
 ## 8. Token refresh
 
-For a longer-lived session without forcing the user back through the login page when the access token expires, enable silent refresh in `oidcConfig`:
+To refresh expired tokens transparently, enable silent renew in `oidcConfig`:
 
 ```ts
 export const oidcConfig: AuthProviderProps = {

--- a/docs/guides/react-spa-direct.md
+++ b/docs/guides/react-spa-direct.md
@@ -8,17 +8,9 @@ The patterns work with React Router, TanStack Router, or no router. For TanStack
 
 ## When to use this pattern
 
-Pick browser-direct OIDC when:
+Use browser-direct when you have no backend and want a static SPA + Kotauth deployment. Accept the trade-off that access tokens are reachable from JavaScript (see [security trade-offs](#security-trade-offs)).
 
-- The SPA is the only client talking to Kotauth — there is no separate backend doing user-facing work
-- You want the simplest possible deployment: a static-hosted SPA + Kotauth, nothing in between
-- You're comfortable with access tokens being reachable from JavaScript (the XSS trade-off)
-
-Pick the [BFF pattern](react-bff-pattern.md) instead when:
-
-- Tokens must never be reachable from JavaScript (high-value targets, regulated industries)
-- You already have a backend that needs to authenticate calls (avoid double-handling identity)
-- You want centrally-managed token refresh, not per-tab refresh in the browser
+For production-grade or regulated apps where tokens must not reach JavaScript, use the [BFF pattern](react-bff-pattern.md) instead.
 
 ## Prerequisites
 

--- a/docs/guides/react-spa-tanstack-router.md
+++ b/docs/guides/react-spa-tanstack-router.md
@@ -1,184 +1,32 @@
 # Integrating Kotauth with a React SPA and TanStack Router
 
-This guide walks through adding Kotauth authentication to a React single-page application using [TanStack Router](https://tanstack.com/router). The result is a complete auth flow: login redirect, callback handling, protected routes, token refresh, and logout.
+TanStack-specific layer on top of the [browser-direct SPA guide](react-spa-direct.md). Read that first — it covers the Kotauth application registration, OIDC client config, `<AuthProvider>` wrapper, and the token-bearing fetch wrapper. This guide adds what TanStack Router needs: an `/auth/callback` route, a `beforeLoad` guard, and the router wiring.
 
-**What you'll build:**
-- OIDC Authorization Code + PKCE flow (the correct flow for SPAs — no client secret needed)
-- Auth context that holds the user session and exposes `login`, `logout`, and `getAccessToken`
-- Route-level protection using TanStack Router's `beforeLoad` hook
-- Silent token refresh before expiry
+**Stack:** React 18+, TanStack Router v1, [`oidc-client-ts`](https://github.com/authts/oidc-client-ts).
 
-**Stack:** React 18, TanStack Router v1, [`oidc-client-ts`](https://github.com/authts/oidc-client-ts)
-
----
-
-## Prerequisites
-
-- Kotauth running locally (`docker compose up`) or on a server
-- A workspace created in the admin console (e.g. slug `my-app`)
-- Node.js 18+
-
----
-
-## 1. Create an Application in Kotauth
-
-In the Kotauth admin console:
-
-1. Navigate to your workspace → **Applications** → **New Application**
-2. Set the name (e.g. `react-frontend`)
-3. Under **Redirect URIs**, add:
-   ```
-   http://localhost:5173/auth/callback
-   ```
-4. Under **Post-Logout Redirect URIs**, add:
-   ```
-   http://localhost:5173
-   ```
-5. Set **Access Type** to `public` (no client secret — correct for SPAs)
-6. Save. Copy the **Client ID** shown on the application detail page.
-
----
-
-## 2. Install Dependencies
-
-```bash
-npm install oidc-client-ts
-```
-
-TanStack Router should already be in your project. If not:
-
-```bash
-npm install @tanstack/react-router
-```
-
----
-
-## 3. Configure the OIDC Client
-
-Create `src/auth/oidcConfig.ts`:
+TanStack's `beforeLoad` runs outside React, so it can't call `react-oidc-context`'s `useAuth()` hook. The cleanest workaround is to construct the `UserManager` yourself and pass it to both `<AuthProvider>` and your `beforeLoad` helper. Replace the inline `oidcConfig` from the foundation guide with an exported `userManager`:
 
 ```ts
-import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
-
-const KOTAUTH_BASE_URL = import.meta.env.VITE_KOTAUTH_URL ?? 'http://localhost:8080'
-const WORKSPACE_SLUG   = import.meta.env.VITE_KOTAUTH_WORKSPACE ?? 'my-app'
-const CLIENT_ID        = import.meta.env.VITE_KOTAUTH_CLIENT_ID ?? 'react-frontend'
+// src/auth/oidcConfig.ts
+import { UserManager, WebStorageStateStore } from "oidc-client-ts";
 
 export const userManager = new UserManager({
-  // The authority is your workspace's OIDC issuer URL.
-  // oidc-client-ts fetches /.well-known/openid-configuration from this URL
-  // to auto-discover all endpoints (token, userinfo, logout, etc.).
-  authority: `${KOTAUTH_BASE_URL}/t/${WORKSPACE_SLUG}`,
-
-  client_id:     CLIENT_ID,
-  redirect_uri:  `${window.location.origin}/auth/callback`,
+  authority: import.meta.env.VITE_KOTAUTH_AUTHORITY,
+  client_id: import.meta.env.VITE_KOTAUTH_CLIENT_ID,
+  redirect_uri: `${window.location.origin}/auth/callback`,
   post_logout_redirect_uri: window.location.origin,
-
-  // Scopes: 'openid' is required. 'profile' and 'email' add standard claims.
-  // Add any custom scopes you defined on the application.
-  scope: 'openid profile email',
-
-  // Authorization Code + PKCE — the only correct flow for SPAs.
-  // oidc-client-ts handles code_verifier/code_challenge generation automatically.
-  response_type: 'code',
-
-  // Store the user session in sessionStorage so it's cleared on tab close.
-  // Use localStorage if you need persistence across tabs — understand the
-  // XSS risk trade-off before choosing.
-  userStore: new WebStorageStateStore({ store: window.sessionStorage }),
-
-  // Trigger a silent token refresh 60 seconds before the access token expires.
+  response_type: "code",
+  scope: "openid profile email",
+  userStore: new WebStorageStateStore({ store: window.localStorage }),
   automaticSilentRenew: true,
-  accessTokenExpiringNotificationTimeInSeconds: 60,
-})
+});
 ```
 
-Add the environment variables to your `.env.local`:
-
-```
-VITE_KOTAUTH_URL=http://localhost:8080
-VITE_KOTAUTH_WORKSPACE=my-app
-VITE_KOTAUTH_CLIENT_ID=react-frontend
-```
+Pass it to `<AuthProvider userManager={userManager}>` in `main.tsx` and register `${origin}/auth/callback` on the Kotauth application.
 
 ---
 
-## 4. Build the Auth Context
-
-Create `src/auth/AuthContext.tsx`:
-
-```tsx
-import { createContext, useContext, useEffect, useState, useCallback } from 'react'
-import type { User } from 'oidc-client-ts'
-import { userManager } from './oidcConfig'
-
-interface AuthContextValue {
-  user:           User | null
-  isLoading:      boolean
-  login:          () => Promise<void>
-  logout:         () => Promise<void>
-  getAccessToken: () => string | null
-}
-
-const AuthContext = createContext<AuthContextValue | null>(null)
-
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser]         = useState<User | null>(null)
-  const [isLoading, setLoading] = useState(true)
-
-  useEffect(() => {
-    // Load any existing session from storage on mount
-    userManager.getUser().then(u => {
-      setUser(u)
-      setLoading(false)
-    })
-
-    // Keep local state in sync when oidc-client-ts silently renews tokens
-    const onUserLoaded   = (u: User) => setUser(u)
-    const onUserUnloaded = ()        => setUser(null)
-
-    userManager.events.addUserLoaded(onUserLoaded)
-    userManager.events.addUserUnloaded(onUserUnloaded)
-
-    return () => {
-      userManager.events.removeUserLoaded(onUserLoaded)
-      userManager.events.removeUserUnloaded(onUserUnloaded)
-    }
-  }, [])
-
-  const login = useCallback(() =>
-    // Redirects to Kotauth login page. After login, Kotauth redirects back
-    // to /auth/callback with the authorization code.
-    userManager.signinRedirect(),
-  [])
-
-  const logout = useCallback(() =>
-    // Redirects to Kotauth's end_session endpoint, which clears the server-side
-    // session and redirects back to post_logout_redirect_uri.
-    userManager.signoutRedirect(),
-  [])
-
-  const getAccessToken = useCallback(() =>
-    user?.access_token ?? null,
-  [user])
-
-  return (
-    <AuthContext.Provider value={{ user, isLoading, login, logout, getAccessToken }}>
-      {children}
-    </AuthContext.Provider>
-  )
-}
-
-export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext)
-  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>')
-  return ctx
-}
-```
-
----
-
-## 5. Handle the Auth Callback
+## 1. Handle the auth callback
 
 Create `src/routes/auth.callback.tsx` (or wherever your file-based routing places it):
 
@@ -207,13 +55,13 @@ export default function AuthCallbackPage() {
 }
 ```
 
-Register this route at `/auth/callback` in your router (see step 7).
+Register this route at `/auth/callback` in your router (see section 3).
 
 ---
 
-## 6. Create an Auth Guard Utility
+## 2. Build the `beforeLoad` guard
 
-TanStack Router's `beforeLoad` is the cleanest place to enforce authentication. Create a reusable helper:
+`beforeLoad` is the cleanest place to enforce authentication — it runs before the route component mounts and can redirect synchronously.
 
 ```ts
 // src/auth/requireAuth.ts
@@ -241,9 +89,9 @@ export async function requireAuth() {
 
 ---
 
-## 7. Wire Up the Router
+## 3. Wire up the router
 
-Here's a minimal but complete router setup:
+A minimal but complete router setup:
 
 ```tsx
 // src/router.tsx
@@ -262,7 +110,7 @@ import AuthCallbackPage  from './routes/auth.callback'
 import DashboardPage     from './routes/dashboard'
 import ProfilePage       from './routes/profile'
 
-// Root route — wraps everything with the AuthProvider (see step 8)
+// Root route — wraps everything with the AuthProvider
 const rootRoute = createRootRoute({ component: RootLayout })
 
 // Public routes
@@ -323,81 +171,57 @@ declare module '@tanstack/react-router' {
 
 ---
 
-## 8. Set Up the Root Layout
+## 4. Root layout
 
-The `AuthProvider` goes in your root layout so every route can access auth state:
+Wrap the root in `<AuthProvider>` (sharing the same `userManager`):
 
 ```tsx
 // src/layouts/RootLayout.tsx
-import { Outlet } from '@tanstack/react-router'
-import { AuthProvider } from '../auth/AuthContext'
+import { Outlet } from "@tanstack/react-router";
+import { AuthProvider } from "react-oidc-context";
+import { userManager } from "../auth/oidcConfig";
 
 export default function RootLayout() {
   return (
-    <AuthProvider>
+    <AuthProvider userManager={userManager}>
       <Outlet />
     </AuthProvider>
-  )
+  );
 }
 ```
 
 ---
 
-## 9. Use Auth State in Components
+## 5. Reading claims and roles
 
-```tsx
-// src/routes/dashboard.tsx
-import { useAuth } from '../auth/AuthContext'
-
-export default function DashboardPage() {
-  const { user, logout, getAccessToken } = useAuth()
-
-  async function fetchProtectedData() {
-    const token = getAccessToken()
-    const res = await fetch('/api/whatever', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    return res.json()
-  }
-
-  return (
-    <div>
-      <h1>Welcome, {user?.profile.name}</h1>
-      <p>Email: {user?.profile.email}</p>
-      <button onClick={logout}>Sign out</button>
-    </div>
-  )
-}
-```
-
-**Getting token claims:** The `user.profile` object contains the OIDC claims from Kotauth's userinfo endpoint — `sub`, `email`, `email_verified`, `name`, `preferred_username`. The `user.access_token` is a JWT you can send to your backend APIs.
-
-**Role-based UI:** Roles and groups from Kotauth appear in the JWT under `realm_access.roles`. You can read them from the decoded token, but for UI decisions it's cleaner to get them from the userinfo profile:
+Inside route components, prefer `useAuth()` from `react-oidc-context` (the foundation guide covers this). For role-based UI:
 
 ```ts
-// oidc-client-ts includes all claims Kotauth returns in user.profile
-const roles: string[] = (user?.profile as any)?.realm_access?.roles ?? []
-const isAdmin = roles.includes('admin')
+const auth = useAuth();
+const roles: string[] = (auth.user?.profile as any)?.realm_access?.roles ?? [];
+const isAdmin = roles.includes("admin");
 ```
+
+The `realm_access.roles` claim is populated automatically when the user has any role assignments in the workspace. Custom claim mappers can add tenant- or app-scoped role arrays.
 
 ---
 
-## 10. Calling Kotauth's API from Your Backend
+## 6. Validating tokens on your backend
 
-Your backend (or BFF) can validate access tokens using Kotauth's JWKS endpoint or introspection endpoint.
+Backends validate access tokens with Kotauth's JWKS or introspection endpoint:
 
-**JWKS (recommended for stateless validation):**
-
-```
-GET http://localhost:8080/t/my-app/protocol/openid-connect/certs
-```
-
-Use any JWT library that supports JWKS to verify the `RS256` signature. The `iss` claim will be `http://localhost:8080/t/my-app`.
-
-**Introspection (for opaque token checking or forced revocation awareness):**
+**JWKS** — recommended for stateless validation:
 
 ```
-POST http://localhost:8080/t/my-app/protocol/openid-connect/introspect
+GET http://localhost:8080/t/<workspace>/protocol/openid-connect/certs
+```
+
+Any JWT library with JWKS support verifies the RS256 signature. The `iss` claim equals `${KAUTH_BASE_URL}/t/<workspace>`.
+
+**Introspection** — for revocation awareness:
+
+```
+POST http://localhost:8080/t/<workspace>/protocol/openid-connect/introspect
 Content-Type: application/x-www-form-urlencoded
 
 token=<access_token>&client_id=<backend_client_id>&client_secret=<backend_secret>
@@ -437,8 +261,8 @@ Kotauth's OIDC endpoints include CORS headers. If you're seeing CORS errors, che
 
 ---
 
-## What's Next
+## Where next
 
-- [Environment Variable Reference](../ENV_REFERENCE.md)
-- [REST API Reference](http://localhost:8080/t/my-app/api/v1/docs) — Swagger UI
-- Webhook setup — receive real-time events (`user.created`, `login.success`, etc.) in your backend
+- [Browser-direct SPA foundation](react-spa-direct.md) — the OIDC config and `<AuthProvider>` this guide builds on
+- [BFF pattern](react-bff-pattern.md) — production-grade alternative where tokens never reach the browser
+- [Environment variable reference](../ENV_REFERENCE.md)

--- a/docs/guides/react-spa-tanstack-router.md
+++ b/docs/guides/react-spa-tanstack-router.md
@@ -405,7 +405,7 @@ token=<access_token>&client_id=<backend_client_id>&client_secret=<backend_secret
 
 ---
 
-## Silent SSO across apps (v1.8.1+)
+## Silent SSO across apps
 
 Kotauth honors the OIDC `prompt`, `max_age`, and `id_token_hint` parameters on `/authorize`. After the user signs into one client on your tenant, every subsequent `/authorize` against the same `/t/{slug}` path silent-auths via a server-side witness cookie — **no UI shown, no extra round-trip visible to the user**.
 
@@ -414,10 +414,10 @@ Kotauth honors the OIDC `prompt`, `max_age`, and `id_token_hint` parameters on `
 For SPA-side use cases:
 
 - **`prompt=login`** — pass `prompt: "login"` to `signinRedirect({ extraQueryParams: { prompt: "login" } })` to force re-auth even if the user has a valid SSO cookie. Useful for "switch account" or "re-authenticate before sensitive action" flows.
-- **`max_age`** — pass `max_age: "300"` to require a credential proof within the last 5 minutes. RPs that gate sensitive operations (admin pages, payment authorization, etc.) typically pair this with the `auth_time` claim verification on the issued ID token (Kotauth populates `auth_time` since v1.8.1; for MFA logins it is the moment the second factor was verified).
+- **`max_age`** — pass `max_age: "300"` to require a credential proof within the last 5 minutes. RPs gating sensitive operations (admin pages, payment authorization, etc.) typically pair this with the `auth_time` claim on the issued ID token. For MFA logins, `auth_time` is the moment the second factor was verified.
 - **`prompt=select_account`** — same effect as `prompt=login` today. Will diverge once Kotauth ships an account picker.
 
-**Logout that actually logs out.** After v1.8.1, hitting `/protocol/openid-connect/logout` clears the silent-SSO cookie too. Your `userManager.signoutRedirect()` call will fully sign the user out — they will see the login form on their next visit, not silent-auth back into the session.
+**Logout that actually logs out.** Hitting `/protocol/openid-connect/logout` clears the silent-SSO cookie. Your `userManager.signoutRedirect()` call will fully sign the user out — they will see the login form on their next visit, not silent-auth back into the session.
 
 ---
 


### PR DESCRIPTION
## Summary

Restructures the README around the first-time-evaluator path, then sweeps every doc the README links into for stale references, AI filler, and cross-file duplication that piled up during the recent docker consolidation (v1.19.2) and React-integration (#95) PRs.

**Net delta across 8 files:** -560 lines, +145 lines. Restructure is real, not just polish.

## Commits

| Commit | What |
|---|---|
| `15869cb` | README 199 → 108 lines. Reordered for evaluator flow: Try → Features → Integrate → Deploy → Under the hood. Dropped the inline env-vars table (duplicated `ENV_REFERENCE.md`), the 18-line architecture tree (duplicated `CLAUDE.md`), the Concepts mapping table. Fixed `Ktor 2` → `Ktor 3.4.2` and stale `1.1.2` image tag → `1.19.2`. |
| `f7d865a` | Correctness fixes: `CONTRIBUTING.md` Flyway migration range V1–V21 → V1–V52; `ROADMAP.md` date 2026-03-21 → 2026-06-23 and version 1.1.0 → 1.19.2; rewrote CONTRIBUTING's "out of scope" list that contradicted ROADMAP phases 6–8; dropped `(v1.8.1+)` version markers from TanStack guide (now baseline). |
| `23fe949` | Strip AI filler from the 4 docs written in the last week. Removed "This guide walks through…" openers, "That's everything the SPA needs" / "That's it" closers, the "Three things to notice:" list whose code beneath repeats every point, the verbose flow narration that follows self-evident code, "Lose it and you lose every encrypted value" dramatic filler, "Three services come up" recap. |
| `9eb92cf` | `ENV_REFERENCE.md` 459 → 428 lines. Dropped the "**Required.** The server refuses to start without it" boilerplate (restates the **Required** tag); removed leaked internal class names (`DemoSeedService`, `EnvironmentConfig.load`, "`FATAL` banner"); collapsed multi-paragraph descriptions for self-documenting vars (`DB_POOL_MIN_IDLE`, `KAUTH_SECRET_KEY`, `KAUTH_TRUSTED_PROXY`). Same information, fewer words. |
| `d36e2b5` | Cross-file dedup. **TanStack guide gutted 444 → 268 lines** — sections 1-4 (OIDC config, AuthContext, useAuth boilerplate) now live canonically in `react-spa-direct.md`; TanStack file covers only what it adds (`/auth/callback` route, `beforeLoad` guard, router wiring, root layout, claim reading, backend JWKS/introspection). Shortened the "when to use" comparisons in both React guides — each side keeps a 3-line decision and links to the other. Trimmed CONTRIBUTING.md's architecture and Project Structure sections to a pointer at CLAUDE.md and a 5-step "adding a feature" list; replaced the Makefile target table with one line ("`make help` for the full list"). Deduped demo-mode between `quickstart.md` (canonical credentials table) and `production.md` (deployment-specific cron only). |

## Files touched

| File | Before | After | Delta |
|---|---|---|---|
| `README.md` | 199 | 108 | -91 |
| `CONTRIBUTING.md` | 252 | 197 | -55 |
| `docs/ROADMAP.md` | (unchanged size) | | metadata refresh |
| `docs/ENV_REFERENCE.md` | 459 | 428 | -31 |
| `docs/deploy/quickstart.md` | 68 | 60 | -8 |
| `docs/deploy/production.md` | 246 | 239 | -7 |
| `docs/guides/react-spa-direct.md` | 273 | 267 | -6 |
| `docs/guides/react-bff-pattern.md` | 459 | 455 | -4 |
| `docs/guides/react-spa-tanstack-router.md` | 444 | 268 | **-176** |

## Verification

- [x] All internal markdown links resolve to real files / anchors (audit script in commit history)
- [x] `docs/adr/ADR-13-oidc-sso-witness-cookie.md` link from TanStack guide still valid
- [x] `quickstart.md#demo-credentials` anchor referenced from `production.md` still exists
- [x] CONTRIBUTING.md links to `CLAUDE.md` and `docs/adr/` (where the trimmed content now canonically lives) all resolve
- [x] Visual review on GitHub-rendered version (PR preview)

## Method

Findings were generated by four parallel Explore agents — one per logical cluster of docs — each prompted to look for AI-sloppy filler, redundancy across files, and outdated references. The agents returned ~75 findings; each cluster was triaged before edits. Specific findings sourced from real patterns (Oriana SPA, Zion BFF) for the React guides, and from grep-verified cross-references for the staleness fixes.