### PR TITLE
Persist email OTP resource indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.20.2] - 2026-07-11
+
+Completes RFC 8707 resource-indicator support for the Email OTP back-channel flow so access tokens can target an API audience without changing the ID token audience.
+
+### Added
+
+- `POST /api/v1/auth/send-otp` accepts optional `resources` and persists the normalized indicators with the OTP challenge.
+- Successful OTP verification validates that every requested resource is enabled and authorized for the originating client, then binds the resources to the single-use authorization code.
+- Email OTP resource-indicator usage is documented in the operator guide and OpenAPI schema.
+
+### Changed
+
+- `EmailOtpService` now requires `ResourceServerRepository` composition and resolves requested resources in one tenant-scoped batch.
+
+### Migrations
+
+- `V56__email_otp_challenge_resources.sql` — adds the non-null JSONB `resources` column to `email_otp_challenges` with an empty-list default.
+
+---
+
 ## [1.20.1] - 2026-07-10
 
 Polish release for v1.20.0 Passkeys — consolidates the two overlapping "disable password sign-in" flags into one canonical column, replaces the split "Authentication Methods" and "Passkeys" cards with a single Sign-in Methods grid, restructures the admin Security rail to actually hold security pages, and nests MFA, Passkeys, and Sessions under a Security parent group in the portal nav.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.20.1"
+version = "1.20.2"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/guides/email-otp.md
+++ b/docs/guides/email-otp.md
@@ -1,0 +1,36 @@
+# Email OTP for backend clients
+
+Kotauth's Email OTP API lets a trusted backend start and verify a passwordless
+email challenge. The backend authenticates with API keys scoped for
+`auth:send-otp` and `auth:verify-otp`; browser clients should call the backend,
+not Kotauth's API directly.
+
+## Requesting an API audience
+
+`POST /t/{tenantSlug}/api/v1/auth/send-otp` accepts an optional `resources`
+array alongside the email address and originating OAuth client:
+
+```json
+{
+  "email": "applicant@example.com",
+  "originatingClientId": "onboarding-bff",
+  "resources": ["https://api.example.com/onboarding"]
+}
+```
+
+Each value is an RFC 8707 resource indicator. Kotauth normalizes and stores the
+list with the OTP challenge so `/auth/verify-otp` can bind it to the resulting
+single-use authorization code. When the backend exchanges that code at the
+token endpoint, the access token's `aud` targets the requested resource while
+the ID token remains bound to `originatingClientId`.
+
+Every requested resource must be enabled in the same workspace and authorized
+for `originatingClientId`. Verification returns `invalid_client` and does not
+issue an authorization code if any resource is unknown, disabled, or not
+authorized for that client.
+
+Omit `resources` to retain the legacy Email OTP behavior. The field defaults to
+an empty list, so existing integrations remain compatible.
+
+See [ADR-15](../adr/ADR-15-email-otp-passwordless-primitive.md) for the Email
+OTP security model and challenge lifecycle.

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresEmailOtpChallengeRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresEmailOtpChallengeRepository.kt
@@ -4,6 +4,8 @@ import com.kauth.domain.model.EmailOtpChallenge
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.EmailOtpChallengeRepository
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
 import org.jetbrains.exposed.v1.jdbc.*
@@ -19,6 +21,7 @@ object EmailOtpChallengesTable : Table("email_otp_challenges") {
     val challengeId = varchar("challenge_id", 64)
     val codeHash = varchar("code_hash", 64)
     val originatingClientId = varchar("originating_client_id", 255).nullable()
+    val resources = jsonb("resources").default("[]")
     val attemptCount = integer("attempt_count").default(0)
     val resendCount = integer("resend_count").default(0)
     val expiresAt = timestampWithTimeZone("expires_at")
@@ -38,6 +41,7 @@ class PostgresEmailOtpChallengeRepository : EmailOtpChallengeRepository {
                     it[challengeId] = challenge.challengeId
                     it[codeHash] = challenge.codeHash
                     it[originatingClientId] = challenge.originatingClientId
+                    it[resources] = Json.encodeToString(challenge.resources)
                     it[attemptCount] = challenge.attemptCount
                     it[resendCount] = challenge.resendCount
                     it[expiresAt] = challenge.expiresAt.toOffsetDateTime()
@@ -100,6 +104,7 @@ class PostgresEmailOtpChallengeRepository : EmailOtpChallengeRepository {
             challengeId = this[EmailOtpChallengesTable.challengeId],
             codeHash = this[EmailOtpChallengesTable.codeHash],
             originatingClientId = this[EmailOtpChallengesTable.originatingClientId],
+            resources = Json.decodeFromString(this[EmailOtpChallengesTable.resources].ifBlank { "[]" }),
             attemptCount = this[EmailOtpChallengesTable.attemptCount],
             resendCount = this[EmailOtpChallengesTable.resendCount],
             expiresAt = this[EmailOtpChallengesTable.expiresAt].toInstant(),

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresEmailOtpChallengeRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresEmailOtpChallengeRepository.kt
@@ -104,7 +104,7 @@ class PostgresEmailOtpChallengeRepository : EmailOtpChallengeRepository {
             challengeId = this[EmailOtpChallengesTable.challengeId],
             codeHash = this[EmailOtpChallengesTable.codeHash],
             originatingClientId = this[EmailOtpChallengesTable.originatingClientId],
-            resources = Json.decodeFromString(this[EmailOtpChallengesTable.resources].ifBlank { "[]" }),
+            resources = Json.decodeFromString(this[EmailOtpChallengesTable.resources]),
             attemptCount = this[EmailOtpChallengesTable.attemptCount],
             resendCount = this[EmailOtpChallengesTable.resendCount],
             expiresAt = this[EmailOtpChallengesTable.expiresAt].toInstant(),

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresResourceServerRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresResourceServerRepository.kt
@@ -49,6 +49,22 @@ class PostgresResourceServerRepository : ResourceServerRepository {
                 ?.toResourceServer()
         }
 
+    override fun findByIdentifiers(
+        tenantId: TenantId,
+        identifiers: Set<String>,
+    ): List<ResourceServer> {
+        if (identifiers.isEmpty()) return emptyList()
+        return transaction {
+            ResourceServersTable
+                .selectAll()
+                .where {
+                    (ResourceServersTable.tenantId eq tenantId.value) and
+                        (ResourceServersTable.identifier inList identifiers)
+                }.orderBy(ResourceServersTable.id)
+                .map { it.toResourceServer() }
+        }
+    }
+
     override fun create(
         tenantId: TenantId,
         identifier: String,

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiOtpRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiOtpRoutes.kt
@@ -64,6 +64,7 @@ internal fun Route.apiOtpRoutes(
                             tenantSlug = tenantSlug,
                             email = normalizedEmail,
                             originatingClientId = body.originatingClientId,
+                            resources = body.resources,
                             ipAddress = ip,
                         )
                 ) {
@@ -147,6 +148,7 @@ private suspend fun ApplicationCall.respondOtpError(error: OtpError) {
 data class SendOtpRequest(
     val email: String,
     val originatingClientId: String? = null,
+    val resources: List<String> = emptyList(),
 )
 
 @Serializable

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -366,6 +366,7 @@ data class ServiceGraph(
                     authorizationCodeRepository = authCodeRepository,
                     emailPort = emailAdapter,
                     auditLog = auditLogAdapter,
+                    resourceServerRepository = resourceServerRepository,
                     roleRepository = roleRepository,
                 )
             val apiKeyBootstrapService =

--- a/src/main/kotlin/com/kauth/domain/model/EmailOtpChallenge.kt
+++ b/src/main/kotlin/com/kauth/domain/model/EmailOtpChallenge.kt
@@ -14,6 +14,7 @@ data class EmailOtpChallenge(
     val challengeId: String,
     val codeHash: String,
     val originatingClientId: String? = null,
+    val resources: List<String> = emptyList(),
     val attemptCount: Int = 0,
     val resendCount: Int = 0,
     val expiresAt: Instant,

--- a/src/main/kotlin/com/kauth/domain/port/ResourceServerRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/ResourceServerRepository.kt
@@ -18,6 +18,11 @@ interface ResourceServerRepository {
         identifier: String,
     ): ResourceServer?
 
+    fun findByIdentifiers(
+        tenantId: TenantId,
+        identifiers: Set<String>,
+    ): List<ResourceServer>
+
     fun create(
         tenantId: TenantId,
         identifier: String,

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -1,5 +1,6 @@
 package com.kauth.domain.service
 
+import com.kauth.domain.model.ApplicationId
 import com.kauth.domain.model.AuditEvent
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.AuthorizationCode
@@ -14,6 +15,7 @@ import com.kauth.domain.port.AuditLogPort
 import com.kauth.domain.port.AuthorizationCodeRepository
 import com.kauth.domain.port.EmailOtpChallengeRepository
 import com.kauth.domain.port.EmailPort
+import com.kauth.domain.port.ResourceServerRepository
 import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
@@ -47,6 +49,7 @@ class EmailOtpService(
     private val authorizationCodeRepository: AuthorizationCodeRepository,
     private val emailPort: EmailPort,
     private val auditLog: AuditLogPort,
+    private val resourceServerRepository: ResourceServerRepository? = null,
     private val roleRepository: RoleRepository? = null,
     private val clock: Clock = Clock.systemUTC(),
 ) {
@@ -63,6 +66,7 @@ class EmailOtpService(
         tenantSlug: String,
         email: String,
         originatingClientId: String? = null,
+        resources: List<String> = emptyList(),
         ipAddress: String? = null,
     ): OtpSendResult {
         val tenant =
@@ -106,6 +110,7 @@ class EmailOtpService(
                     challengeId = generateChallengeHandle(),
                     codeHash = sha256Hex(rawCode),
                     originatingClientId = originatingClientId,
+                    resources = resources.normalizedResources(),
                     resendCount = if (invalidated > 0) 1 else 0,
                     expiresAt = expiresAt,
                     createdAt = now,
@@ -144,6 +149,7 @@ class EmailOtpService(
                     mapOf(
                         "resend_count" to challenge.resendCount.toString(),
                         "originating_client_id" to (originatingClientId ?: ""),
+                        "resources" to challenge.resources.joinToString(","),
                     ),
             ),
         )
@@ -212,7 +218,7 @@ class EmailOtpService(
         )
 
         val authCode =
-            issueAuthorizationCodeFor(tenant, user.id, challenge.originatingClientId)
+            issueAuthorizationCodeFor(tenant, user.id, challenge)
                 ?: return reject(tenant.id, user.id, null, OtpError.InvalidClient, ipAddress)
 
         auditLog.record(
@@ -282,12 +288,14 @@ class EmailOtpService(
     private fun issueAuthorizationCodeFor(
         tenant: Tenant,
         userId: UserId,
-        clientIdString: String?,
+        challenge: EmailOtpChallenge,
     ): AuthorizationCode? {
+        val clientIdString = challenge.originatingClientId
         if (clientIdString.isNullOrBlank()) return null
         val client = applicationRepository.findByClientId(tenant.id, clientIdString) ?: return null
         if (!client.enabled) return null
         val redirectUri = client.redirectUris.firstOrNull() ?: return null
+        val resources = challengeResourcesFor(tenant, client.id, challenge.resources) ?: return null
 
         val now = clock.instant()
         return authorizationCodeRepository.save(
@@ -301,9 +309,30 @@ class EmailOtpService(
                 expiresAt = now.plusSeconds(AUTH_CODE_TTL_SECONDS),
                 createdAt = now,
                 authTime = now,
+                resources = resources,
             ),
         )
     }
+
+    private fun challengeResourcesFor(
+        tenant: Tenant,
+        clientPk: ApplicationId,
+        requestedResources: List<String>,
+    ): List<String>? {
+        val challengeResources = requestedResources.normalizedResources()
+        if (challengeResources.isEmpty()) return emptyList()
+        val repo = resourceServerRepository ?: return null
+        val authorized = repo.listAuthorizedFor(clientPk).map { it.identifier }.toSet()
+        return challengeResources.takeIf {
+            it.all { identifier ->
+                val resource = repo.findByIdentifier(tenant.id, identifier)
+                resource != null && resource.enabled && identifier in authorized
+            }
+        }
+    }
+
+    private fun List<String>.normalizedResources(): List<String> =
+        map { it.trim() }.filter { it.isNotBlank() }.distinct()
 
     private fun reject(
         tenantId: TenantId,

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -20,6 +20,8 @@ import com.kauth.domain.port.RoleRepository
 import com.kauth.domain.port.TenantRepository
 import com.kauth.domain.port.UserRepository
 import com.kauth.domain.util.sha256Hex
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -49,7 +51,7 @@ class EmailOtpService(
     private val authorizationCodeRepository: AuthorizationCodeRepository,
     private val emailPort: EmailPort,
     private val auditLog: AuditLogPort,
-    private val resourceServerRepository: ResourceServerRepository? = null,
+    private val resourceServerRepository: ResourceServerRepository,
     private val roleRepository: RoleRepository? = null,
     private val clock: Clock = Clock.systemUTC(),
 ) {
@@ -149,7 +151,7 @@ class EmailOtpService(
                     mapOf(
                         "resend_count" to challenge.resendCount.toString(),
                         "originating_client_id" to (originatingClientId ?: ""),
-                        "resources" to challenge.resources.joinToString(","),
+                        "resources" to Json.encodeToString(challenge.resources),
                     ),
             ),
         )
@@ -321,11 +323,14 @@ class EmailOtpService(
     ): List<String>? {
         val challengeResources = requestedResources.normalizedResources()
         if (challengeResources.isEmpty()) return emptyList()
-        val repo = resourceServerRepository ?: return null
-        val authorized = repo.listAuthorizedFor(clientPk).map { it.identifier }.toSet()
+        val authorized = resourceServerRepository.listAuthorizedFor(clientPk).map { it.identifier }.toSet()
+        val resourcesByIdentifier =
+            resourceServerRepository
+                .findByIdentifiers(tenant.id, challengeResources.toSet())
+                .associateBy { it.identifier }
         return challengeResources.takeIf {
             it.all { identifier ->
-                val resource = repo.findByIdentifier(tenant.id, identifier)
+                val resource = resourcesByIdentifier[identifier]
                 resource != null && resource.enabled && identifier in authorized
             }
         }

--- a/src/main/resources/db/migration/V54__email_otp_challenge_resources.sql
+++ b/src/main/resources/db/migration/V54__email_otp_challenge_resources.sql
@@ -1,0 +1,9 @@
+-- V54: Bind RFC 8707 resource indicators to email-OTP challenges.
+--
+-- Email OTP is a back-channel authorization-code issuer. Store the resources
+-- requested by the originating client when the code is sent, then copy them to
+-- the authorization code after OTP verification so /token can mint an
+-- audience-targeted access token while keeping id_token.aud on the OAuth client.
+
+ALTER TABLE email_otp_challenges
+    ADD COLUMN resources JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/src/main/resources/db/migration/V56__email_otp_challenge_resources.sql
+++ b/src/main/resources/db/migration/V56__email_otp_challenge_resources.sql
@@ -1,4 +1,4 @@
--- V54: Bind RFC 8707 resource indicators to email-OTP challenges.
+-- V56: Bind RFC 8707 resource indicators to email-OTP challenges.
 --
 -- Email OTP is a back-channel authorization-code issuer. Store the resources
 -- requested by the originating client when the code is sent, then copy them to

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -322,6 +322,16 @@ components:
             OAuth client_id that triggered the send. Required at verify-otp
             time to bind the authorization code to a registered client. The
             client must have at least one redirect URI configured.
+        resources:
+          type: array
+          uniqueItems: true
+          default: []
+          items:
+            type: string
+          description: |
+            Optional RFC 8707 resource indicators to bind to the challenge and
+            resulting authorization code. Each resource must be enabled in the
+            workspace and authorized for originatingClientId.
 
     SendOtpResponse:
       type: object
@@ -1148,6 +1158,11 @@ paths:
         `originatingClientId` is required for the verify-otp authorization-code
         issuance to bind the resulting code to a confidential client. The
         client must have at least one redirect URI registered.
+
+        Optional RFC 8707 `resources` are persisted with the challenge. On
+        successful verification, every resource must be enabled and authorized
+        for `originatingClientId`; the resulting authorization code carries the
+        resource indicators into the token exchange.
       tags: [Auth — Email OTP]
       security: [{ bearerAuth: [auth:send-otp] }]
       requestBody:

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -17,6 +17,7 @@ import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
 import com.kauth.fakes.FakeEmailOtpChallengeRepository
 import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeResourceServerRepository
 import com.kauth.fakes.FakeRoleRepository
 import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeUserRepository
@@ -49,6 +50,7 @@ class ApiOtpRoutesTest {
     private val roles = FakeRoleRepository()
     private val email = FakeEmailPort()
     private val audit = FakeAuditLogPort()
+    private val resources = FakeResourceServerRepository()
     private val apiKeys = FakeApiKeyRepository()
 
     private val apiKeyService = ApiKeyService(apiKeys, tenants)
@@ -61,6 +63,7 @@ class ApiOtpRoutesTest {
             authorizationCodeRepository = authCodes,
             emailPort = email,
             auditLog = audit,
+            resourceServerRepository = resources,
             roleRepository = roles,
         )
 
@@ -77,6 +80,7 @@ class ApiOtpRoutesTest {
         roles.clear()
         email.clear()
         audit.clear()
+        resources.clear()
         apiKeys.clear()
 
         val tenant =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -83,8 +83,8 @@ class ApiOtpRoutesTest {
             tenants.add(
                 Tenant(
                     id = TenantId(0),
-                    slug = "zion",
-                    displayName = "Zion",
+                    slug = "acme",
+                    displayName = "Acme",
                     issuerUrl = null,
                     securityConfig = SecurityConfig(emailOtpSignupEnabled = true),
                 ),
@@ -93,12 +93,12 @@ class ApiOtpRoutesTest {
             Application(
                 id = ApplicationId(0),
                 tenantId = tenant.id,
-                clientId = "zion-bff",
-                name = "Zion BFF",
+                clientId = "acme-bff",
+                name = "Acme BFF",
                 description = null,
                 accessType = AccessType.CONFIDENTIAL,
                 enabled = true,
-                redirectUris = listOf("https://bff.zion.test/auth/callback"),
+                redirectUris = listOf("https://bff.acme.test/auth/callback"),
             ),
         )
 
@@ -115,14 +115,17 @@ class ApiOtpRoutesTest {
         testApplication {
             application { installApp(AlwaysAllowLimiter(), AlwaysAllowLimiter()) }
             val response =
-                client.post("/t/zion/api/v1/auth/send-otp") {
+                client.post("/t/acme/api/v1/auth/send-otp") {
                     bearerAuth(sendKey)
                     contentType(ContentType.Application.Json)
-                    setBody("""{"email":"applicant@zion.test","originatingClientId":"zion-bff"}""")
+                    setBody(
+                        """{"email":"alice@acme.test","originatingClientId":"acme-bff","resources":["orders-api"]}""",
+                    )
                 }
             assertEquals(HttpStatusCode.Accepted, response.status)
             assertTrue(""""challengeId"""" in response.bodyAsText())
             assertEquals(1, email.otps.size)
+            assertEquals(listOf("orders-api"), challenges.all().single().resources)
         }
 
     @Test
@@ -138,7 +141,7 @@ class ApiOtpRoutesTest {
                     ) as ApiKeyResult.Success
                 ).value.rawKey
             val response =
-                client.post("/t/zion/api/v1/auth/send-otp") {
+                client.post("/t/acme/api/v1/auth/send-otp") {
                     bearerAuth(unscoped)
                     contentType(ContentType.Application.Json)
                     setBody("""{"email":"x@y.test"}""")
@@ -162,10 +165,10 @@ class ApiOtpRoutesTest {
                 }
             application { installApp(blocker, AlwaysAllowLimiter()) }
             val response =
-                client.post("/t/zion/api/v1/auth/send-otp") {
+                client.post("/t/acme/api/v1/auth/send-otp") {
                     bearerAuth(sendKey)
                     contentType(ContentType.Application.Json)
-                    setBody("""{"email":"applicant@zion.test"}""")
+                    setBody("""{"email":"alice@acme.test"}""")
                 }
             assertEquals(HttpStatusCode.TooManyRequests, response.status)
         }
@@ -174,16 +177,16 @@ class ApiOtpRoutesTest {
     fun `verify-otp returns 200 with an authorization code on the happy path`() =
         testApplication {
             application { installApp(AlwaysAllowLimiter(), AlwaysAllowLimiter()) }
-            client.post("/t/zion/api/v1/auth/send-otp") {
+            client.post("/t/acme/api/v1/auth/send-otp") {
                 bearerAuth(sendKey)
                 contentType(ContentType.Application.Json)
-                setBody("""{"email":"applicant@zion.test","originatingClientId":"zion-bff"}""")
+                setBody("""{"email":"alice@acme.test","originatingClientId":"acme-bff"}""")
             }
             val sent = email.otps.single()
             val challengeId = challenges.all().single().challengeId
 
             val verify =
-                client.post("/t/zion/api/v1/auth/verify-otp") {
+                client.post("/t/acme/api/v1/auth/verify-otp") {
                     bearerAuth(verifyKey)
                     contentType(ContentType.Application.Json)
                     setBody("""{"challengeId":"$challengeId","otp":"${sent.code}"}""")
@@ -197,13 +200,13 @@ class ApiOtpRoutesTest {
         testApplication {
             application { installApp(AlwaysAllowLimiter(), AlwaysAllowLimiter()) }
             // Create a challenge that's already past expiry.
-            val tenant = tenants.findBySlug("zion")!!
+            val tenant = tenants.findBySlug("acme")!!
             val user =
                 users.add(
                     com.kauth.domain.model.User(
                         tenantId = tenant.id,
                         username = "ghost",
-                        email = "ghost@zion.test",
+                        email = "ghost@acme.test",
                         fullName = "Ghost",
                         passwordHash = "x",
                     ),
@@ -224,7 +227,7 @@ class ApiOtpRoutesTest {
             )
 
             val verify =
-                client.post("/t/zion/api/v1/auth/verify-otp") {
+                client.post("/t/acme/api/v1/auth/verify-otp") {
                     bearerAuth(verifyKey)
                     contentType(ContentType.Application.Json)
                     setBody("""{"challengeId":"expired-handle","otp":"123456"}""")
@@ -236,15 +239,15 @@ class ApiOtpRoutesTest {
     fun `verify-otp returns 422 invalid_otp on wrong code`() =
         testApplication {
             application { installApp(AlwaysAllowLimiter(), AlwaysAllowLimiter()) }
-            client.post("/t/zion/api/v1/auth/send-otp") {
+            client.post("/t/acme/api/v1/auth/send-otp") {
                 bearerAuth(sendKey)
                 contentType(ContentType.Application.Json)
-                setBody("""{"email":"applicant@zion.test","originatingClientId":"zion-bff"}""")
+                setBody("""{"email":"alice@acme.test","originatingClientId":"acme-bff"}""")
             }
             val challengeId = challenges.all().single().challengeId
 
             val verify =
-                client.post("/t/zion/api/v1/auth/verify-otp") {
+                client.post("/t/acme/api/v1/auth/verify-otp") {
                     bearerAuth(verifyKey)
                     contentType(ContentType.Application.Json)
                     setBody("""{"challengeId":"$challengeId","otp":"999999"}""")
@@ -293,7 +296,7 @@ class ApiOtpRoutesTest {
             )
 
             val verify =
-                client.post("/t/zion/api/v1/auth/verify-otp") {
+                client.post("/t/acme/api/v1/auth/verify-otp") {
                     bearerAuth(verifyKey)
                     contentType(ContentType.Application.Json)
                     setBody("""{"challengeId":"alien-handle","otp":"123456"}""")

--- a/src/test/kotlin/com/kauth/adapter/web/api/OtpTestStubs.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/OtpTestStubs.kt
@@ -7,6 +7,7 @@ import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
 import com.kauth.fakes.FakeEmailOtpChallengeRepository
 import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeResourceServerRepository
 import com.kauth.fakes.FakeRoleRepository
 import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeUserRepository
@@ -21,6 +22,7 @@ internal fun stubEmailOtpService(): EmailOtpService =
         authorizationCodeRepository = FakeAuthorizationCodeRepository(),
         emailPort = FakeEmailPort(),
         auditLog = FakeAuditLogPort(),
+        resourceServerRepository = FakeResourceServerRepository(),
         roleRepository = FakeRoleRepository(),
     )
 

--- a/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
@@ -22,6 +22,7 @@ import com.kauth.fakes.FakeEmailVerificationTokenRepository
 import com.kauth.fakes.FakePasswordHasher
 import com.kauth.fakes.FakePasswordPolicyPort
 import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeResourceServerRepository
 import com.kauth.fakes.FakeRoleRepository
 import com.kauth.fakes.FakeSessionRepository
 import com.kauth.fakes.FakeTenantRepository
@@ -56,6 +57,7 @@ class EmailOtpLoginRoutesTest {
     private val authCodes = FakeAuthorizationCodeRepository()
     private val sessions = FakeSessionRepository()
     private val roles = FakeRoleRepository()
+    private val resources = FakeResourceServerRepository()
     private val hasher = FakePasswordHasher()
     private val auditLog = FakeAuditLogPort()
     private val emails = FakeEmailPort()
@@ -109,6 +111,7 @@ class EmailOtpLoginRoutesTest {
             authorizationCodeRepository = authCodes,
             emailPort = emails,
             auditLog = auditLog,
+            resourceServerRepository = resources,
             roleRepository = roles,
         )
 
@@ -157,6 +160,7 @@ class EmailOtpLoginRoutesTest {
         authCodes.clear()
         sessions.clear()
         roles.clear()
+        resources.clear()
         prTokens.clear()
         evTokens.clear()
         emails.clear()

--- a/src/test/kotlin/com/kauth/domain/port/ResourceServerRepositoryContractTest.kt
+++ b/src/test/kotlin/com/kauth/domain/port/ResourceServerRepositoryContractTest.kt
@@ -19,20 +19,13 @@ class ResourceServerRepositoryContractTest {
     private val clientInA = ApplicationId(100)
     private val clientInB = ApplicationId(200)
 
-    private val tenantLookup: (ApplicationId) -> TenantId? =
-        { id ->
-            when (id) {
-                clientInA -> tenantA
-                clientInB -> tenantB
-                else -> null
-            }
-        }
-
-    private val repo = FakeResourceServerRepository(clientTenantLookup = tenantLookup)
+    private val repo = FakeResourceServerRepository()
 
     @BeforeTest
     fun setup() {
         repo.clear()
+        repo.registerClient(clientInA, tenantA)
+        repo.registerClient(clientInB, tenantB)
     }
 
     @Test
@@ -58,6 +51,17 @@ class ResourceServerRepositoryContractTest {
         assertEquals(tenantB, fromB.tenantId)
         assertEquals("Payment API", fromA.name)
         assertEquals("Other Payment API", fromB.name)
+    }
+
+    @Test
+    fun `findByIdentifiers resolves a tenant-scoped batch`() {
+        repo.create(tenantA, "payment-api", "Payment API", null)
+        repo.create(tenantA, "ledger-api", "Ledger API", null)
+        repo.create(tenantB, "payment-api", "Other Payment API", null)
+
+        val found = repo.findByIdentifiers(tenantA, setOf("payment-api", "ledger-api", "missing"))
+
+        assertEquals(listOf("payment-api", "ledger-api"), found.map { it.identifier })
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
@@ -4,6 +4,7 @@ import com.kauth.domain.model.AccessType
 import com.kauth.domain.model.Application
 import com.kauth.domain.model.ApplicationId
 import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.ResourceServer
 import com.kauth.domain.model.Role
 import com.kauth.domain.model.SecurityConfig
 import com.kauth.domain.model.Tenant
@@ -15,6 +16,7 @@ import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
 import com.kauth.fakes.FakeEmailOtpChallengeRepository
 import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeResourceServerRepository
 import com.kauth.fakes.FakeRoleRepository
 import com.kauth.fakes.FakeTenantRepository
 import com.kauth.fakes.FakeUserRepository
@@ -36,6 +38,10 @@ class EmailOtpServiceTest {
     private val challenges = FakeEmailOtpChallengeRepository()
     private val apps = FakeApplicationRepository()
     private val authCodes = FakeAuthorizationCodeRepository()
+    private val resources =
+        FakeResourceServerRepository { appId ->
+            apps.findById(appId)?.tenantId
+        }
     private val roles = FakeRoleRepository()
     private val email = FakeEmailPort()
     private val audit = FakeAuditLogPort()
@@ -54,6 +60,7 @@ class EmailOtpServiceTest {
             authorizationCodeRepository = authCodes,
             emailPort = email,
             auditLog = audit,
+            resourceServerRepository = resources,
             roleRepository = roles,
             clock = fixedClock,
         )
@@ -65,6 +72,7 @@ class EmailOtpServiceTest {
         challenges.clear()
         apps.clear()
         authCodes.clear()
+        resources.clear()
         roles.clear()
         email.clear()
         audit.clear()
@@ -116,6 +124,31 @@ class EmailOtpServiceTest {
         assertEquals(sha256Hex(sentCode), saved.codeHash)
         assertEquals(clientApp.clientId, saved.originatingClientId)
         assertEquals(AuditEventType.EMAIL_OTP_SENT, audit.events.single().eventType)
+    }
+
+    @Test
+    fun `sendOtp stores normalized requested resources`() {
+        users.add(
+            User(
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.test",
+                fullName = "Alice",
+                passwordHash = "x",
+            ),
+        )
+
+        val result =
+            newService().sendOtp(
+                tenant.slug,
+                "alice@acme.test",
+                clientApp.clientId,
+                resources = listOf(" orders-api ", "", "orders-api"),
+            )
+
+        assertTrue(result is OtpSendResult.Success)
+        val saved = challenges.findByChallengeId(result.challengeId)!!
+        assertEquals(listOf("orders-api"), saved.resources)
     }
 
     @Test
@@ -215,6 +248,7 @@ class EmailOtpServiceTest {
     private fun seedChallenge(
         codeRaw: String = "123456",
         clientId: String? = null,
+        resources: List<String> = emptyList(),
     ): Pair<User, com.kauth.domain.model.EmailOtpChallenge> {
         val user =
             users.add(
@@ -234,6 +268,7 @@ class EmailOtpServiceTest {
                     challengeId = "handle-1",
                     codeHash = sha256Hex(codeRaw),
                     originatingClientId = clientId,
+                    resources = resources,
                     expiresAt = fixedClock.instant().plusSeconds(600),
                 ),
             )
@@ -253,6 +288,39 @@ class EmailOtpServiceTest {
         assertNotNull(consumed.consumedAt)
         assertTrue(users.findByEmail(tenant.id, "alice@acme.test")!!.emailVerified)
         assertEquals(AuditEventType.EMAIL_OTP_VERIFIED, audit.events.last().eventType)
+    }
+
+    @Test
+    fun `verifyOtp copies authorized OTP resources to the issued auth code`() {
+        val resource =
+            resources.seed(
+                ResourceServer(
+                    id = null,
+                    tenantId = tenant.id,
+                    identifier = "orders-api",
+                    name = "Orders API",
+                    description = null,
+                ),
+            )
+        resources.setAuthorizedResources(clientApp.id, listOf(resource.id!!))
+        seedChallenge(clientId = clientApp.clientId, resources = listOf("orders-api"))
+
+        val result = newService().verifyOtp(tenant.slug, "handle-1", "123456")
+
+        assertTrue(result is OtpVerifyResult.Success)
+        val stored = authCodes.findByCode(result.authorizationCode)!!
+        assertEquals(listOf("orders-api"), stored.resources)
+    }
+
+    @Test
+    fun `verifyOtp rejects unauthorized OTP resources`() {
+        seedChallenge(clientId = clientApp.clientId, resources = listOf("orders-api"))
+
+        val result = newService().verifyOtp(tenant.slug, "handle-1", "123456")
+
+        assertTrue(result is OtpVerifyResult.Failure)
+        assertEquals(OtpError.InvalidClient, result.error)
+        assertTrue(authCodes.all().isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
@@ -38,10 +38,7 @@ class EmailOtpServiceTest {
     private val challenges = FakeEmailOtpChallengeRepository()
     private val apps = FakeApplicationRepository()
     private val authCodes = FakeAuthorizationCodeRepository()
-    private val resources =
-        FakeResourceServerRepository { appId ->
-            apps.findById(appId)?.tenantId
-        }
+    private val resources = FakeResourceServerRepository()
     private val roles = FakeRoleRepository()
     private val email = FakeEmailPort()
     private val audit = FakeAuditLogPort()
@@ -100,6 +97,7 @@ class EmailOtpServiceTest {
                     redirectUris = listOf("https://bff.acme.example.com/auth/callback"),
                 ),
             )
+        resources.registerClient(clientApp.id, clientApp.tenantId)
     }
 
     // ----- sendOtp -----
@@ -149,6 +147,7 @@ class EmailOtpServiceTest {
         assertTrue(result is OtpSendResult.Success)
         val saved = challenges.findByChallengeId(result.challengeId)!!
         assertEquals(listOf("orders-api"), saved.resources)
+        assertEquals("[\"orders-api\"]", audit.events.single().details["resources"])
     }
 
     @Test
@@ -370,6 +369,7 @@ class EmailOtpServiceTest {
                 authorizationCodeRepository = authCodes,
                 emailPort = email,
                 auditLog = audit,
+                resourceServerRepository = resources,
                 roleRepository = roles,
                 clock = expiredClock,
             )

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -54,10 +54,7 @@ class OAuthServiceTest {
     private val hasher = FakePasswordHasher()
     private val tokens = FakeTokenPort()
     private val auditLog = FakeAuditLogPort()
-    private val resourceServers =
-        com.kauth.fakes.FakeResourceServerRepository(
-            clientTenantLookup = { id -> apps.findById(id)?.tenantId },
-        )
+    private val resourceServers = com.kauth.fakes.FakeResourceServerRepository()
 
     private val svc =
         OAuthService(
@@ -133,6 +130,8 @@ class OAuthServiceTest {
         users.add(testUser)
         apps.add(publicClient)
         apps.add(confidentialClient, secretHash = hasher.hash("secret123"))
+        resourceServers.registerClient(publicClient.id, publicClient.tenantId)
+        resourceServers.registerClient(confidentialClient.id, confidentialClient.tenantId)
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/fakes/FakeResourceServerRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeResourceServerRepository.kt
@@ -8,17 +8,24 @@ import com.kauth.domain.port.ResourceAuthorizationError
 import com.kauth.domain.port.ResourceServerRepository
 import java.time.Instant
 
-class FakeResourceServerRepository(
-    private val clientTenantLookup: (ApplicationId) -> TenantId? = { null },
-) : ResourceServerRepository {
+class FakeResourceServerRepository : ResourceServerRepository {
     private val byId = mutableMapOf<Int, ResourceServer>()
     private val authorizations = mutableMapOf<Int, MutableSet<Int>>()
+    private val clientTenants = mutableMapOf<Int, TenantId>()
     private var nextId = 1
 
     fun clear() {
         byId.clear()
         authorizations.clear()
+        clientTenants.clear()
         nextId = 1
+    }
+
+    fun registerClient(
+        clientPk: ApplicationId,
+        tenantId: TenantId,
+    ) {
+        clientTenants[clientPk.value] = tenantId
     }
 
     fun seed(rs: ResourceServer): ResourceServer {
@@ -41,6 +48,14 @@ class FakeResourceServerRepository(
         tenantId: TenantId,
         identifier: String,
     ): ResourceServer? = byId.values.firstOrNull { it.tenantId == tenantId && it.identifier == identifier }
+
+    override fun findByIdentifiers(
+        tenantId: TenantId,
+        identifiers: Set<String>,
+    ): List<ResourceServer> =
+        byId.values
+            .filter { it.tenantId == tenantId && it.identifier in identifiers }
+            .sortedBy { it.id!!.value }
 
     override fun create(
         tenantId: TenantId,
@@ -105,8 +120,7 @@ class FakeResourceServerRepository(
         clientPk: ApplicationId,
         resourceServerIds: List<ResourceServerId>,
     ): ResourceAuthorizationError? {
-        val clientTenantId =
-            clientTenantLookup(clientPk) ?: return ResourceAuthorizationError.UnknownClient
+        val clientTenantId = clientTenants[clientPk.value] ?: return ResourceAuthorizationError.UnknownClient
 
         for (rsId in resourceServerIds) {
             val rs = byId[rsId.value] ?: return ResourceAuthorizationError.UnknownResource(rsId)


### PR DESCRIPTION
## Summary

This teaches the email-OTP admin flow to carry RFC 8707 resource indicators through to the authorization code it issues.

The normal `/authorize` flow already supports resource indicators: Kotauth validates the requested resources, stores them on the authorization code, and later uses them so `/token` can mint an access token whose `aud` targets the requested API while the OIDC ID token keeps `aud` on the OAuth client.

The email-OTP flow is a back-channel authorization-code issuer, so it needs the same resource context that `/authorize` already has. Without that context, callers that need an API-specific access-token audience are pushed toward the client-level `audience` field, which conflates access-token targeting with OIDC client identity and can make ID-token audience validation fail.

## Changes

- Adds `resources` to email OTP challenges and persists them in `email_otp_challenges.resources`.
- Lets `/api/v1/auth/send-otp` receive resource indicators from trusted admin callers.
- Normalizes requested resources before storing them.
- Validates requested resources against the originating client's authorized resource servers before issuing an authorization code.
- Copies authorized resources onto the issued authorization code so the token endpoint can mint the correct access-token audience.
- Updates tests with product-generic tenant/client/resource fixtures.
- Covers the happy path, normalization, route input, and unauthorized-resource rejection with tests.

## Impact

Callers can request an API audience for email-OTP login without relying on the client-level `audience` field. That keeps ID tokens audience-bound to the OAuth client while access tokens can target the requested resource server.

This also brings the email-OTP shortcut in line with the existing `/authorize` resource-indicator behavior.

## Validation

- `./gradlew ktlintCheck --no-daemon`
- `./gradlew test --tests com.kauth.domain.service.EmailOtpServiceTest --tests com.kauth.adapter.web.api.ApiOtpRoutesTest --no-daemon`
- `git diff --check`
