### PR TITLE
Configurable sign-in identifier: username, email, or either per workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sign-in identifiers are now trimmed of surrounding whitespace** before
   lookup; previously they were passed through raw. In `Username only` mode
   this means a username pasted with a trailing space, which previously
-  failed, now signs in. This is safe: stored usernames cannot contain
-  leading or trailing whitespace — except a backup-imported account, whose
-  username is restored verbatim — so trimming can only ever resolve the same
-  account the untrimmed value would have, never a different one.
+  failed, now signs in. This is safe because every write path now
+  normalizes (trims and lowercases) before storing, so a stored username can
+  no longer carry leading or trailing whitespace at all — trimming at lookup
+  can only ever resolve the same account the untrimmed value would have,
+  never a different one.
+- **Sign-in now matches usernames case-insensitively.** Usernames are
+  always stored lowercase, and the submitted identifier is lowercased
+  before lookup in `Username only` and `Username or email` modes. A user
+  who was created or previously signed in as `Dave` still signs in with
+  `Dave`, `DAVE`, or `dave`.
 
 ### Security
 
+- **Usernames are always normalized.** Every path that can create or rename
+  a username — admin create, admin rename, self-registration, social login,
+  JIT provisioning, email-OTP sign-up, and backup import — now trims,
+  lowercases, and validates the result against `[a-zA-Z0-9._@+-]+` before
+  writing it, rejecting the write if it doesn't produce a valid value.
+  Self-registration previously ran no username validation at all. A backup
+  record whose username doesn't normalize into something valid is now
+  rejected by name during import instead of being written verbatim.
 - **Username/email collision prevention.** Creating or updating a user whose
   username equals a different user's email address (or vice versa) is now
   rejected — across admin user creation, admin user update, SCIM, and
@@ -62,12 +76,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sign-in on it would lock out invite- and SCIM-provisioned users who never
   completed verification — exactly the users this feature exists to serve.
 
+### Fixed
+
+- **Admin username renames now actually persist against Postgres.**
+  `PostgresUserRepository.update()` never wrote the `username` column, so
+  renaming a user's username from the admin UI or admin API silently had no
+  effect against a real database while the request appeared to succeed.
+
 ### Migrations
 
 - `V65__login_identifier_mode.sql` — adds
   `tenant_security_config.login_identifier_mode`, `NOT NULL DEFAULT
   'USERNAME'`, constrained to `USERNAME` / `EMAIL` / `EITHER`. Additive only:
   every existing workspace keeps its current sign-in behaviour.
+- `V66__normalize_usernames.sql` — rewrites every existing username to its
+  normalized form (lowercased, trimmed, each run of characters outside
+  `[a-z0-9._@+-]` collapsed to a single `.`), then adds a unique index on
+  `(tenant_id, lower(username))` to enforce the rule going forward. **This
+  changes existing users' sign-in identifiers** — a user stored as `"John
+  Doe"` becomes `john.doe` — so operators should tell affected users their
+  new identifier. **The migration aborts the upgrade** if two usernames in
+  one tenant would normalize to the same value (e.g. `Dave` and `dave`);
+  see `docs/guides/sign-in-identifier.md` for a pre-flight query to find and
+  resolve collisions before upgrading.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lookup; previously they were passed through raw. In `Username only` mode
   this means a username pasted with a trailing space, which previously
   failed, now signs in. This is safe: stored usernames cannot contain
-  leading or trailing whitespace, so trimming can only ever resolve the same
+  leading or trailing whitespace — except a backup-imported account, whose
+  username is restored verbatim — so trimming can only ever resolve the same
   account the untrimmed value would have, never a different one.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,14 +91,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every existing workspace keeps its current sign-in behaviour.
 - `V66__normalize_usernames.sql` — rewrites every existing username to its
   normalized form (lowercased, trimmed, each run of characters outside
-  `[a-z0-9._@+-]` collapsed to a single `.`), then adds a unique index on
-  `(tenant_id, lower(username))` to enforce the rule going forward. **This
-  changes existing users' sign-in identifiers** — a user stored as `"John
-  Doe"` becomes `john.doe` — so operators should tell affected users their
-  new identifier. **The migration aborts the upgrade** if two usernames in
-  one tenant would normalize to the same value (e.g. `Dave` and `dave`);
-  see `docs/guides/sign-in-identifier.md` for a pre-flight query to find and
-  resolve collisions before upgrading.
+  `[a-z0-9._@+-]` collapsed to a single `.`, then leading/trailing `.`/`_`/`-`
+  stripped), adds `CHECK (username = lower(username))` so storage being
+  lowercase is enforced by the database and not just application code, and
+  adds a unique index on `(tenant_id, lower(username))` to enforce the rule
+  going forward. **This changes existing users' sign-in identifiers** — a
+  user stored as `"John Doe"` becomes `john.doe` — so operators should tell
+  affected users their new identifier. **The migration aborts the upgrade**
+  if two usernames in one tenant would normalize to the same value (e.g.
+  `Dave` and `dave`), or if any username would normalize to an empty or
+  still-invalid value — most notably a username made entirely of a
+  non-Latin script (e.g. `Иван`, `用户`), which would otherwise silently
+  become `''` and leave that user unable to sign in by username again. See
+  `docs/guides/sign-in-identifier.md` for pre-flight queries to find and
+  resolve both cases before upgrading, and for a rolling-deploy note: once
+  `V66` runs, an old replica still doing a case-exact username comparison
+  will fail to match a user whose stored username was just rewritten, until
+  the last old replica drains.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.24.0] - 2026-09-04
+
+### Added
+
+- **Per-workspace sign-in identifier mode.** The Sign-In Identifier section of
+  the workspace Security Policy page offers three modes: `Username only`
+  (today's behaviour, and the default), `Email only`, and
+  `Username or email`. In the last mode, both namespaces are always checked —
+  never short-circuited, so a miss and a hit cost the same two lookups — and
+  a value that matches one account's username and a *different* account's
+  email is refused rather than guessed, with the same generic failure as any
+  other bad credential. Migration `V65` adds
+  `tenant_security_config.login_identifier_mode`, defaulting every existing
+  workspace to `USERNAME` — **existing workspaces are unaffected until an
+  admin changes the setting.** The hosted login form's identifier label,
+  input type, and `autocomplete` hint adapt to the chosen mode.
+- **Auto-generated usernames.** A user provisioned without one — an
+  admin-created invite or a SCIM push supplying only a name and email — now
+  gets a readable username generated from the given name (or the email's
+  local part) plus a short random suffix, checked against both the username
+  and email namespaces so generation can never manufacture the collision
+  below.
+- **Admin-editable usernames.** Usernames were previously immutable after
+  creation. An administrator can now rename a user's username from the admin
+  UI or the admin API, subject to the same collision check as creation.
+
+### Changed
+
+- **Generic sign-in failure message.** "Invalid username or password."
+  became **"Invalid sign-in details."**, since the old wording named
+  "username", which was misleading for a workspace in `Email only` mode.
+- **Sign-in identifiers are now trimmed of surrounding whitespace** before
+  lookup; previously they were passed through raw. In `Username only` mode
+  this means a username pasted with a trailing space, which previously
+  failed, now signs in. This is safe: stored usernames cannot contain
+  leading or trailing whitespace, so trimming can only ever resolve the same
+  account the untrimmed value would have, never a different one.
+
+### Security
+
+- **Username/email collision prevention.** Creating or updating a user whose
+  username equals a different user's email address (or vice versa) is now
+  rejected — across admin user creation, admin user update, SCIM, and
+  self-registration. The two namespaces are separately unique in the
+  database, so without this check a pair could exist that `Username or
+  email` mode cannot resolve. A user whose username *is* their own email
+  address remains fully supported and is unaffected by this check.
+- **Email sign-in does not require a verified email address, by design.**
+  Username sign-in has never checked `emailVerified`, and gating email
+  sign-in on it would lock out invite- and SCIM-provisioned users who never
+  completed verification — exactly the users this feature exists to serve.
+
+### Migrations
+
+- `V65__login_identifier_mode.sql` — adds
+  `tenant_security_config.login_identifier_mode`, `NOT NULL DEFAULT
+  'USERNAME'`, constrained to `USERNAME` / `EMAIL` / `EITHER`. Additive only:
+  every existing workspace keeps its current sign-in behaviour.
+
+---
+
 ## [1.23.0] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workspace to `USERNAME` — **existing workspaces are unaffected until an
   admin changes the setting.** The hosted login form's identifier label,
   input type, and `autocomplete` hint adapt to the chosen mode.
-- **Auto-generated usernames.** A user provisioned without one — an
-  admin-created invite or a SCIM push supplying only a name and email — now
-  gets a readable username generated from the given name (or the email's
-  local part) plus a short random suffix, checked against both the username
-  and email namespaces so generation can never manufacture the collision
-  below.
+- **Auto-generated usernames.** A user provisioned without one through the
+  admin API or admin UI — an invite or a create call supplying only a name
+  and email — now gets a readable username generated from the given name
+  (or the email's local part) plus a short random suffix, checked against
+  both the username and email namespaces so generation can never manufacture
+  the collision below. SCIM is unaffected: `userName` is REQUIRED by RFC
+  7643, so a SCIM push that omits it is still rejected rather than
+  generated.
 - **Admin-editable usernames.** Usernames were previously immutable after
   creation. An administrator can now rename a user's username from the admin
   UI or the admin API, subject to the same collision check as creation.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For configuration knobs — set your own `KAUTH_SECRET_KEY`, point at an externa
 - **Multi-tenancy** — Isolated workspaces, each with its own users, applications, settings, and RS256 signing keys
 - **RBAC** — Roles, groups, composite role inheritance, JWT `realm_access` / `resource_access` claims
 - **MFA** — TOTP (RFC 6238), recovery codes, per-tenant policy (optional / required / required for admins)
+- **Sign-in identifier** — per-workspace choice of username, email, or either; existing workspaces keep username-only until an admin opts in
 - **Social login** — Google and GitHub OAuth2, with automatic account linking
 - **OIDC identity brokering** — sign users in through any OpenID Connect provider, configured per workspace; endpoints read from the issuer's discovery document, with optional per-endpoint pins. Optional just-in-time account creation, off by default and gated on a provider-asserted verified email plus an exact-match allowed-domain list. No identity provider has been verified against a live tenant; the implementation follows the specifications the providers publish
 - **User self-service** — Email verification, password reset, session management, MFA enrollment

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.23.0"
+version = "1.24.0"
 
 application {
     mainClass.set("com.kauth.ApplicationKt")

--- a/docs/guides/sign-in-identifier.md
+++ b/docs/guides/sign-in-identifier.md
@@ -72,6 +72,68 @@ predates this validation (or predates any format checking at all, as with
 self-registration and backup-imported accounts) does not block unrelated
 edits to the same user, such as updating their email or name.
 
+## Username normalization
+
+Every path that can create or rename a username — admin create, admin
+rename, self-registration, social login, JIT provisioning, email-OTP
+sign-up, and backup import — now normalizes it the same way before writing:
+trimmed of surrounding whitespace, lowercased, then required to match
+`[a-zA-Z0-9._@+-]+`. A value that fails to normalize into something valid
+is rejected rather than stored as-is. Self-registration previously ran no
+username validation at all; it is now covered by the same rule as every
+other path.
+
+One consequence: sign-in matches usernames **case-insensitively**. Storage
+is always lowercase, and the identifier submitted at sign-in is lowercased
+before lookup, so a user who originally signed up or was created as `Dave`
+still signs in as `Dave`, `DAVE`, or `dave` — their stored username is
+`dave`.
+
+## Upgrading to v1.24.0
+
+Migration `V66` normalizes every username already in the database to the
+rule above, then adds a unique index on `(tenant_id, lower(username))` so
+two usernames differing only by case (or by punctuation collapsed to `.`)
+can no longer coexist. This has two consequences an operator must plan for
+before upgrading:
+
+- **Existing sign-in identifiers can change.** A user stored as `"John
+  Doe"` becomes `john.doe`; a user stored as `Dave` becomes `dave`. Anyone
+  whose stored username was not already trimmed, lowercase, and
+  pattern-valid needs to be told their new sign-in identifier before or
+  right after the upgrade.
+- **The migration aborts the upgrade if it would have to merge two
+  identities.** If two usernames in the same tenant would normalize to the
+  same value — e.g. `Dave` and `dave`, or `john.doe` and `John_Doe` — `V66`
+  raises an exception and the migration (and therefore the upgrade) does
+  not complete. This is deliberate: silently merging or dropping one of the
+  two accounts would be worse than a blocked upgrade. The operator must
+  rename one of the colliding accounts by hand and re-run the migration.
+
+Run this query against the target database **before** upgrading to find
+every tenant/username group that would collide. It mirrors `V66`'s own
+normalization exactly — lowercase, trim, collapse forbidden-character runs
+to `.`, then strip leading/trailing `.`/`_`/`-`:
+
+```sql
+SELECT tenant_id,
+       regexp_replace(
+         regexp_replace(
+           regexp_replace(lower(btrim(username)), '[^a-z0-9._@+-]+', '.', 'g'),
+           '^[._-]+', ''
+         ),
+         '[._-]+$', ''
+       ) AS normalized,
+       count(*)
+FROM users
+GROUP BY 1, 2
+HAVING count(*) > 1;
+```
+
+Any row this returns is an upgrade blocker: rename one of the colliding
+usernames (through the admin UI or API, on the pre-upgrade version) until
+the query returns nothing, then upgrade.
+
 ## Sign-in failure message
 
 The generic sign-in failure changed from "Invalid username or password." to
@@ -83,13 +145,15 @@ which was misleading for a workspace in `EMAIL` mode.
 The identifier submitted at sign-in is now trimmed of surrounding whitespace
 before lookup; previously it was passed through raw. In `USERNAME` mode this
 means a username pasted with a trailing space, which previously failed, now
-signs in. This is safe for `createUser`, `register`, social login, JIT
-provisioning, and email-OTP sign-up, all of which trim before storing —
-trimming at lookup can only ever resolve the same account the untrimmed
-value would have, never a different one. `BackupImporterService` is the one
-exception: it writes a restored username verbatim, untrimmed, so a backup
-imported from an older instance can still carry leading or trailing
-whitespace in a stored username.
+signs in. This is safe because every write path — `createUser`, `register`,
+social login, JIT provisioning, email-OTP sign-up, and backup import —
+normalizes (trims and lowercases) before storing, so a stored username can
+no longer carry leading or trailing whitespace at all; trimming at lookup
+can only ever resolve the same account the untrimmed value would have,
+never a different one. Backup import used to be the one exception, writing
+a restored username verbatim; it now normalizes and rejects the record
+instead if the result isn't valid (see Upgrading, below, for the equivalent
+cleanup `V66` performs on rows already in the database).
 
 ## A note on rolling deploys
 

--- a/docs/guides/sign-in-identifier.md
+++ b/docs/guides/sign-in-identifier.md
@@ -104,7 +104,7 @@ before upgrading:
   right after the upgrade.
 - **The migration aborts the upgrade if it would have to merge two
   identities.** If two usernames in the same tenant would normalize to the
-  same value — e.g. `Dave` and `dave`, or `john.doe` and `John_Doe` — `V66`
+  same value — e.g. `Dave` and `dave`, or `john.doe` and `John Doe` — `V66`
   raises an exception and the migration (and therefore the upgrade) does
   not complete. This is deliberate: silently merging or dropping one of the
   two accounts would be worse than a blocked upgrade. The operator must

--- a/docs/guides/sign-in-identifier.md
+++ b/docs/guides/sign-in-identifier.md
@@ -1,0 +1,77 @@
+# Sign-in identifier modes
+
+Kotauth v1.24.0 adds a per-workspace choice of what a user types into the
+identifier field of the hosted login form: username, email address, or
+either.
+
+## The three modes
+
+The **Sign-In Identifier** section of the workspace Security Policy page
+(`/admin/workspaces/<slug>/settings/security`) offers three options:
+
+- **Username only** — users sign in with their username. This is the
+  default, and preserves the behaviour every workspace had before v1.24.0.
+- **Email only** — users sign in with their email address.
+- **Username or email** — users may enter either. If a submitted value
+  matches one account's username and a *different* account's email, sign-in
+  is refused rather than guessing which account was meant. The refusal is
+  the same generic failure as any other bad credential, so it is not
+  externally distinguishable from a wrong password.
+
+**Existing workspaces are unaffected until an admin changes this setting.**
+Migration `V65` defaults every existing tenant to `USERNAME`, so upgrading
+to v1.24.0 does not change what anyone can sign in with.
+
+The hosted login form adapts its identifier label, input type, and
+`autocomplete` hint to the workspace's mode — for example, `Email only`
+renders an `email`-type field with `autocomplete="email"`, while
+`Username only` keeps a plain text field so a value that happens to look
+like an email is not blocked by native browser validation.
+
+## Email sign-in does not require a verified address
+
+This is a deliberate decision, not an oversight. Username sign-in has never
+checked whether a user's email is verified, and gating email sign-in on
+verification would lock out invite- and SCIM-provisioned users who have
+never completed the verification step — exactly the accounts this feature
+exists to serve. Do not add an `emailVerified` check to the email or either
+lookup path; it would be a regression, not a fix.
+
+## Preventing an unresolvable pair
+
+Because usernames and email addresses are separately unique namespaces, the
+database alone would allow a pair that `EITHER` mode cannot resolve: user A's
+username equal to user B's email (or vice versa). Kotauth rejects that pair
+at write time instead — across admin user creation and update, SCIM, and
+self-registration — regardless of which mode the workspace currently uses,
+so switching to `EITHER` later never surfaces a latent collision.
+
+A user whose username **is their own** email address is unaffected and
+remains fully supported; that is the shape most integrators actually want.
+
+## Auto-generated and admin-editable usernames
+
+When a user is provisioned without a username — an admin-created invite or a
+SCIM push that supplies only a name and email — Kotauth generates one: a
+readable stem from the given name (falling back to the email's local part),
+followed by a short random suffix, checked against both the username and
+email namespaces so generation can never manufacture the collision above.
+
+Usernames are no longer immutable. An administrator can rename a user's
+username from the admin UI or the admin API, subject to the same collision
+check.
+
+## Sign-in failure message
+
+The generic sign-in failure changed from "Invalid username or password." to
+**"Invalid sign-in details."**, since the old wording named "username",
+which was misleading for a workspace in `EMAIL` mode.
+
+## A note on whitespace
+
+The identifier submitted at sign-in is now trimmed of surrounding whitespace
+before lookup; previously it was passed through raw. In `USERNAME` mode this
+means a username pasted with a trailing space, which previously failed, now
+signs in. This is safe: stored usernames cannot contain leading or trailing
+whitespace, so trimming can only ever resolve the same account the untrimmed
+value would have, never a different one.

--- a/docs/guides/sign-in-identifier.md
+++ b/docs/guides/sign-in-identifier.md
@@ -46,20 +46,31 @@ at write time instead — across admin user creation and update, SCIM, and
 self-registration — regardless of which mode the workspace currently uses,
 so switching to `EITHER` later never surfaces a latent collision.
 
+Social login, JIT provisioning, and backup import do not run this check —
+they provision users outside the admin/SCIM/self-registration paths and can
+still create a colliding pair. An administrator can resolve one after the
+fact by renaming the username, which is validated the same way.
+
 A user whose username **is their own** email address is unaffected and
 remains fully supported; that is the shape most integrators actually want.
 
 ## Auto-generated and admin-editable usernames
 
-When a user is provisioned without a username — an admin-created invite or a
-SCIM push that supplies only a name and email — Kotauth generates one: a
+When a user is provisioned without a username — an admin-created invite or
+API call that supplies only a name and email — Kotauth generates one: a
 readable stem from the given name (falling back to the email's local part),
 followed by a short random suffix, checked against both the username and
 email namespaces so generation can never manufacture the collision above.
+This applies to the admin API and admin UI only. SCIM's `userName` is
+REQUIRED per RFC 7643, so a SCIM push omitting it is rejected rather than
+generated.
 
 Usernames are no longer immutable. An administrator can rename a user's
 username from the admin UI or the admin API, subject to the same collision
-check.
+check. Renaming validates only the new value — a stored username that
+predates this validation (or predates any format checking at all, as with
+self-registration and backup-imported accounts) does not block unrelated
+edits to the same user, such as updating their email or name.
 
 ## Sign-in failure message
 
@@ -72,6 +83,18 @@ which was misleading for a workspace in `EMAIL` mode.
 The identifier submitted at sign-in is now trimmed of surrounding whitespace
 before lookup; previously it was passed through raw. In `USERNAME` mode this
 means a username pasted with a trailing space, which previously failed, now
-signs in. This is safe: stored usernames cannot contain leading or trailing
-whitespace, so trimming can only ever resolve the same account the untrimmed
-value would have, never a different one.
+signs in. This is safe for `createUser`, `register`, social login, JIT
+provisioning, and email-OTP sign-up, all of which trim before storing —
+trimming at lookup can only ever resolve the same account the untrimmed
+value would have, never a different one. `BackupImporterService` is the one
+exception: it writes a restored username verbatim, untrimmed, so a backup
+imported from an older instance can still carry leading or trailing
+whitespace in a stored username.
+
+## A note on rolling deploys
+
+During a rolling deploy, old and new replicas serve traffic side by side.
+Switching a workspace's mode away from `USERNAME` takes effect immediately
+in the database, but a request that happens to land on an old replica still
+resolves by username only, regardless of the new setting, until that
+replica is replaced.

--- a/docs/guides/sign-in-identifier.md
+++ b/docs/guides/sign-in-identifier.md
@@ -109,11 +109,28 @@ before upgrading:
   not complete. This is deliberate: silently merging or dropping one of the
   two accounts would be worse than a blocked upgrade. The operator must
   rename one of the colliding accounts by hand and re-run the migration.
+- **The migration aborts the upgrade if a username would normalize to
+  nothing at all.** A username made entirely of characters outside
+  `[a-z0-9._@+-]` — most notably a non-Latin username such as `Иван` or
+  `用户` — collapses to an empty string under `V66`'s own rewrite rule.
+  `users.username` is `NOT NULL` with no format `CHECK` before this
+  migration, so an empty string would otherwise commit silently, and that
+  user could never sign in by username again with no error and no log line
+  anywhere. `V66` refuses to let that happen: it raises an exception naming
+  the tenant and the row's `id` (never the raw username, the same
+  restraint the collision check above already uses) and the migration does
+  not complete. **The operator must rename that user by hand, on the
+  pre-upgrade version, to something matching `[a-z0-9._@+-]+` before
+  re-running the migration.** This is a real possibility for any
+  self-hosted install used outside the anglosphere — `AuthService.register`
+  historically ran no username validation at all, so such rows can exist in
+  the wild.
 
-Run this query against the target database **before** upgrading to find
-every tenant/username group that would collide. It mirrors `V66`'s own
-normalization exactly — lowercase, trim, collapse forbidden-character runs
-to `.`, then strip leading/trailing `.`/`_`/`-`:
+Run these queries against the target database **before** upgrading.
+
+Every tenant/username group that would collide once normalized. This
+mirrors `V66`'s own normalization exactly — lowercase, trim, collapse
+forbidden-character runs to `.`, then strip leading/trailing `.`/`_`/`-`:
 
 ```sql
 SELECT tenant_id,
@@ -133,6 +150,25 @@ HAVING count(*) > 1;
 Any row this returns is an upgrade blocker: rename one of the colliding
 usernames (through the admin UI or API, on the pre-upgrade version) until
 the query returns nothing, then upgrade.
+
+Every row that would normalize to an empty or otherwise still-invalid
+value — the companion query for the non-Latin-username case above:
+
+```sql
+SELECT id, tenant_id, username
+FROM users
+WHERE regexp_replace(
+        regexp_replace(
+          regexp_replace(lower(btrim(username)), '[^a-z0-9._@+-]+', '.', 'g'),
+          '^[._-]+', ''
+        ),
+        '[._-]+$', ''
+      ) !~ '^[a-z0-9._@+-]+$';
+```
+
+Any row this returns is also an upgrade blocker: rename the user (through
+the admin UI or API, on the pre-upgrade version) to a username matching
+`[a-z0-9._@+-]+` until the query returns nothing, then upgrade.
 
 ## Sign-in failure message
 
@@ -162,3 +198,16 @@ Switching a workspace's mode away from `USERNAME` takes effect immediately
 in the database, but a request that happens to land on an old replica still
 resolves by username only, regardless of the new setting, until that
 replica is replaced.
+
+`V66` itself has the same exposure. It runs once, at the start of the
+deploy, and rewrites every stored username immediately — but an old
+replica still running the previous release's code may do a case-exact
+username comparison somewhere in its own request handling (rather than
+going through a case-insensitive lookup). For the window between `V66`
+running and the last old replica draining, such a replica will fail to
+match a user whose stored username `V66` just rewrote — e.g. a user stored
+as `Dave` is now `dave` in the database, and an old replica comparing the
+submitted value byte-for-byte against the row it fetches will not find it.
+This resolves itself as soon as the rolling deploy finishes and only new
+replicas remain; there is no user-visible action to take beyond finishing
+the deploy promptly.

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresTenantRepository.kt
@@ -1,5 +1,6 @@
 package com.kauth.adapter.persistence
 
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.PortalConfig
 import com.kauth.domain.model.PortalLayout
@@ -134,6 +135,7 @@ class PostgresTenantRepository(
                     it[emailOtpSignupEnabled] = tenant.securityConfig.emailOtpSignupEnabled
                     it[emailOtpLockoutThreshold] = tenant.securityConfig.emailOtpLockoutThreshold
                     it[emailOtpLoginEnabled] = tenant.securityConfig.emailOtpLoginEnabled
+                    it[loginIdentifierMode] = tenant.securityConfig.loginIdentifierMode.name
                 }
             if (updatedRows == 0) {
                 TenantSecurityConfigTable.insert {
@@ -156,6 +158,7 @@ class PostgresTenantRepository(
                     it[emailOtpSignupEnabled] = tenant.securityConfig.emailOtpSignupEnabled
                     it[emailOtpLockoutThreshold] = tenant.securityConfig.emailOtpLockoutThreshold
                     it[emailOtpLoginEnabled] = tenant.securityConfig.emailOtpLoginEnabled
+                    it[loginIdentifierMode] = tenant.securityConfig.loginIdentifierMode.name
                 }
             }
             tenantJoined
@@ -243,6 +246,8 @@ class PostgresTenantRepository(
             emailOtpSignupEnabled = this[TenantSecurityConfigTable.emailOtpSignupEnabled],
             emailOtpLockoutThreshold = this[TenantSecurityConfigTable.emailOtpLockoutThreshold],
             emailOtpLoginEnabled = this[TenantSecurityConfigTable.emailOtpLoginEnabled],
+            loginIdentifierMode =
+                LoginIdentifierMode.fromStorage(this[TenantSecurityConfigTable.loginIdentifierMode]),
         )
     }
 

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
@@ -43,6 +43,20 @@ class PostgresUserRepository : UserRepository {
                 .singleOrNull()
         }
 
+    override fun findByUsernameIgnoreCase(
+        tenantId: TenantId,
+        username: String,
+    ): User? =
+        transaction {
+            UsersTable
+                .selectAll()
+                .where {
+                    (UsersTable.tenantId eq tenantId.value) and
+                        (UsersTable.username.lowerCase() eq username.trim().lowercase())
+                }.map { it.toUser() }
+                .singleOrNull()
+        }
+
     override fun findByEmail(
         tenantId: TenantId,
         email: String,

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
@@ -54,7 +54,10 @@ class PostgresUserRepository : UserRepository {
                     (UsersTable.tenantId eq tenantId.value) and
                         (UsersTable.username.lowerCase() eq username.trim().lowercase())
                 }.map { it.toUser() }
-                .singleOrNull()
+                // UNIQUE (tenant_id, username) permits two rows differing only in case, so a
+                // case-differing collision is still one match — singleOrNull() would fail open
+                // here (return null) precisely on the collision this lookup exists to catch.
+                .firstOrNull()
         }
 
     override fun findByEmail(

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresUserRepository.kt
@@ -152,6 +152,7 @@ class PostgresUserRepository : UserRepository {
     override fun update(user: User): User =
         transaction {
             UsersTable.update({ UsersTable.id eq user.id!!.value }) {
+                it[username] = user.username
                 it[email] = user.email.lowercase()
                 it[fullName] = user.fullName
                 it[externalId] = user.externalId

--- a/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/TenantSecurityConfigTable.kt
@@ -32,6 +32,7 @@ object TenantSecurityConfigTable : Table("tenant_security_config") {
     val emailOtpSignupEnabled = bool("email_otp_signup_enabled").default(false)
     val emailOtpLockoutThreshold = integer("email_otp_lockout_threshold").default(5)
     val emailOtpLoginEnabled = bool("email_otp_login_enabled").default(false)
+    val loginIdentifierMode = varchar("login_identifier_mode", 10).default("USERNAME")
     val createdAt = timestampWithTimeZone("created_at")
     val updatedAt = timestampWithTimeZone("updated_at")
 

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -1040,6 +1040,9 @@ object EnglishStrings {
     const val USERNAME_LABEL = "Username"
     const val USERNAME_FORMAT_HINT = "Letters, digits, dots, underscores, hyphens, @, and +."
 
+    /** Usernames are stored lowercased; uppercase input is accepted and normalized, not rejected. */
+    const val USERNAME_LOWERCASE_HINT = "Saved in lowercase, regardless of how it's typed here."
+
     /** Create-user form only: the username field is optional there, unlike on the edit form. */
     const val USERNAME_GENERATE_HINT = "Leave blank to generate one from the name and email."
 

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -479,8 +479,6 @@ object EnglishStrings {
 
     // Admin — sign-in identifier (workspace security policy)
     const val ADMIN_SIGNIN_IDENTIFIER_SECTION = "Sign-In Identifier"
-    const val ADMIN_SIGNIN_IDENTIFIER_HELP =
-        "Choose what users type to identify themselves on the login page."
     const val ADMIN_SIGNIN_IDENTIFIER_USERNAME_LABEL = "Username only"
     const val ADMIN_SIGNIN_IDENTIFIER_USERNAME_DESC =
         "Users sign in with their username. This is the default."

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -477,6 +477,21 @@ object EnglishStrings {
     const val ADMIN_SECURITY_PASSWORD_POLICY_SECTION = "Password Policy"
     const val ADMIN_SECURITY_PASSWORD_REQUIREMENTS_SECTION = "Password Requirements"
 
+    // Admin — sign-in identifier (workspace security policy)
+    const val ADMIN_SIGNIN_IDENTIFIER_SECTION = "Sign-In Identifier"
+    const val ADMIN_SIGNIN_IDENTIFIER_HELP =
+        "Choose what users type to identify themselves on the login page."
+    const val ADMIN_SIGNIN_IDENTIFIER_USERNAME_LABEL = "Username only"
+    const val ADMIN_SIGNIN_IDENTIFIER_USERNAME_DESC =
+        "Users sign in with their username. This is the default."
+    const val ADMIN_SIGNIN_IDENTIFIER_EMAIL_LABEL = "Email only"
+    const val ADMIN_SIGNIN_IDENTIFIER_EMAIL_DESC =
+        "Users sign in with their email address."
+    const val ADMIN_SIGNIN_IDENTIFIER_EITHER_LABEL = "Username or email"
+    const val ADMIN_SIGNIN_IDENTIFIER_EITHER_DESC =
+        "Users may enter either. If a value matches one account's username and another's " +
+            "email, sign-in is refused rather than guessing."
+
     const val ADMIN_PASSKEYS_PAGE_TITLE = "Passkeys"
     const val ADMIN_PASSKEYS_ENROLLMENT_LABEL = "Passkey enrollment"
     const val ADMIN_PASSKEYS_ENROLLMENT_HINT = "users have enrolled at least one passkey"

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -1009,6 +1009,14 @@ object EnglishStrings {
     const val USER_NAME_PARTS_HINT =
         "Optional. Stored separately from the display name, so filling these in never rewrites Full Name."
 
+    /**
+     * The username field's format rule, shown on the create-user form and the user-detail edit
+     * form. Usernames used to be permanent; they are now editable so a generated handle doesn't
+     * have to stick forever.
+     */
+    const val USERNAME_LABEL = "Username"
+    const val USERNAME_FORMAT_HINT = "Letters, digits, dots, underscores, hyphens, @, and +."
+
     /** Group detail only: provisioning carries no roles, so the one thing the UI owns is safe to edit. */
     const val SCIM_IDP_MANAGED_ROLES_EDITABLE =
         "Role assignment is not provisioned and stays editable. Roles are assigned here and nowhere else, so a " +

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -573,6 +573,16 @@ object EnglishStrings {
     const val LOGIN_REGISTRATION_SUCCESS = "Account created successfully. Please sign in."
     const val LOGIN_USERNAME = "Username"
     const val LOGIN_USERNAME_PLACEHOLDER = "Enter your username"
+
+    // Login page — identifier field, per workspace sign-in identifier mode
+    const val LOGIN_IDENTIFIER_EMAIL = "Email address"
+    const val LOGIN_IDENTIFIER_EMAIL_PLACEHOLDER = "Enter your email address"
+    const val LOGIN_IDENTIFIER_EITHER = "Username or email"
+    const val LOGIN_IDENTIFIER_EITHER_PLACEHOLDER = "Username or email address"
+
+    // Shared sign-in failure. Deliberately vague and mode-agnostic: it must not reveal
+    // whether an account exists, nor which identifier namespace was matched.
+    const val LOGIN_INVALID_CREDENTIALS = "Invalid sign-in details."
     const val LOGIN_PASSWORD_PLACEHOLDER = "Enter your password"
     const val LOGIN_SUBMIT = "Sign In"
     const val LOGIN_FORGOT_PASSWORD = "Forgot password?"

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -580,6 +580,9 @@ object EnglishStrings {
     const val LOGIN_IDENTIFIER_EITHER = "Username or email"
     const val LOGIN_IDENTIFIER_EITHER_PLACEHOLDER = "Username or email address"
 
+    // Admin — security policy form validation
+    const val SECURITY_POLICY_INVALID_LOGIN_IDENTIFIER_MODE = "Not a recognised sign-in identifier mode."
+
     // Shared sign-in failure. Deliberately vague and mode-agnostic: it must not reveal
     // whether an account exists, nor which identifier namespace was matched.
     const val LOGIN_INVALID_CREDENTIALS = "Invalid sign-in details."

--- a/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/EnglishStrings.kt
@@ -1040,6 +1040,9 @@ object EnglishStrings {
     const val USERNAME_LABEL = "Username"
     const val USERNAME_FORMAT_HINT = "Letters, digits, dots, underscores, hyphens, @, and +."
 
+    /** Create-user form only: the username field is optional there, unlike on the edit form. */
+    const val USERNAME_GENERATE_HINT = "Leave blank to generate one from the name and email."
+
     /** Group detail only: provisioning carries no roles, so the one thing the UI owns is safe to edit. */
     const val SCIM_IDP_MANAGED_ROLES_EDITABLE =
         "Role assignment is not provisioned and stays editable. Roles are assigned here and nowhere else, so a " +

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -422,14 +422,17 @@ fun Route.adminSettingsRoutes(
 
         val update =
             WorkspaceSettingsUpdate.from(workspace).copy(
-                passwordPolicyMinLength = params["passwordPolicyMinLength"]?.toIntOrNull() ?: 8,
+                passwordPolicyMinLength =
+                    params["passwordPolicyMinLength"]?.toIntOrNull() ?: s.passwordMinLength,
                 passwordPolicyRequireSpecial = params["passwordPolicyRequireSpecial"] == "true",
                 passwordPolicyRequireUppercase = params["passwordPolicyRequireUppercase"] == "true",
                 passwordPolicyRequireNumber = params["passwordPolicyRequireNumber"] == "true",
-                passwordPolicyHistoryCount = params["passwordPolicyHistoryCount"]?.toIntOrNull() ?: 0,
-                passwordPolicyMaxAgeDays = params["passwordPolicyMaxAgeDays"]?.toIntOrNull() ?: 0,
+                passwordPolicyHistoryCount =
+                    params["passwordPolicyHistoryCount"]?.toIntOrNull() ?: s.passwordHistoryCount,
+                passwordPolicyMaxAgeDays =
+                    params["passwordPolicyMaxAgeDays"]?.toIntOrNull() ?: s.passwordMaxAgeDays,
                 passwordPolicyBlacklistEnabled = params["passwordPolicyBlacklistEnabled"] == "true",
-                mfaPolicy = params["mfaPolicy"]?.trim() ?: "optional",
+                mfaPolicy = params["mfaPolicy"]?.trim() ?: s.mfaPolicy,
                 lockoutMaxAttempts = params["lockoutMaxAttempts"]?.toIntOrNull() ?: s.lockoutMaxAttempts,
                 lockoutDurationMinutes = params["lockoutDurationMinutes"]?.toIntOrNull() ?: s.lockoutDurationMinutes,
                 corsAllowCredentials = params["corsAllowCredentials"] == "true",

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -436,7 +436,8 @@ fun Route.adminSettingsRoutes(
                 hibpCheckEnabled = params["hibpCheckEnabled"] == "true",
                 magicLinkTokenTtlMinutes =
                     params["magicLinkTokenTtlMinutes"]?.toIntOrNull() ?: s.magicLinkTokenTtlMinutes,
-                loginIdentifierMode = LoginIdentifierMode.fromStorage(params["loginIdentifierMode"]),
+                loginIdentifierMode =
+                    params["loginIdentifierMode"]?.let { LoginIdentifierMode.fromStorage(it) } ?: s.loginIdentifierMode,
             )
 
         when (val policyResult = workspaceSettingsService.updateWorkspaceSettings(slug, update)) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -3,6 +3,7 @@ package com.kauth.adapter.web.admin
 import com.kauth.adapter.web.EnglishStrings
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.DEFAULT_OIDC_SCOPES
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.MethodKey
 import com.kauth.domain.model.PortalLayout
@@ -435,6 +436,7 @@ fun Route.adminSettingsRoutes(
                 hibpCheckEnabled = params["hibpCheckEnabled"] == "true",
                 magicLinkTokenTtlMinutes =
                     params["magicLinkTokenTtlMinutes"]?.toIntOrNull() ?: s.magicLinkTokenTtlMinutes,
+                loginIdentifierMode = LoginIdentifierMode.fromStorage(params["loginIdentifierMode"]),
             )
 
         when (val policyResult = workspaceSettingsService.updateWorkspaceSettings(slug, update)) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminSettingsRoutes.kt
@@ -420,6 +420,20 @@ fun Route.adminSettingsRoutes(
         val params = call.receiveParameters()
         val s = workspace.securityConfig
 
+        val loginIdentifierModeRaw = params["loginIdentifierMode"]
+        val parsedLoginIdentifierMode = LoginIdentifierMode.parseOrNull(loginIdentifierModeRaw)
+        if (loginIdentifierModeRaw != null && parsedLoginIdentifierMode == null) {
+            return@post call.respondHtml(
+                HttpStatusCode.UnprocessableEntity,
+                AdminView.securityPolicyPage(
+                    workspace,
+                    wsPairs,
+                    session.username,
+                    error = EnglishStrings.SECURITY_POLICY_INVALID_LOGIN_IDENTIFIER_MODE,
+                ),
+            )
+        }
+
         val update =
             WorkspaceSettingsUpdate.from(workspace).copy(
                 passwordPolicyMinLength =
@@ -439,8 +453,7 @@ fun Route.adminSettingsRoutes(
                 hibpCheckEnabled = params["hibpCheckEnabled"] == "true",
                 magicLinkTokenTtlMinutes =
                     params["magicLinkTokenTtlMinutes"]?.toIntOrNull() ?: s.magicLinkTokenTtlMinutes,
-                loginIdentifierMode =
-                    params["loginIdentifierMode"]?.let { LoginIdentifierMode.fromStorage(it) } ?: s.loginIdentifierMode,
+                loginIdentifierMode = parsedLoginIdentifierMode ?: s.loginIdentifierMode,
             )
 
         when (val policyResult = workspaceSettingsService.updateWorkspaceSettings(slug, update)) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -352,21 +352,44 @@ fun Route.adminUserRoutes(
                 val params = call.receiveParameters()
                 val email = params["email"]?.trim() ?: ""
                 val fullName = params["fullName"]?.trim() ?: ""
+                val username = params["username"]?.trim()?.ifBlank { null }
                 val givenName = params["givenName"]?.trim()?.ifBlank { null }
                 val familyName = params["familyName"]?.trim()?.ifBlank { null }
                 val isHtmx = call.request.headers["HX-Request"] == "true"
                 // The form submits the whole mutable profile, so a name part left empty means
                 // "clear it" — which updateUser's null-means-unchanged parameters cannot express.
+                // A username rename goes through updateUser instead of replaceUserProfile, since
+                // the latter treats every parameter as authoritative and has no username field of
+                // its own; skip the extra call (and audit entry) when the username is untouched.
                 val result =
-                    adminUserService.replaceUserProfile(
-                        userId = userId,
-                        tenantId = ctx.workspace.id,
-                        email = email,
-                        fullName = fullName,
-                        externalId = user.externalId,
-                        givenName = givenName,
-                        familyName = familyName,
-                    )
+                    if (username != null && username != user.username) {
+                        when (
+                            val usernameResult =
+                                adminUserService.updateUser(userId, ctx.workspace.id, username = username)
+                        ) {
+                            is AdminResult.Failure -> usernameResult
+                            is AdminResult.Success ->
+                                adminUserService.replaceUserProfile(
+                                    userId = userId,
+                                    tenantId = ctx.workspace.id,
+                                    email = email,
+                                    fullName = fullName,
+                                    externalId = user.externalId,
+                                    givenName = givenName,
+                                    familyName = familyName,
+                                )
+                        }
+                    } else {
+                        adminUserService.replaceUserProfile(
+                            userId = userId,
+                            tenantId = ctx.workspace.id,
+                            email = email,
+                            fullName = fullName,
+                            externalId = user.externalId,
+                            givenName = givenName,
+                            familyName = familyName,
+                        )
+                    }
                 when (result) {
                     is AdminResult.Success -> {
                         if (isHtmx) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminUserRoutes.kt
@@ -352,44 +352,27 @@ fun Route.adminUserRoutes(
                 val params = call.receiveParameters()
                 val email = params["email"]?.trim() ?: ""
                 val fullName = params["fullName"]?.trim() ?: ""
-                val username = params["username"]?.trim()?.ifBlank { null }
+                val username = params["username"]?.trim()
                 val givenName = params["givenName"]?.trim()?.ifBlank { null }
                 val familyName = params["familyName"]?.trim()?.ifBlank { null }
                 val isHtmx = call.request.headers["HX-Request"] == "true"
                 // The form submits the whole mutable profile, so a name part left empty means
-                // "clear it" — which updateUser's null-means-unchanged parameters cannot express.
-                // A username rename goes through updateUser instead of replaceUserProfile, since
-                // the latter treats every parameter as authoritative and has no username field of
-                // its own; skip the extra call (and audit entry) when the username is untouched.
+                // "clear it" — which replaceUserProfile's other parameters treat as authoritative.
+                // Username is the one exception: it keeps updateUser's null-means-unchanged
+                // convention, but everything (including the rename) still lands in this single
+                // write, so a mid-submission failure can never leave the username changed while
+                // the rest of the profile — or the form the admin sees next — is not.
                 val result =
-                    if (username != null && username != user.username) {
-                        when (
-                            val usernameResult =
-                                adminUserService.updateUser(userId, ctx.workspace.id, username = username)
-                        ) {
-                            is AdminResult.Failure -> usernameResult
-                            is AdminResult.Success ->
-                                adminUserService.replaceUserProfile(
-                                    userId = userId,
-                                    tenantId = ctx.workspace.id,
-                                    email = email,
-                                    fullName = fullName,
-                                    externalId = user.externalId,
-                                    givenName = givenName,
-                                    familyName = familyName,
-                                )
-                        }
-                    } else {
-                        adminUserService.replaceUserProfile(
-                            userId = userId,
-                            tenantId = ctx.workspace.id,
-                            email = email,
-                            fullName = fullName,
-                            externalId = user.externalId,
-                            givenName = givenName,
-                            familyName = familyName,
-                        )
-                    }
+                    adminUserService.replaceUserProfile(
+                        userId = userId,
+                        tenantId = ctx.workspace.id,
+                        email = email,
+                        fullName = fullName,
+                        externalId = user.externalId,
+                        givenName = givenName,
+                        familyName = familyName,
+                        username = username,
+                    )
                 when (result) {
                     is AdminResult.Success -> {
                         if (isHtmx) {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -605,6 +605,7 @@ internal fun DIV.userProfileEditFragment(
                             attributes["pattern"] = "[a-zA-Z0-9._@+-]+"
                         }
                         div("edit-row__hint") { +EnglishStrings.USERNAME_FORMAT_HINT }
+                        div("edit-row__hint") { +EnglishStrings.USERNAME_LOWERCASE_HINT }
                     }
                 }
                 div("edit-row") {
@@ -984,6 +985,7 @@ internal fun createUserPageImpl(
                                 attributes["pattern"] = "[a-zA-Z0-9._@+-]+"
                             }
                             div("edit-row__hint") { +EnglishStrings.USERNAME_FORMAT_HINT }
+                            div("edit-row__hint") { +EnglishStrings.USERNAME_LOWERCASE_HINT }
                             div("edit-row__hint") { +EnglishStrings.USERNAME_GENERATE_HINT }
                         }
                     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -520,14 +520,10 @@ internal fun DIV.userProfileReadFragment(
         div("ov-card") {
             div("ov-card__section-label") { +"Profile" }
             div("ov-card__row") {
-                span("ov-card__label") { +"Username" }
+                span("ov-card__label") { +EnglishStrings.USERNAME_LABEL }
                 span("ov-card__value") {
                     span("ov-card__value--mono") { +user.username }
                     copyBtn(user.username)
-                    span("lock-icon") {
-                        attributes["title"] = "Immutable after creation"
-                        inlineSvgIcon("lock", "Immutable")
-                    }
                 }
             }
             ovRow("Email") {
@@ -598,14 +594,17 @@ internal fun DIV.userProfileEditFragment(
                 attributes["hx-target"] = "#profile-section"
                 attributes["hx-swap"] = "outerHTML"
                 div("edit-row") {
-                    span("edit-row__label") { +"Username" }
+                    span("edit-row__label") { +EnglishStrings.USERNAME_LABEL }
                     div {
                         input(classes = "edit-row__field edit-row__field--mono") {
                             type = InputType.text
+                            name = "username"
                             value = user.username
-                            disabled = true
+                            autoComplete = "off"
+                            attributes["spellcheck"] = "false"
+                            attributes["pattern"] = "[a-zA-Z0-9._@+-]+"
                         }
-                        div("edit-row__hint") { +"Immutable after creation" }
+                        div("edit-row__hint") { +EnglishStrings.USERNAME_FORMAT_HINT }
                     }
                 }
                 div("edit-row") {
@@ -973,7 +972,7 @@ internal fun createUserPageImpl(
                     method = FormMethod.post,
                 ) {
                     div("edit-row") {
-                        span("edit-row__label") { +"Username" }
+                        span("edit-row__label") { +EnglishStrings.USERNAME_LABEL }
                         div {
                             input(classes = "edit-row__field edit-row__field--mono") {
                                 type = InputType.text
@@ -985,9 +984,7 @@ internal fun createUserPageImpl(
                                 attributes["spellcheck"] = "false"
                                 attributes["pattern"] = "[a-zA-Z0-9._@+-]+"
                             }
-                            div("edit-row__hint") {
-                                +"Letters, digits, dots, underscores, hyphens, @, and +. Immutable after creation."
-                            }
+                            div("edit-row__hint") { +EnglishStrings.USERNAME_FORMAT_HINT }
                         }
                     }
                     div("edit-row") {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -977,7 +977,6 @@ internal fun createUserPageImpl(
                             input(classes = "edit-row__field edit-row__field--mono") {
                                 type = InputType.text
                                 name = "username"
-                                required = true
                                 value = prefill.username
                                 placeholder = "johndoe"
                                 autoComplete = "off"
@@ -985,6 +984,7 @@ internal fun createUserPageImpl(
                                 attributes["pattern"] = "[a-zA-Z0-9._@+-]+"
                             }
                             div("edit-row__hint") { +EnglishStrings.USERNAME_FORMAT_HINT }
+                            div("edit-row__hint") { +EnglishStrings.USERNAME_GENERATE_HINT }
                         }
                     }
                     div("edit-row") {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -6,6 +6,7 @@ import com.kauth.adapter.web.JsIntegrity
 import com.kauth.adapter.web.inlineSvgIcon
 import com.kauth.domain.model.Application
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.PortalLayout
 import com.kauth.domain.model.Tenant
@@ -755,6 +756,31 @@ internal fun securityPolicyPageImpl(
                     }
                 }
 
+                // ── Sign-In Identifier ───────────────────────────────
+                div("ov-card") {
+                    div("ov-card__section-label") { +EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_SECTION }
+                    div("radio-group") {
+                        loginIdentifierRow(
+                            workspace.securityConfig.loginIdentifierMode,
+                            LoginIdentifierMode.USERNAME,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_USERNAME_LABEL,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_USERNAME_DESC,
+                        )
+                        loginIdentifierRow(
+                            workspace.securityConfig.loginIdentifierMode,
+                            LoginIdentifierMode.EMAIL,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_EMAIL_LABEL,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_EMAIL_DESC,
+                        )
+                        loginIdentifierRow(
+                            workspace.securityConfig.loginIdentifierMode,
+                            LoginIdentifierMode.EITHER,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_EITHER_LABEL,
+                            EnglishStrings.ADMIN_SIGNIN_IDENTIFIER_EITHER_DESC,
+                        )
+                    }
+                }
+
                 // ── Account Lockout ──────────────────────────────────
                 div("ov-card") {
                     div("ov-card__section-label") { +"Account Lockout" }
@@ -1223,6 +1249,26 @@ private fun DIV.colorField(label: String, key: String, formName: String, current
                 maxLength = "7"
                 attributes["data-hex-key"] = key
             }
+        }
+    }
+}
+
+// ── Sign-in identifier row helper ────────────────────────────────────────
+// One radio row in the Sign-In Identifier ov-card, mirroring the MFA policy radio group.
+private fun FlowContent.loginIdentifierRow(
+    current: LoginIdentifierMode,
+    mode: LoginIdentifierMode,
+    label: String,
+    description: String,
+) {
+    label("radio-row") {
+        input(type = InputType.radio, name = "loginIdentifierMode") {
+            value = mode.name
+            if (current == mode) checked = true
+        }
+        div("radio-row__body") {
+            span("radio-row__label") { +label }
+            span("radio-row__desc") { +description }
         }
     }
 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -266,7 +266,8 @@ data class ProblemDetail(
 // -- Request bodies -----------------------------------------------------------
 
 @Serializable data class CreateUserRequest(
-    val username: String,
+    /** Omit or leave blank to have Kotauth generate one from the name and email. */
+    val username: String? = null,
     val email: String,
     val fullName: String,
     val password: String,
@@ -333,7 +334,8 @@ data class ProblemDetail(
  * Requires SMTP to be configured on the tenant.
  */
 @Serializable data class InviteUserRequest(
-    val username: String,
+    /** Omit or leave blank to have Kotauth generate one from the name and email. */
+    val username: String? = null,
     val email: String,
     val fullName: String,
 )

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -275,6 +275,7 @@ data class ProblemDetail(
 @Serializable data class UpdateUserRequest(
     val email: String? = null,
     val fullName: String? = null,
+    val username: String? = null,
 )
 
 @Serializable data class CreateRoleRequest(

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
@@ -122,7 +122,10 @@ internal fun Route.apiUserRoutes(
                 val userId = call.parseUserIdOr { return@put } ?: return@put
                 val body = call.receive<UpdateUserRequest>()
 
-                when (val result = adminUserService.updateUser(userId, tenantId, body.email, body.fullName)) {
+                when (
+                    val result =
+                        adminUserService.updateUser(userId, tenantId, body.email, body.fullName, body.username)
+                ) {
                     is AdminResult.Success -> call.respond(HttpStatusCode.OK, result.value.toApiDto())
                     is AdminResult.Failure -> call.respondAdminError(result.error)
                 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiUserRoutes.kt
@@ -58,7 +58,7 @@ internal fun Route.apiUserRoutes(
                 val result =
                     adminUserService.createUser(
                         tenantId = tenantId,
-                        username = body.username,
+                        username = body.username ?: "",
                         email = body.email,
                         fullName = body.fullName,
                         password = body.password,
@@ -85,7 +85,7 @@ internal fun Route.apiUserRoutes(
                 val result =
                     adminUserService.createUser(
                         tenantId = tenantId,
-                        username = body.username,
+                        username = body.username ?: "",
                         email = body.email,
                         fullName = body.fullName,
                         password = null,

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthHelpers.kt
@@ -340,7 +340,7 @@ internal fun OAuthError.toDescription(): String =
 
 internal fun AuthError.toMessage(): String =
     when (this) {
-        is AuthError.InvalidCredentials -> "Invalid username or password."
+        is AuthError.InvalidCredentials -> EnglishStrings.LOGIN_INVALID_CREDENTIALS
         is AuthError.TenantNotFound -> "Tenant not found."
         is AuthError.RegistrationDisabled -> "Registration is not enabled for this tenant."
         is AuthError.UserAlreadyExists -> "That username is already taken."
@@ -349,10 +349,10 @@ internal fun AuthError.toMessage(): String =
         is AuthError.ValidationError -> this.message
         // Collapsed to the generic message — these states would otherwise let an attacker
         // enumerate accounts (lockout, pending invite, expired/forced-change flags).
-        is AuthError.PasswordExpired -> "Invalid username or password."
-        is AuthError.AccountLocked -> "Invalid username or password."
-        is AuthError.PendingSetup -> "Invalid username or password."
-        is AuthError.PasswordChangeRequired -> "Invalid username or password."
+        is AuthError.PasswordExpired -> EnglishStrings.LOGIN_INVALID_CREDENTIALS
+        is AuthError.AccountLocked -> EnglishStrings.LOGIN_INVALID_CREDENTIALS
+        is AuthError.PendingSetup -> EnglishStrings.LOGIN_INVALID_CREDENTIALS
+        is AuthError.PasswordChangeRequired -> EnglishStrings.LOGIN_INVALID_CREDENTIALS
         is AuthError.PasswordLoginDisabled ->
             "Password sign-in is disabled for this workspace. " +
                 "Use the email link option or sign in with a configured social provider."

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthView.kt
@@ -7,6 +7,7 @@ import com.kauth.adapter.web.ViewContext
 import com.kauth.adapter.web.demoBanner
 import com.kauth.adapter.web.inlineSvgIcon
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.SecurityConfig
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.TenantTheme
@@ -127,6 +128,7 @@ object AuthView {
         passwordLoginEnabled: Boolean = true,
         emailOtpLoginEnabled: Boolean = false,
         passkeysEnabled: Boolean = false,
+        loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
     ): HTML.() -> Unit =
         {
             head { authHead(ctx.t("AUTH_PAGE_TITLE_LOGIN", ctx.workspaceName), ctx.theme) }
@@ -154,16 +156,41 @@ object AuthView {
                                 encType = FormEncType.applicationXWwwFormUrlEncoded,
                                 method = FormMethod.post,
                             ) {
+                                val identifierLabel =
+                                    when (loginIdentifierMode) {
+                                        LoginIdentifierMode.USERNAME -> ctx.t("LOGIN_USERNAME")
+                                        LoginIdentifierMode.EMAIL -> ctx.t("LOGIN_IDENTIFIER_EMAIL")
+                                        LoginIdentifierMode.EITHER -> ctx.t("LOGIN_IDENTIFIER_EITHER")
+                                    }
+                                val identifierPlaceholder =
+                                    when (loginIdentifierMode) {
+                                        LoginIdentifierMode.USERNAME -> ctx.t("LOGIN_USERNAME_PLACEHOLDER")
+                                        LoginIdentifierMode.EMAIL -> ctx.t("LOGIN_IDENTIFIER_EMAIL_PLACEHOLDER")
+                                        LoginIdentifierMode.EITHER -> ctx.t("LOGIN_IDENTIFIER_EITHER_PLACEHOLDER")
+                                    }
+                                // EITHER stays type=text: type=email would let native validation
+                                // block a legitimate username from being submitted at all.
+                                val identifierType =
+                                    if (loginIdentifierMode == LoginIdentifierMode.EMAIL) {
+                                        InputType.email
+                                    } else {
+                                        InputType.text
+                                    }
+                                val autocompleteBase =
+                                    if (loginIdentifierMode == LoginIdentifierMode.EMAIL) "email" else "username"
                                 div("field") {
                                     label {
                                         htmlFor = "username"
-                                        +ctx.t("LOGIN_USERNAME")
+                                        +identifierLabel
                                     }
-                                    input(type = InputType.text, name = "username") {
+                                    input(type = identifierType, name = "username") {
                                         id = "username"
-                                        placeholder = ctx.t("LOGIN_USERNAME_PLACEHOLDER")
+                                        placeholder = identifierPlaceholder
                                         attributes["autocomplete"] =
-                                            if (passkeysEnabled) "username webauthn" else "username"
+                                            if (passkeysEnabled) "$autocompleteBase webauthn" else autocompleteBase
+                                        if (loginIdentifierMode == LoginIdentifierMode.EMAIL) {
+                                            attributes["inputmode"] = "email"
+                                        }
                                         required = true
                                         attributes["autofocus"] = "true"
                                     }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/AuthView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/AuthView.kt
@@ -128,7 +128,7 @@ object AuthView {
         passwordLoginEnabled: Boolean = true,
         emailOtpLoginEnabled: Boolean = false,
         passkeysEnabled: Boolean = false,
-        loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
+        loginIdentifierMode: LoginIdentifierMode,
     ): HTML.() -> Unit =
         {
             head { authHead(ctx.t("AUTH_PAGE_TITLE_LOGIN", ctx.workspaceName), ctx.theme) }

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -2,6 +2,7 @@ package com.kauth.adapter.web.auth
 
 import com.kauth.adapter.web.admin.resolvedBaseUrl
 import com.kauth.domain.model.GrantType
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.port.IdentityProviderRepository
 import com.kauth.domain.port.RateLimiterPort
 import com.kauth.domain.port.ResourceServerRepository
@@ -253,6 +254,8 @@ internal fun Route.oauthProtocolRoutes(
                         passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                         emailOtpLoginEnabled = tenant?.securityConfig?.emailOtpLoginEnabled == true,
                         passkeysEnabled = tenant?.passkeysEnabled == true,
+                        loginIdentifierMode =
+                            tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME,
                     ),
                 )
                 return@get
@@ -480,6 +483,7 @@ internal fun Route.oauthProtocolRoutes(
                 passwordLoginEnabled = tenant.securityConfig.passwordLoginEnabled,
                 emailOtpLoginEnabled = tenant.securityConfig.emailOtpLoginEnabled,
                 passkeysEnabled = tenant.passkeysEnabled,
+                loginIdentifierMode = tenant.securityConfig.loginIdentifierMode,
             ),
         )
     }
@@ -513,6 +517,8 @@ internal fun Route.oauthProtocolRoutes(
                     passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                     emailOtpLoginEnabled = tenant?.securityConfig?.emailOtpLoginEnabled == true,
                     passkeysEnabled = tenant?.passkeysEnabled == true,
+                    loginIdentifierMode =
+                        tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME,
                 ),
             )
         }
@@ -544,6 +550,8 @@ internal fun Route.oauthProtocolRoutes(
                         passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                         emailOtpLoginEnabled = tenant?.securityConfig?.emailOtpLoginEnabled == true,
                         passkeysEnabled = tenant?.passkeysEnabled == true,
+                        loginIdentifierMode =
+                            tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME,
                     ),
                 )
             }
@@ -583,6 +591,7 @@ internal fun Route.oauthProtocolRoutes(
                                     passwordLoginEnabled = tenant.securityConfig.passwordLoginEnabled,
                                     emailOtpLoginEnabled = tenant.securityConfig.emailOtpLoginEnabled,
                                     passkeysEnabled = tenant.passkeysEnabled,
+                                    loginIdentifierMode = tenant.securityConfig.loginIdentifierMode,
                                 ),
                             )
                         }
@@ -630,6 +639,7 @@ internal fun Route.oauthProtocolRoutes(
                                 passwordLoginEnabled = tenant.securityConfig.passwordLoginEnabled,
                                 emailOtpLoginEnabled = tenant.securityConfig.emailOtpLoginEnabled,
                                 passkeysEnabled = tenant.passkeysEnabled,
+                                loginIdentifierMode = tenant.securityConfig.loginIdentifierMode,
                             ),
                         )
                     },

--- a/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutes.kt
@@ -4,6 +4,7 @@ import com.kauth.adapter.web.EnglishStrings
 import com.kauth.domain.model.AuditEvent
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.BrokeredSignInFailure
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.port.AuditLogPort
@@ -265,6 +266,8 @@ private suspend fun ApplicationCall.allowSocialRequest(
             emptyList()
         }
     response.headers.append("Retry-After", "60")
+    // Tenant may be unresolved (unknown slug); USERNAME is the safe, mode-agnostic fallback.
+    val loginIdentifierMode = tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME
     respondHtml(
         HttpStatusCode.TooManyRequests,
         AuthView.loginPage(
@@ -274,6 +277,7 @@ private suspend fun ApplicationCall.allowSocialRequest(
             enabledProviders = enabledProviders,
             passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
             passkeysEnabled = tenant?.passkeysEnabled == true,
+            loginIdentifierMode = loginIdentifierMode,
         ),
     )
     return false
@@ -401,6 +405,9 @@ internal fun Route.socialLoginRoutes(
                         enabledProviders = enabledProviders,
                         passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                         passkeysEnabled = tenant?.passkeysEnabled == true,
+                        // Tenant may be unresolved (unknown slug); USERNAME is the safe fallback.
+                        loginIdentifierMode =
+                            tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME,
                     ),
                 )
             }
@@ -427,6 +434,8 @@ internal fun Route.socialLoginRoutes(
             } else {
                 emptyList()
             }
+        // Tenant may be unresolved (unknown slug); USERNAME is the safe, mode-agnostic fallback.
+        val loginIdentifierMode = tenant?.securityConfig?.loginIdentifierMode ?: LoginIdentifierMode.USERNAME
 
         if (socialLoginService == null) {
             return@get call.respond(HttpStatusCode.NotImplemented, mapOf("error" to "social_login_not_configured"))
@@ -473,6 +482,7 @@ internal fun Route.socialLoginRoutes(
                     enabledProviders = enabledProviders,
                     passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                     passkeysEnabled = tenant?.passkeysEnabled == true,
+                    loginIdentifierMode = loginIdentifierMode,
                 ),
             )
             return@get
@@ -494,6 +504,7 @@ internal fun Route.socialLoginRoutes(
                     enabledProviders = enabledProviders,
                     passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                     passkeysEnabled = tenant?.passkeysEnabled == true,
+                    loginIdentifierMode = loginIdentifierMode,
                 ),
             )
             return@get
@@ -516,6 +527,7 @@ internal fun Route.socialLoginRoutes(
                     enabledProviders = enabledProviders,
                     passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                     passkeysEnabled = tenant?.passkeysEnabled == true,
+                    loginIdentifierMode = loginIdentifierMode,
                 ),
             )
             return@get
@@ -541,6 +553,7 @@ internal fun Route.socialLoginRoutes(
                     enabledProviders = enabledProviders,
                     passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                     passkeysEnabled = tenant?.passkeysEnabled == true,
+                    loginIdentifierMode = loginIdentifierMode,
                 ),
             )
             return@get
@@ -586,6 +599,7 @@ internal fun Route.socialLoginRoutes(
                         enabledProviders = enabledProviders,
                         passwordLoginEnabled = tenant?.securityConfig?.passwordLoginEnabled != false,
                         passkeysEnabled = tenant?.passkeysEnabled == true,
+                        loginIdentifierMode = loginIdentifierMode,
                     ),
                 )
             }
@@ -659,6 +673,7 @@ internal fun Route.socialLoginRoutes(
                                     enabledProviders = enabledProviders,
                                     passwordLoginEnabled = activeTenant.securityConfig.passwordLoginEnabled,
                                     passkeysEnabled = activeTenant.passkeysEnabled,
+                                    loginIdentifierMode = activeTenant.securityConfig.loginIdentifierMode,
                                 ),
                             )
                         },

--- a/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/portal/PortalRoutes.kt
@@ -119,7 +119,12 @@ fun Route.portalRoutes(
                 val error = call.request.queryParameters["error"]
                 return@get call.respondHtml(
                     HttpStatusCode.OK,
-                    PortalView.loginPage(slug, call.portalViewContext(tenant), error),
+                    PortalView.loginPage(
+                        slug,
+                        call.portalViewContext(tenant),
+                        error,
+                        tenant.securityConfig.loginIdentifierMode,
+                    ),
                 )
             }
 

--- a/src/main/kotlin/com/kauth/adapter/web/portal/PortalView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/portal/PortalView.kt
@@ -8,6 +8,7 @@ import com.kauth.adapter.web.demoBanner
 import com.kauth.adapter.web.inlineSvgIcon
 import com.kauth.adapter.web.providerIconName
 import com.kauth.domain.model.Application
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.PortalLayout
 import com.kauth.domain.model.SecurityConfig
 import com.kauth.domain.model.SocialAccount
@@ -89,6 +90,7 @@ object PortalView {
         slug: String,
         ctx: ViewContext,
         error: String?,
+        loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
     ): HTML.() -> Unit =
         {
             head { authPageHead("${ctx.workspaceName} | ${ctx.t("PORTAL_LOGIN_SUBMIT")}", ctx.theme) }
@@ -110,15 +112,36 @@ object PortalView {
                         encType = FormEncType.applicationXWwwFormUrlEncoded,
                         method = FormMethod.post,
                     ) {
+                        val identifierLabel =
+                            when (loginIdentifierMode) {
+                                LoginIdentifierMode.USERNAME -> ctx.t("PORTAL_LOGIN_USERNAME")
+                                LoginIdentifierMode.EMAIL -> ctx.t("LOGIN_IDENTIFIER_EMAIL")
+                                LoginIdentifierMode.EITHER -> ctx.t("LOGIN_IDENTIFIER_EITHER")
+                            }
+                        val identifierPlaceholder =
+                            when (loginIdentifierMode) {
+                                LoginIdentifierMode.USERNAME -> ctx.t("PORTAL_LOGIN_USERNAME_PLACEHOLDER")
+                                LoginIdentifierMode.EMAIL -> ctx.t("LOGIN_IDENTIFIER_EMAIL_PLACEHOLDER")
+                                LoginIdentifierMode.EITHER -> ctx.t("LOGIN_IDENTIFIER_EITHER_PLACEHOLDER")
+                            }
+                        // EITHER stays type=text: type=email would let native validation
+                        // block a legitimate username from being submitted at all.
+                        val identifierType =
+                            if (loginIdentifierMode == LoginIdentifierMode.EMAIL) InputType.email else InputType.text
+                        val autocompleteBase =
+                            if (loginIdentifierMode == LoginIdentifierMode.EMAIL) "email" else "username"
                         div("field") {
                             label {
                                 htmlFor = "username"
-                                +ctx.t("PORTAL_LOGIN_USERNAME")
+                                +identifierLabel
                             }
-                            input(type = InputType.text, name = "username") {
+                            input(type = identifierType, name = "username") {
                                 id = "username"
-                                placeholder = ctx.t("PORTAL_LOGIN_USERNAME_PLACEHOLDER")
-                                attributes["autocomplete"] = "username"
+                                placeholder = identifierPlaceholder
+                                attributes["autocomplete"] = autocompleteBase
+                                if (loginIdentifierMode == LoginIdentifierMode.EMAIL) {
+                                    attributes["inputmode"] = "email"
+                                }
                                 required = true
                                 attributes["autofocus"] = "true"
                             }

--- a/src/main/kotlin/com/kauth/adapter/web/portal/PortalView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/portal/PortalView.kt
@@ -90,7 +90,7 @@ object PortalView {
         slug: String,
         ctx: ViewContext,
         error: String?,
-        loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
+        loginIdentifierMode: LoginIdentifierMode,
     ): HTML.() -> Unit =
         {
             head { authPageHead("${ctx.workspaceName} | ${ctx.t("PORTAL_LOGIN_SUBMIT")}", ctx.theme) }

--- a/src/main/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutes.kt
@@ -173,7 +173,11 @@ private fun userSchema(): JsonObject =
                         name = "userName",
                         type = "string",
                         required = true,
-                        caseExact = true,
+                        // Storage is always lowercase and matching is case-insensitive end to
+                        // end (ScimUserMapper normalizes on write, PostgresUserRepository's
+                        // lookup is IgnoreCase) — a connector resending its original mixed-case
+                        // value must resolve to the same user, not a "not found" or a rename.
+                        caseExact = false,
                         mutability = "immutable",
                         uniqueness = "server",
                         description = "Unique identifier for the user, used to log in. Immutable once created.",

--- a/src/main/kotlin/com/kauth/adapter/web/scim/ScimUserRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/scim/ScimUserRoutes.kt
@@ -21,6 +21,7 @@ import com.kauth.domain.scim.parseFilter
 import com.kauth.domain.service.AdminError
 import com.kauth.domain.service.AdminResult
 import com.kauth.domain.service.AdminUserService
+import com.kauth.domain.service.UsernamePolicy
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -295,7 +296,10 @@ private fun lookupFastPath(
     literal: String,
 ): User? =
     when (attr) {
-        "userName" -> adminUserService.findByUsername(tenantId, literal)
+        // Case-insensitive: storage is always lowercase, but a connector may resend the
+        // mixed-case value it originally submitted (e.g. an Okta/Entra UPN), and a
+        // case-sensitive lookup here would tell it the user it just created doesn't exist.
+        "userName" -> adminUserService.findByUsernameIgnoreCase(tenantId, literal)
         "externalId" -> adminUserService.findByExternalId(tenantId, literal)
         "id" ->
             literal.toIntOrNull()?.let { idValue ->
@@ -391,12 +395,17 @@ private fun <T> runScimTransaction(
         AdminResult.Failure(e.error)
     }
 
-/** `userName` is the SCIM correlation key; a PUT/PATCH that tries to change it is rejected, never silently dropped. */
+/**
+ * `userName` is the SCIM correlation key; a PUT/PATCH that tries to change it is rejected, never
+ * silently dropped. Both sides are compared normalized (see [UsernamePolicy]) — [existingUsername]
+ * is already stored normalized, but comparing raw would treat a connector resubmitting the same
+ * username in different case (e.g. `Dave.Smith` after it was stored as `dave.smith`) as a rename.
+ */
 private suspend fun ApplicationCall.rejectUsernameRename(
     existingUsername: String,
     write: ScimUserWrite,
 ): Unit? {
-    if (write.user.username == existingUsername) return Unit
+    if (UsernamePolicy.normalize(write.user.username) == UsernamePolicy.normalize(existingUsername)) return Unit
     val (status, body) =
         ScimFailure(
             ScimErrorType.mutability,

--- a/src/main/kotlin/com/kauth/cli/ResetAdminMfaCommand.kt
+++ b/src/main/kotlin/com/kauth/cli/ResetAdminMfaCommand.kt
@@ -5,6 +5,7 @@ import com.kauth.adapter.persistence.MfaRecoveryCodesTable
 import com.kauth.adapter.persistence.TenantsTable
 import com.kauth.adapter.persistence.UsersTable
 import com.kauth.config.DbConfig
+import com.kauth.domain.service.UsernamePolicy
 import com.kauth.infrastructure.DatabaseFactory
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
@@ -13,7 +14,9 @@ import kotlin.system.exitProcess
 
 object ResetAdminMfaCommand {
     fun execute(args: List<String>) {
-        val username = parseUsername(args)
+        // Usernames are always stored normalized (see UsernamePolicy) — this break-glass lookup
+        // must match the same way, or an operator's `USER=Admin` fails after V66 rewrites the row.
+        val username = parseUsername(args)?.let { UsernamePolicy.normalize(it) }
         if (username == null) {
             System.err.println("Usage: cli reset-admin-mfa --username=<admin-username>")
             exitProcess(1)

--- a/src/main/kotlin/com/kauth/cli/ResetAdminPasskeysCommand.kt
+++ b/src/main/kotlin/com/kauth/cli/ResetAdminPasskeysCommand.kt
@@ -2,13 +2,16 @@ package com.kauth.cli
 
 import com.kauth.config.EnvironmentConfig
 import com.kauth.config.ServiceGraph
+import com.kauth.domain.service.UsernamePolicy
 import com.kauth.domain.service.WebAuthnResult
 import com.kauth.infrastructure.DatabaseFactory
 import kotlin.system.exitProcess
 
 object ResetAdminPasskeysCommand {
     fun execute(args: List<String>) {
-        val username = parseUsername(args)
+        // Usernames are always stored normalized (see UsernamePolicy) — this break-glass lookup
+        // must match the same way, or an operator's `USER=Admin` fails after V66 rewrites the row.
+        val username = parseUsername(args)?.let { UsernamePolicy.normalize(it) }
         if (username == null) {
             System.err.println("Usage: cli reset-admin-passkeys --username=<admin-username>")
             exitProcess(1)

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -515,6 +515,7 @@ data class ServiceGraph(
                             tokenValidator = oidcTokenValidator,
                             formPoster = JdkHttpFormPoster(),
                         ),
+                    collisionCheck = identifierCollisionCheck,
                     applicationRepository = applicationRepository,
                     roleRepository = roleRepository,
                     jitProvisioning = jitProvisioningService,

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -89,6 +89,7 @@ import com.kauth.domain.service.RoleGroupService
 import com.kauth.domain.service.SecurityMethodsService
 import com.kauth.domain.service.SocialLoginService
 import com.kauth.domain.service.UserAttributeService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.domain.service.WebAuthnService
 import com.kauth.domain.service.WebhookService
 import com.kauth.domain.service.WorkspaceSettingsService
@@ -334,6 +335,7 @@ data class ServiceGraph(
                     passwordPolicy = passwordPolicyAdapter,
                     emailScope = applicationScope,
                 )
+            val identifierResolver = UserIdentifierResolver(userRepository)
             val authService =
                 AuthService(
                     userRepository = userRepository,
@@ -346,6 +348,7 @@ data class ServiceGraph(
                     passwordPolicy = passwordPolicyAdapter,
                     applicationRepository = applicationRepository,
                     roleRepository = roleRepository,
+                    identifierResolver = identifierResolver,
                 )
             // -- User attributes + claim mapping ------------------------------
             val userAttributeService =

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -75,6 +75,7 @@ import com.kauth.domain.service.BackupImporterService
 import com.kauth.domain.service.CorsService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.EmailOtpService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.IdentityProviderProbeService
 import com.kauth.domain.service.IdentityProviderService
 import com.kauth.domain.service.ImpersonationService
@@ -405,6 +406,7 @@ data class ServiceGraph(
                     auditLog = auditLogAdapter,
                     corsPort = corsOriginCache,
                 )
+            val identifierCollisionCheck = IdentifierCollisionCheck(userRepository)
             val adminUserService =
                 AdminUserService(
                     tenantRepository = tenantRepository,
@@ -413,6 +415,7 @@ data class ServiceGraph(
                     passwordHasher = passwordHasher,
                     auditLog = auditLogAdapter,
                     credentialFlowService = credentialFlowService,
+                    collisionCheck = identifierCollisionCheck,
                     passwordPolicy = passwordPolicyAdapter,
                     emailPort = emailAdapter,
                 )

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -338,6 +338,7 @@ data class ServiceGraph(
                     emailScope = applicationScope,
                 )
             val identifierResolver = UserIdentifierResolver(userRepository)
+            val identifierCollisionCheck = IdentifierCollisionCheck(userRepository)
             val authService =
                 AuthService(
                     userRepository = userRepository,
@@ -351,6 +352,7 @@ data class ServiceGraph(
                     applicationRepository = applicationRepository,
                     roleRepository = roleRepository,
                     identifierResolver = identifierResolver,
+                    collisionCheck = identifierCollisionCheck,
                 )
             // -- User attributes + claim mapping ------------------------------
             val userAttributeService =
@@ -407,7 +409,6 @@ data class ServiceGraph(
                     auditLog = auditLogAdapter,
                     corsPort = corsOriginCache,
                 )
-            val identifierCollisionCheck = IdentifierCollisionCheck(userRepository)
             val usernameGenerator = UsernameGenerator(userRepository)
             val adminUserService =
                 AdminUserService(

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -91,6 +91,7 @@ import com.kauth.domain.service.SecurityMethodsService
 import com.kauth.domain.service.SocialLoginService
 import com.kauth.domain.service.UserAttributeService
 import com.kauth.domain.service.UserIdentifierResolver
+import com.kauth.domain.service.UsernameGenerator
 import com.kauth.domain.service.WebAuthnService
 import com.kauth.domain.service.WebhookService
 import com.kauth.domain.service.WorkspaceSettingsService
@@ -407,6 +408,7 @@ data class ServiceGraph(
                     corsPort = corsOriginCache,
                 )
             val identifierCollisionCheck = IdentifierCollisionCheck(userRepository)
+            val usernameGenerator = UsernameGenerator(userRepository)
             val adminUserService =
                 AdminUserService(
                     tenantRepository = tenantRepository,
@@ -416,6 +418,7 @@ data class ServiceGraph(
                     auditLog = auditLogAdapter,
                     credentialFlowService = credentialFlowService,
                     collisionCheck = identifierCollisionCheck,
+                    usernameGenerator = usernameGenerator,
                     passwordPolicy = passwordPolicyAdapter,
                     emailPort = emailAdapter,
                 )

--- a/src/main/kotlin/com/kauth/domain/model/BackupExport.kt
+++ b/src/main/kotlin/com/kauth/domain/model/BackupExport.kt
@@ -107,6 +107,7 @@ data class SecurityConfigBackup(
     val emailOtpSignupEnabled: Boolean = false,
     val emailOtpLockoutThreshold: Int = 5,
     val emailOtpLoginEnabled: Boolean = false,
+    val loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
 )
 
 @Serializable

--- a/src/main/kotlin/com/kauth/domain/model/LoginIdentifierMode.kt
+++ b/src/main/kotlin/com/kauth/domain/model/LoginIdentifierMode.kt
@@ -1,0 +1,22 @@
+package com.kauth.domain.model
+
+/**
+ * What a user types in the identifier field of the hosted login form.
+ *
+ * Per-tenant, stored on [SecurityConfig]. Defaults to [USERNAME] so an upgrade
+ * never widens an existing workspace's authentication surface.
+ */
+enum class LoginIdentifierMode {
+    USERNAME,
+    EMAIL,
+
+    /** Username is tried first; email second. Never short-circuits — see UserIdentifierResolver. */
+    EITHER,
+    ;
+
+    companion object {
+        /** Parses persisted/form values, falling back to [USERNAME] for anything unrecognised. */
+        fun fromStorage(raw: String?): LoginIdentifierMode =
+            entries.firstOrNull { it.name.equals(raw?.trim(), ignoreCase = true) } ?: USERNAME
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/model/LoginIdentifierMode.kt
+++ b/src/main/kotlin/com/kauth/domain/model/LoginIdentifierMode.kt
@@ -18,5 +18,13 @@ enum class LoginIdentifierMode {
         /** Parses persisted/form values, falling back to [USERNAME] for anything unrecognised. */
         fun fromStorage(raw: String?): LoginIdentifierMode =
             entries.firstOrNull { it.name.equals(raw?.trim(), ignoreCase = true) } ?: USERNAME
+
+        /**
+         * Parses a submitted form value, returning null for anything unrecognised instead of
+         * coercing to [USERNAME]. Use this where a present-but-invalid value must be rejected
+         * rather than silently swapped for a mode the operator did not choose.
+         */
+        fun parseOrNull(raw: String?): LoginIdentifierMode? =
+            entries.firstOrNull { it.name.equals(raw?.trim(), ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
+++ b/src/main/kotlin/com/kauth/domain/model/SecurityConfig.kt
@@ -37,6 +37,8 @@ data class SecurityConfig(
     // Cross-challenge failed-OTP threshold. 0 disables.
     val emailOtpLockoutThreshold: Int = 5,
     val emailOtpLoginEnabled: Boolean = false,
+    // Which identifier the hosted login form accepts. USERNAME preserves pre-1.24 behaviour.
+    val loginIdentifierMode: LoginIdentifierMode = LoginIdentifierMode.USERNAME,
 ) {
     val isLockoutEnabled: Boolean get() = lockoutMaxAttempts > 0
 }

--- a/src/main/kotlin/com/kauth/domain/model/WorkspaceSettingsUpdate.kt
+++ b/src/main/kotlin/com/kauth/domain/model/WorkspaceSettingsUpdate.kt
@@ -26,6 +26,7 @@ data class WorkspaceSettingsUpdate(
     val emailOtpLockoutThreshold: Int,
     val emailOtpLoginEnabled: Boolean,
     val passkeysEnabled: Boolean,
+    val loginIdentifierMode: LoginIdentifierMode,
 ) {
     companion object {
         fun from(tenant: Tenant): WorkspaceSettingsUpdate {
@@ -56,6 +57,7 @@ data class WorkspaceSettingsUpdate(
                 emailOtpLockoutThreshold = s.emailOtpLockoutThreshold,
                 emailOtpLoginEnabled = s.emailOtpLoginEnabled,
                 passkeysEnabled = tenant.passkeysEnabled,
+                loginIdentifierMode = s.loginIdentifierMode,
             )
         }
     }

--- a/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
@@ -20,6 +20,19 @@ interface UserRepository {
         username: String,
     ): User?
 
+    /**
+     * Case-insensitive username lookup. Usernames are stored as-is and [findByUsername] is an
+     * exact match, but emails are lowercased on write — so matching a submitted email against
+     * existing usernames (as [com.kauth.domain.service.IdentifierCollisionCheck] does) must
+     * ignore case on both sides or a differently-cased pair slips through. Not for sign-in
+     * resolution: [com.kauth.domain.service.UserIdentifierResolver] intentionally keeps using the
+     * case-sensitive [findByUsername].
+     */
+    fun findByUsernameIgnoreCase(
+        tenantId: TenantId,
+        username: String,
+    ): User?
+
     fun findByEmail(
         tenantId: TenantId,
         email: String,

--- a/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
@@ -15,18 +15,25 @@ interface UserRepository {
         tenantId: TenantId,
     ): User?
 
+    /**
+     * Exact-match username lookup. Usernames are stored normalized (trimmed, lowercased) by
+     * every write path, so this is effectively case-insensitive from a caller that also
+     * normalizes its input before calling — which is what
+     * [com.kauth.domain.service.UserIdentifierResolver] does for sign-in: it lowercases the
+     * submitted identifier first, then calls this exact-match method.
+     */
     fun findByUsername(
         tenantId: TenantId,
         username: String,
     ): User?
 
     /**
-     * Case-insensitive username lookup. Usernames are stored as-is and [findByUsername] is an
-     * exact match, but emails are lowercased on write — so matching a submitted email against
-     * existing usernames (as [com.kauth.domain.service.IdentifierCollisionCheck] does) must
-     * ignore case on both sides or a differently-cased pair slips through. Not for sign-in
-     * resolution: [com.kauth.domain.service.UserIdentifierResolver] intentionally keeps using the
-     * case-sensitive [findByUsername].
+     * Case-insensitive username lookup, for callers that cannot first normalize their input.
+     * Emails are lowercased on write but are a separate namespace from usernames, so matching a
+     * submitted email against existing usernames (as
+     * [com.kauth.domain.service.IdentifierCollisionCheck] does) must ignore case explicitly
+     * rather than relying on the input already being lowercase — this method exists for exactly
+     * that comparison. Sign-in does not need it: see [findByUsername].
      */
     fun findByUsernameIgnoreCase(
         tenantId: TenantId,
@@ -64,9 +71,14 @@ interface UserRepository {
         search: String? = null,
     ): Long
 
+    /** Persists [user] verbatim — callers must pass an already-normalized (trimmed, lowercased) username. */
     fun save(user: User): User
 
-    /** Updates mutable profile fields (username, email, fullName, emailVerified, enabled). */
+    /**
+     * Updates mutable profile fields (username, email, fullName, emailVerified, enabled).
+     * Persists [user]'s username verbatim — callers must pass an already-normalized
+     * (trimmed, lowercased) value.
+     */
     fun update(user: User): User
 
     /**

--- a/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/UserRepository.kt
@@ -66,7 +66,7 @@ interface UserRepository {
 
     fun save(user: User): User
 
-    /** Updates mutable profile fields (email, fullName, emailVerified, enabled). Username is immutable. */
+    /** Updates mutable profile fields (username, email, fullName, emailVerified, enabled). */
     fun update(user: User): User
 
     /**

--- a/src/main/kotlin/com/kauth/domain/scim/ScimUserMapper.kt
+++ b/src/main/kotlin/com/kauth/domain/scim/ScimUserMapper.kt
@@ -3,6 +3,7 @@ package com.kauth.domain.scim
 import com.kauth.domain.model.Group
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.User
+import com.kauth.domain.service.UsernamePolicy
 
 private const val USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
 
@@ -129,9 +130,30 @@ object ScimUserMapper {
         // or, for `active`, silently leaves an account enabled after a deprovision.
         resource.validateAttributeShapes(ScimResourceScope.USER).getOrElse { return Result.failure(it) }
 
-        val username = (resource.attributes["userName"] as? ScimValue.Str)?.value?.trim()
-        if (username.isNullOrEmpty()) {
+        val suppliedUsername = (resource.attributes["userName"] as? ScimValue.Str)?.value?.trim()
+        if (suppliedUsername.isNullOrEmpty()) {
             return Result.failure(ScimFailure(ScimErrorType.invalidValue, "userName is required"))
+        }
+        // Same normalization every other write path applies (see UsernamePolicy) — usernames are
+        // ALWAYS stored trimmed and lowercased. A connector deserves a diagnostic naming exactly
+        // why its value was refused, not a silent rewrite it can't detect from the 200 response.
+        val username = UsernamePolicy.normalize(suppliedUsername)
+        when (UsernamePolicy.validate(username)) {
+            UsernamePolicy.Violation.INVALID_FORMAT ->
+                return Result.failure(
+                    ScimFailure(
+                        ScimErrorType.invalidValue,
+                        "userName may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                    ),
+                )
+            UsernamePolicy.Violation.TOO_LONG ->
+                return Result.failure(
+                    ScimFailure(
+                        ScimErrorType.invalidValue,
+                        "userName must be ${UsernamePolicy.MAX_LENGTH} characters or fewer.",
+                    ),
+                )
+            null -> Unit
         }
 
         // `name` is singular complex (RFC 7643 §4.1.1); a scalar written over it is rejected by

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -27,11 +27,6 @@ class AdminUserService(
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val emailPort: EmailPort? = null,
 ) {
-    private companion object {
-        /** Shared by [createUser] and [updateUser] so the two paths cannot drift apart. */
-        val USERNAME_PATTERN = Regex("[a-zA-Z0-9._@+-]+")
-    }
-
     fun createUser(
         tenantId: TenantId,
         username: String,
@@ -61,9 +56,9 @@ class AdminUserService(
             if (username.isBlank()) {
                 usernameGenerator.generate(tenantId, givenName, resolvedEmail)
             } else {
-                username.trim()
+                UsernamePolicy.normalize(username)
             }
-        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
+        if (!resolvedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
             return AdminResult.Failure(
                 AdminError.Validation(
                     "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
@@ -451,11 +446,12 @@ class AdminUserService(
      * username or email — the two call sites cannot drift apart on what a rename is allowed to do.
      *
      * Format and collision checks on the username itself only run when a rename is actually
-     * requested. A stored username can predate this feature (or any format validation at all —
-     * see `AuthService.register` and `BackupImporterService`), so re-validating it on every
-     * unrelated field update would make such a user permanently un-editable. The email→username
-     * collision direction still runs unconditionally, because the email is written on every call
-     * regardless of whether a rename was requested.
+     * requested. Every write path now normalizes and validates (see [UsernamePolicy]), but a
+     * stored username can still predate that guarantee on a database that has not yet run the
+     * V66 normalization migration, so re-validating it on every unrelated field update would make
+     * such a user permanently un-editable until then. The email→username collision direction still
+     * runs unconditionally, because the email is written on every call regardless of whether a
+     * rename was requested.
      */
     private fun resolveUsername(
         tenantId: TenantId,
@@ -464,8 +460,8 @@ class AdminUserService(
         username: String?,
         resolvedEmail: String,
     ): AdminResult<String> {
-        val trimmed = username?.trim()
-        val renaming = trimmed != null && trimmed != user.username
+        val normalized = username?.let { UsernamePolicy.normalize(it) }
+        val renaming = normalized != null && normalized != user.username
 
         if (!renaming) {
             collisionCheck
@@ -474,12 +470,12 @@ class AdminUserService(
             return AdminResult.Success(user.username)
         }
 
-        val resolvedUsername = trimmed
+        val resolvedUsername = normalized
 
         if (resolvedUsername.isBlank()) {
             return AdminResult.Failure(AdminError.Validation("Username is required."))
         }
-        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
+        if (!resolvedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
             return AdminResult.Failure(
                 AdminError.Validation(
                     "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -22,6 +22,7 @@ class AdminUserService(
     private val passwordHasher: PasswordHasher,
     private val auditLog: AuditLogPort,
     private val credentialFlowService: CredentialFlowService,
+    private val collisionCheck: IdentifierCollisionCheck,
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val emailPort: EmailPort? = null,
 ) {
@@ -58,6 +59,11 @@ class AdminUserService(
         if (email.isBlank() || !email.contains('@')) {
             return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
         }
+        val resolvedEmail = email.trim().lowercase()
+
+        collisionCheck
+            .check(tenantId, username.trim(), resolvedEmail)
+            ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
 
         val resolvedPasswordHash: String
         val resolvedRequiredActions: Set<RequiredAction>

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -449,6 +449,13 @@ class AdminUserService(
      * Shared by [updateUser] and [replaceUserProfile]: resolves an optional username edit
      * (null means unchanged), validates format, and rejects a collision with another user's
      * username or email — the two call sites cannot drift apart on what a rename is allowed to do.
+     *
+     * Format and collision checks on the username itself only run when a rename is actually
+     * requested. A stored username can predate this feature (or any format validation at all —
+     * see `AuthService.register` and `BackupImporterService`), so re-validating it on every
+     * unrelated field update would make such a user permanently un-editable. The email→username
+     * collision direction still runs unconditionally, because the email is written on every call
+     * regardless of whether a rename was requested.
      */
     private fun resolveUsername(
         tenantId: TenantId,
@@ -457,7 +464,17 @@ class AdminUserService(
         username: String?,
         resolvedEmail: String,
     ): AdminResult<String> {
-        val resolvedUsername = username?.trim() ?: user.username
+        val trimmed = username?.trim()
+        val renaming = trimmed != null && trimmed != user.username
+
+        if (!renaming) {
+            collisionCheck
+                .check(tenantId, username = null, email = resolvedEmail, excludingUserId = userId)
+                ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+            return AdminResult.Success(user.username)
+        }
+
+        val resolvedUsername = trimmed
 
         if (resolvedUsername.isBlank()) {
             return AdminResult.Failure(AdminError.Validation("Username is required."))
@@ -469,7 +486,7 @@ class AdminUserService(
                 ),
             )
         }
-        if (resolvedUsername != user.username && userRepository.existsByUsername(tenantId, resolvedUsername)) {
+        if (userRepository.existsByUsername(tenantId, resolvedUsername)) {
             return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))
         }
 

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -23,6 +23,7 @@ class AdminUserService(
     private val auditLog: AuditLogPort,
     private val credentialFlowService: CredentialFlowService,
     private val collisionCheck: IdentifierCollisionCheck,
+    private val usernameGenerator: UsernameGenerator,
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val emailPort: EmailPort? = null,
 ) {
@@ -46,23 +47,27 @@ class AdminUserService(
             tenantRepository.findById(tenantId)
                 ?: return AdminResult.Failure(AdminError.NotFound("Workspace not found."))
 
-        if (username.isBlank()) {
-            return AdminResult.Failure(AdminError.Validation("Username is required."))
+        if (email.isBlank() || !email.contains('@')) {
+            return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
         }
-        if (!username.matches(Regex("[a-zA-Z0-9._@+-]+"))) {
+        val resolvedEmail = email.trim().lowercase()
+
+        val resolvedUsername =
+            if (username.isBlank()) {
+                usernameGenerator.generate(tenantId, givenName, resolvedEmail)
+            } else {
+                username.trim()
+            }
+        if (!resolvedUsername.matches(Regex("[a-zA-Z0-9._@+-]+"))) {
             return AdminResult.Failure(
                 AdminError.Validation(
                     "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
                 ),
             )
         }
-        if (email.isBlank() || !email.contains('@')) {
-            return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
-        }
-        val resolvedEmail = email.trim().lowercase()
 
         collisionCheck
-            .check(tenantId, username.trim(), resolvedEmail)
+            .check(tenantId, resolvedUsername, resolvedEmail)
             ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
 
         val resolvedPasswordHash: String
@@ -96,19 +101,19 @@ class AdminUserService(
             resolvedRequiredActions = emptySet()
         }
 
-        if (userRepository.existsByUsername(tenantId, username)) {
-            return AdminResult.Failure(AdminError.Conflict("Username '$username' is already taken."))
+        if (userRepository.existsByUsername(tenantId, resolvedUsername)) {
+            return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))
         }
-        if (userRepository.existsByEmail(tenantId, email)) {
-            return AdminResult.Failure(AdminError.Conflict("Email '${email.lowercase()}' is already registered."))
+        if (userRepository.existsByEmail(tenantId, resolvedEmail)) {
+            return AdminResult.Failure(AdminError.Conflict("Email '$resolvedEmail' is already registered."))
         }
 
         val user =
             userRepository.save(
                 User(
                     tenantId = tenantId,
-                    username = username.trim(),
-                    email = email.trim().lowercase(),
+                    username = resolvedUsername,
+                    email = resolvedEmail,
                     fullName = fullName.trim(),
                     passwordHash = resolvedPasswordHash,
                     emailVerified = !sendInvite,
@@ -132,7 +137,7 @@ class AdminUserService(
                 eventType = AuditEventType.ADMIN_USER_CREATED,
                 ipAddress = null,
                 userAgent = null,
-                details = mapOf("username" to username, "invite" to sendInvite.toString()),
+                details = mapOf("username" to resolvedUsername, "invite" to sendInvite.toString()),
             ),
         )
 

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -348,33 +348,19 @@ class AdminUserService(
 
         val resolvedEmail = email?.trim()?.lowercase() ?: user.email
         val resolvedFullName = fullName?.trim() ?: user.fullName
-        val resolvedUsername = username?.trim() ?: user.username
 
         if (resolvedEmail.isBlank() || !resolvedEmail.contains('@')) {
             return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
         }
-
-        if (resolvedUsername.isBlank()) {
-            return AdminResult.Failure(AdminError.Validation("Username is required."))
-        }
-        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
-            return AdminResult.Failure(
-                AdminError.Validation(
-                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
-                ),
-            )
-        }
-
         if (resolvedEmail != user.email && userRepository.existsByEmail(tenantId, resolvedEmail)) {
             return AdminResult.Failure(AdminError.Conflict("Email '$resolvedEmail' is already registered."))
         }
-        if (resolvedUsername != user.username && userRepository.existsByUsername(tenantId, resolvedUsername)) {
-            return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))
-        }
 
-        collisionCheck
-            .check(tenantId, resolvedUsername, resolvedEmail, excludingUserId = userId)
-            ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+        val resolvedUsername =
+            when (val r = resolveUsername(tenantId, userId, user, username, resolvedEmail)) {
+                is AdminResult.Failure -> return r
+                is AdminResult.Success -> r.value
+            }
 
         val updated =
             userRepository.update(
@@ -389,7 +375,7 @@ class AdminUserService(
                 eventType = AuditEventType.ADMIN_USER_UPDATED,
                 ipAddress = null,
                 userAgent = null,
-                details = mapOf("username" to user.username),
+                details = usernameChangeAuditDetails(user, resolvedUsername),
             ),
         )
 
@@ -397,9 +383,12 @@ class AdminUserService(
     }
 
     /**
-     * Replaces the full mutable profile in one write. Unlike [updateUser], every parameter here
-     * is authoritative — a null clears the field. Used by the SCIM PUT/PATCH flow and by the admin
-     * profile form, both of which supply a fully resolved desired state rather than a partial edit.
+     * Replaces the full mutable profile in one write. Unlike [updateUser], `email`, `fullName`,
+     * `externalId`, `givenName`, and `familyName` are all authoritative — a null clears the field.
+     * `username` alone keeps [updateUser]'s null-means-unchanged convention, since SCIM never
+     * supplies it (`userName` stays immutable over the SCIM protocol surface — see
+     * ScimDiscoveryRoutes) and only the admin UI's profile form does, alongside the rest of the
+     * profile, so a rename cannot land as two separate writes with two different failure windows.
      */
     fun replaceUserProfile(
         userId: UserId,
@@ -409,6 +398,7 @@ class AdminUserService(
         externalId: String?,
         givenName: String?,
         familyName: String?,
+        username: String? = null,
     ): AdminResult<User> {
         val user =
             userRepository.findById(userId, tenantId)
@@ -422,6 +412,12 @@ class AdminUserService(
             return AdminResult.Failure(AdminError.Conflict("Email '$resolvedEmail' is already registered."))
         }
 
+        val resolvedUsername =
+            when (val r = resolveUsername(tenantId, userId, user, username, resolvedEmail)) {
+                is AdminResult.Failure -> return r
+                is AdminResult.Success -> r.value
+            }
+
         val updated =
             userRepository.update(
                 user.copy(
@@ -430,6 +426,7 @@ class AdminUserService(
                     externalId = externalId,
                     givenName = givenName,
                     familyName = familyName,
+                    username = resolvedUsername,
                 ),
             )
 
@@ -441,12 +438,62 @@ class AdminUserService(
                 eventType = AuditEventType.ADMIN_USER_UPDATED,
                 ipAddress = null,
                 userAgent = null,
-                details = mapOf("username" to user.username),
+                details = usernameChangeAuditDetails(user, resolvedUsername),
             ),
         )
 
         return AdminResult.Success(updated)
     }
+
+    /**
+     * Shared by [updateUser] and [replaceUserProfile]: resolves an optional username edit
+     * (null means unchanged), validates format, and rejects a collision with another user's
+     * username or email — the two call sites cannot drift apart on what a rename is allowed to do.
+     */
+    private fun resolveUsername(
+        tenantId: TenantId,
+        userId: UserId,
+        user: User,
+        username: String?,
+        resolvedEmail: String,
+    ): AdminResult<String> {
+        val resolvedUsername = username?.trim() ?: user.username
+
+        if (resolvedUsername.isBlank()) {
+            return AdminResult.Failure(AdminError.Validation("Username is required."))
+        }
+        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
+            return AdminResult.Failure(
+                AdminError.Validation(
+                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                ),
+            )
+        }
+        if (resolvedUsername != user.username && userRepository.existsByUsername(tenantId, resolvedUsername)) {
+            return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))
+        }
+
+        collisionCheck
+            .check(tenantId, resolvedUsername, resolvedEmail, excludingUserId = userId)
+            ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+
+        return AdminResult.Success(resolvedUsername)
+    }
+
+    /**
+     * The pre-rename username always identifies which row was touched. When a rename actually
+     * happened, the new value is added alongside it so an investigator can tell a username changed
+     * — and to what — without diffing database snapshots.
+     */
+    private fun usernameChangeAuditDetails(
+        user: User,
+        resolvedUsername: String,
+    ): Map<String, String> =
+        if (resolvedUsername != user.username) {
+            mapOf("username" to user.username, "newUsername" to resolvedUsername)
+        } else {
+            mapOf("username" to user.username)
+        }
 
     fun setUserEnabled(
         userId: UserId,

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -58,17 +58,18 @@ class AdminUserService(
             } else {
                 UsernamePolicy.normalize(username)
             }
-        if (!resolvedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
-            return AdminResult.Failure(
-                AdminError.Validation(
-                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
-                ),
-            )
-        }
-        if (resolvedUsername.length > UsernamePolicy.MAX_LENGTH) {
-            return AdminResult.Failure(
-                AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
-            )
+        when (UsernamePolicy.validate(resolvedUsername)) {
+            UsernamePolicy.Violation.INVALID_FORMAT ->
+                return AdminResult.Failure(
+                    AdminError.Validation(
+                        "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                    ),
+                )
+            UsernamePolicy.Violation.TOO_LONG ->
+                return AdminResult.Failure(
+                    AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
+                )
+            null -> Unit
         }
 
         collisionCheck
@@ -261,6 +262,17 @@ class AdminUserService(
         tenantId: TenantId,
         username: String,
     ): User? = userRepository.findByUsername(tenantId, username)
+
+    /**
+     * Case-insensitive tenant-scoped username lookup — the indexed fast path for SCIM's
+     * `userName eq` filter. Storage is always lowercase (see [UsernamePolicy]), but a connector
+     * may resend the mixed-case value it originally submitted (e.g. an Okta/Entra UPN like
+     * `Dave.Smith@corp.com`), and a case-sensitive lookup would tell it that user doesn't exist.
+     */
+    fun findByUsernameIgnoreCase(
+        tenantId: TenantId,
+        username: String,
+    ): User? = userRepository.findByUsernameIgnoreCase(tenantId, username)
 
     /** Tenant-scoped external-id lookup — the indexed fast path for SCIM's `externalId eq` filter. */
     fun findByExternalId(
@@ -483,17 +495,18 @@ class AdminUserService(
         if (resolvedUsername.isBlank()) {
             return AdminResult.Failure(AdminError.Validation("Username is required."))
         }
-        if (!resolvedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
-            return AdminResult.Failure(
-                AdminError.Validation(
-                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
-                ),
-            )
-        }
-        if (resolvedUsername.length > UsernamePolicy.MAX_LENGTH) {
-            return AdminResult.Failure(
-                AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
-            )
+        when (UsernamePolicy.validate(resolvedUsername)) {
+            UsernamePolicy.Violation.INVALID_FORMAT ->
+                return AdminResult.Failure(
+                    AdminError.Validation(
+                        "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                    ),
+                )
+            UsernamePolicy.Violation.TOO_LONG ->
+                return AdminResult.Failure(
+                    AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
+                )
+            null -> Unit
         }
         if (userRepository.existsByUsername(tenantId, resolvedUsername)) {
             return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -65,6 +65,11 @@ class AdminUserService(
                 ),
             )
         }
+        if (resolvedUsername.length > UsernamePolicy.MAX_LENGTH) {
+            return AdminResult.Failure(
+                AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
+            )
+        }
 
         collisionCheck
             .check(tenantId, resolvedUsername, resolvedEmail)
@@ -449,9 +454,10 @@ class AdminUserService(
      * requested. Every write path now normalizes and validates (see [UsernamePolicy]), but a
      * stored username can still predate that guarantee on a database that has not yet run the
      * V66 normalization migration, so re-validating it on every unrelated field update would make
-     * such a user permanently un-editable until then. The email→username collision direction still
-     * runs unconditionally, because the email is written on every call regardless of whether a
-     * rename was requested.
+     * such a user permanently un-editable until then. The email→username collision direction is
+     * independent of that: it runs whenever the email is actually changing, rename or not — a
+     * user whose stored email happens to equal a different user's username must still be able to
+     * update unrelated fields, but a NEWLY set email is always checked.
      */
     private fun resolveUsername(
         tenantId: TenantId,
@@ -464,9 +470,11 @@ class AdminUserService(
         val renaming = normalized != null && normalized != user.username
 
         if (!renaming) {
-            collisionCheck
-                .check(tenantId, username = null, email = resolvedEmail, excludingUserId = userId)
-                ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+            if (resolvedEmail != user.email) {
+                collisionCheck
+                    .checkEmailOnly(tenantId, email = resolvedEmail, excludingUserId = userId)
+                    ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+            }
             return AdminResult.Success(user.username)
         }
 
@@ -480,6 +488,11 @@ class AdminUserService(
                 AdminError.Validation(
                     "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
                 ),
+            )
+        }
+        if (resolvedUsername.length > UsernamePolicy.MAX_LENGTH) {
+            return AdminResult.Failure(
+                AdminError.Validation("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
             )
         }
         if (userRepository.existsByUsername(tenantId, resolvedUsername)) {

--- a/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AdminUserService.kt
@@ -27,6 +27,11 @@ class AdminUserService(
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val emailPort: EmailPort? = null,
 ) {
+    private companion object {
+        /** Shared by [createUser] and [updateUser] so the two paths cannot drift apart. */
+        val USERNAME_PATTERN = Regex("[a-zA-Z0-9._@+-]+")
+    }
+
     fun createUser(
         tenantId: TenantId,
         username: String,
@@ -58,7 +63,7 @@ class AdminUserService(
             } else {
                 username.trim()
             }
-        if (!resolvedUsername.matches(Regex("[a-zA-Z0-9._@+-]+"))) {
+        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
             return AdminResult.Failure(
                 AdminError.Validation(
                     "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
@@ -335,6 +340,7 @@ class AdminUserService(
         tenantId: TenantId,
         email: String? = null,
         fullName: String? = null,
+        username: String? = null,
     ): AdminResult<User> {
         val user =
             userRepository.findById(userId, tenantId)
@@ -342,16 +348,38 @@ class AdminUserService(
 
         val resolvedEmail = email?.trim()?.lowercase() ?: user.email
         val resolvedFullName = fullName?.trim() ?: user.fullName
+        val resolvedUsername = username?.trim() ?: user.username
 
         if (resolvedEmail.isBlank() || !resolvedEmail.contains('@')) {
             return AdminResult.Failure(AdminError.Validation("A valid email address is required."))
         }
 
+        if (resolvedUsername.isBlank()) {
+            return AdminResult.Failure(AdminError.Validation("Username is required."))
+        }
+        if (!resolvedUsername.matches(USERNAME_PATTERN)) {
+            return AdminResult.Failure(
+                AdminError.Validation(
+                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                ),
+            )
+        }
+
         if (resolvedEmail != user.email && userRepository.existsByEmail(tenantId, resolvedEmail)) {
             return AdminResult.Failure(AdminError.Conflict("Email '$resolvedEmail' is already registered."))
         }
+        if (resolvedUsername != user.username && userRepository.existsByUsername(tenantId, resolvedUsername)) {
+            return AdminResult.Failure(AdminError.Conflict("Username '$resolvedUsername' is already taken."))
+        }
 
-        val updated = userRepository.update(user.copy(email = resolvedEmail, fullName = resolvedFullName))
+        collisionCheck
+            .check(tenantId, resolvedUsername, resolvedEmail, excludingUserId = userId)
+            ?.let { return AdminResult.Failure(AdminError.Validation(it)) }
+
+        val updated =
+            userRepository.update(
+                user.copy(email = resolvedEmail, fullName = resolvedFullName, username = resolvedUsername),
+            )
 
         auditLog.record(
             AuditEvent(

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -47,6 +47,7 @@ class AuthService(
     private val applicationRepository: ApplicationRepository? = null,
     private val roleRepository: RoleRepository? = null,
     private val identifierResolver: UserIdentifierResolver,
+    private val collisionCheck: IdentifierCollisionCheck,
 ) {
     // Equalises latency so wrong-password vs. user-not-found / disabled / locked / pending-setup
     // are indistinguishable timing-wise — closes the bcrypt-skipped enumeration vector.
@@ -407,11 +408,21 @@ class AuthService(
             return AuthResult.Failure(AuthError.EmailAlreadyExists)
         }
 
+        val normalizedUsername = username.trim()
+        val normalizedEmail = email.trim().lowercase()
+
+        // Same-namespace duplicates are ruled out above; this catches the cross-namespace
+        // pair — this username equal to a DIFFERENT user's email, or vice versa — that the
+        // database's separate unique constraints would otherwise allow through.
+        collisionCheck
+            .check(tenant.id, normalizedUsername, normalizedEmail)
+            ?.let { return AuthResult.Failure(AuthError.ValidationError(it)) }
+
         val newUser =
             User(
                 tenantId = tenant.id,
-                username = username.trim(),
-                email = email.trim().lowercase(),
+                username = normalizedUsername,
+                email = normalizedEmail,
                 fullName = fullName.trim(),
                 passwordHash = passwordHasher.hash(effectivePassword),
             )

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -382,6 +382,20 @@ class AuthService(
             return AuthResult.Failure(AuthError.ValidationError("Please enter a valid email address."))
         }
 
+        // Normalize FIRST, then validate — "Dave" becomes "dave" and is accepted, while
+        // "john doe" is rejected rather than silently rewritten. This was previously the only
+        // write path with no username format validation at all.
+        val normalizedUsername = UsernamePolicy.normalize(username)
+        val normalizedEmail = email.trim().lowercase()
+
+        if (!normalizedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
+            return AuthResult.Failure(
+                AuthError.ValidationError(
+                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                ),
+            )
+        }
+
         // In passwordless mode the password is generated server-side and never used by
         // the user — skip policy/confirmation checks. The User table still requires a
         // hash, so we mint a random unguessable secret to satisfy the schema.
@@ -401,16 +415,13 @@ class AuthService(
                 rawPassword
             }
 
-        if (userRepository.existsByUsername(tenant.id, username)) {
+        if (userRepository.existsByUsername(tenant.id, normalizedUsername)) {
             return AuthResult.Failure(AuthError.UserAlreadyExists)
         }
 
-        if (userRepository.existsByEmail(tenant.id, email)) {
+        if (userRepository.existsByEmail(tenant.id, normalizedEmail)) {
             return AuthResult.Failure(AuthError.EmailAlreadyExists)
         }
-
-        val normalizedUsername = username.trim()
-        val normalizedEmail = email.trim().lowercase()
 
         // Same-namespace duplicates are ruled out above; this catches the cross-namespace
         // pair — this username equal to a DIFFERENT user's email, or vice versa — that the

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -388,12 +388,18 @@ class AuthService(
         val normalizedUsername = UsernamePolicy.normalize(username)
         val normalizedEmail = email.trim().lowercase()
 
-        if (!normalizedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
-            return AuthResult.Failure(
-                AuthError.ValidationError(
-                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
-                ),
-            )
+        when (UsernamePolicy.validate(normalizedUsername)) {
+            UsernamePolicy.Violation.INVALID_FORMAT ->
+                return AuthResult.Failure(
+                    AuthError.ValidationError(
+                        "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                    ),
+                )
+            UsernamePolicy.Violation.TOO_LONG ->
+                return AuthResult.Failure(
+                    AuthError.ValidationError("Username must be ${UsernamePolicy.MAX_LENGTH} characters or fewer."),
+                )
+            null -> Unit
         }
 
         // In passwordless mode the password is generated server-side and never used by

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -46,6 +46,7 @@ class AuthService(
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val applicationRepository: ApplicationRepository? = null,
     private val roleRepository: RoleRepository? = null,
+    private val identifierResolver: UserIdentifierResolver = UserIdentifierResolver(userRepository),
 ) {
     // Equalises latency so wrong-password vs. user-not-found / disabled / locked / pending-setup
     // are indistinguishable timing-wise — closes the bcrypt-skipped enumeration vector.
@@ -96,7 +97,28 @@ class AuthService(
             return AuthResult.Failure(AuthError.InvalidCredentials)
         }
 
-        val user = userRepository.findByUsername(tenant.id, username)
+        val resolution =
+            identifierResolver.resolve(
+                tenant.id,
+                tenant.securityConfig.loginIdentifierMode,
+                username,
+            )
+        if (resolution is IdentifierResolution.Ambiguous) {
+            runDummyVerify(rawPassword)
+            auditLog.record(
+                AuditEvent(
+                    tenantId = tenant.id,
+                    userId = null,
+                    clientId = null,
+                    eventType = AuditEventType.LOGIN_FAILED,
+                    ipAddress = ipAddress,
+                    userAgent = userAgent,
+                    details = mapOf("reason" to "ambiguous_identifier"),
+                ),
+            )
+            return AuthResult.Failure(AuthError.InvalidCredentials)
+        }
+        val user = (resolution as? IdentifierResolution.Found)?.user
         if (user == null) {
             runDummyVerify(rawPassword)
             auditLog.record(

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -46,7 +46,7 @@ class AuthService(
     private val passwordPolicy: PasswordPolicyPort? = null,
     private val applicationRepository: ApplicationRepository? = null,
     private val roleRepository: RoleRepository? = null,
-    private val identifierResolver: UserIdentifierResolver = UserIdentifierResolver(userRepository),
+    private val identifierResolver: UserIdentifierResolver,
 ) {
     // Equalises latency so wrong-password vs. user-not-found / disabled / locked / pending-setup
     // are indistinguishable timing-wise — closes the bcrypt-skipped enumeration vector.

--- a/src/main/kotlin/com/kauth/domain/service/AuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/AuthService.kt
@@ -30,7 +30,8 @@ import java.time.Instant
  * indistinguishable from a wrong password — no slug enumeration leaks.
  *
  * Flow — login:
- *   slug → Tenant → find User by username in that tenant → verify password → tokens + session
+ *   slug → Tenant → resolve User by the workspace's identifier mode (username, email, or
+ *   either — see UserIdentifierResolver) in that tenant → verify password → tokens + session
  *
  * Flow — register:
  *   slug → Tenant → check policy → validate → hash password → save User

--- a/src/main/kotlin/com/kauth/domain/service/BackupExporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupExporterService.kt
@@ -117,6 +117,7 @@ class BackupExporterService(
                             emailOtpSignupEnabled = emailOtpSignupEnabled,
                             emailOtpLockoutThreshold = emailOtpLockoutThreshold,
                             emailOtpLoginEnabled = emailOtpLoginEnabled,
+                            loginIdentifierMode = loginIdentifierMode,
                         )
                     },
                 theme =

--- a/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
@@ -400,7 +400,12 @@ class BackupImporterService(
                 )
             val savedId =
                 saved.id ?: error("UserRepository.save returned a user with null id for '$normalizedUsername'")
+            // Audit events reference the ORIGINAL exported username (pre-normalization), so a
+            // legacy backup with mixed-case usernames must resolve under that key too. Keying on
+            // the original first (see lookup below) avoids two different original usernames that
+            // normalize to the same value from clobbering each other's resolution.
             userPkByUsername[normalizedUsername] = savedId
+            userPkByUsername[ub.username] = savedId
 
             ub.customAttributes.forEach { (key, value) ->
                 userAttributeRepository.upsert(
@@ -458,7 +463,8 @@ class BackupImporterService(
             auditLogPort?.record(
                 AuditEvent(
                     tenantId = createdTenant.id,
-                    userId = ev.username?.let { userPkByUsername[it] },
+                    userId =
+                        ev.username?.let { userPkByUsername[it] ?: userPkByUsername[UsernamePolicy.normalize(it)] },
                     clientId = ev.clientId?.let { appPkByClientId[it] },
                     eventType =
                         runCatching { AuditEventType.valueOf(ev.eventType) }

--- a/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
@@ -352,12 +352,26 @@ class BackupImporterService(
 
         val userPkByUsername: MutableMap<String, UserId> = mutableMapOf()
         export.users.forEach { ub ->
+            // Normalize, then reject rather than rewrite: a restore that silently alters an
+            // identifier can break an integrator's stored references to it. A username that
+            // fails to normalize into a valid one names the offending record so an operator can
+            // fix the export by hand and retry, rather than getting a 500 from the unique
+            // constraint or a garbled username on the far side.
+            val normalizedUsername = UsernamePolicy.normalize(ub.username)
+            if (!normalizedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
+                error(
+                    "Backup import rejected: user record for email '${ub.email}' has username " +
+                        "'${ub.username}' which does not normalize to a valid username " +
+                        "(got '$normalizedUsername'). Usernames must match " +
+                        "${UsernamePolicy.USERNAME_PATTERN.pattern} after trimming and lowercasing.",
+                )
+            }
             val saved =
                 userRepository.save(
                     User(
                         id = null,
                         tenantId = createdTenant.id,
-                        username = ub.username,
+                        username = normalizedUsername,
                         email = ub.email,
                         fullName = ub.fullName,
                         passwordHash = ub.passwordHash,
@@ -372,8 +386,9 @@ class BackupImporterService(
                         familyName = ub.familyName,
                     ),
                 )
-            val savedId = saved.id ?: error("UserRepository.save returned a user with null id for '${ub.username}'")
-            userPkByUsername[ub.username] = savedId
+            val savedId =
+                saved.id ?: error("UserRepository.save returned a user with null id for '$normalizedUsername'")
+            userPkByUsername[normalizedUsername] = savedId
 
             ub.customAttributes.forEach { (key, value) ->
                 userAttributeRepository.upsert(

--- a/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
@@ -158,6 +158,7 @@ class BackupImporterService(
                             emailOtpSignupEnabled = emailOtpSignupEnabled,
                             emailOtpLockoutThreshold = emailOtpLockoutThreshold,
                             emailOtpLoginEnabled = emailOtpLoginEnabled,
+                            loginIdentifierMode = loginIdentifierMode,
                         )
                     },
                 smtpHost = tb.smtp.host,

--- a/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/BackupImporterService.kt
@@ -350,22 +350,34 @@ class BackupImporterService(
             }
         }
 
+        // Normalize, then reject rather than rewrite: a restore that silently alters an
+        // identifier can break an integrator's stored references to it. Validated as one pass
+        // over every record before any of them is saved, and reported together, so an operator
+        // restoring hundreds of users sees the full list of offenders in one failure instead of
+        // discovering them one retry at a time.
+        val invalidUserRecords =
+            export.users.mapNotNull { ub ->
+                val normalized = UsernamePolicy.normalize(ub.username)
+                if (UsernamePolicy.isValid(normalized)) {
+                    null
+                } else {
+                    "user record for email '${ub.email}' has username '${ub.username}' which does not " +
+                        "normalize to a valid username (got '$normalized')"
+                }
+            }
+        if (invalidUserRecords.isNotEmpty()) {
+            error(
+                "Backup import rejected: ${invalidUserRecords.size} user record(s) have usernames " +
+                    "that do not normalize to a valid username. Usernames must match " +
+                    "${UsernamePolicy.USERNAME_PATTERN.pattern} and be at most " +
+                    "${UsernamePolicy.MAX_LENGTH} characters after trimming and lowercasing. " +
+                    "Offending records: ${invalidUserRecords.joinToString("; ")}.",
+            )
+        }
+
         val userPkByUsername: MutableMap<String, UserId> = mutableMapOf()
         export.users.forEach { ub ->
-            // Normalize, then reject rather than rewrite: a restore that silently alters an
-            // identifier can break an integrator's stored references to it. A username that
-            // fails to normalize into a valid one names the offending record so an operator can
-            // fix the export by hand and retry, rather than getting a 500 from the unique
-            // constraint or a garbled username on the far side.
             val normalizedUsername = UsernamePolicy.normalize(ub.username)
-            if (!normalizedUsername.matches(UsernamePolicy.USERNAME_PATTERN)) {
-                error(
-                    "Backup import rejected: user record for email '${ub.email}' has username " +
-                        "'${ub.username}' which does not normalize to a valid username " +
-                        "(got '$normalizedUsername'). Usernames must match " +
-                        "${UsernamePolicy.USERNAME_PATTERN.pattern} after trimming and lowercasing.",
-                )
-            }
             val saved =
                 userRepository.save(
                     User(

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -82,8 +82,15 @@ class EmailOtpService(
 
         val user =
             existing ?: run {
-                if (!tenant.securityConfig.emailOtpSignupEnabled) {
-                    // Signup disabled — return a uniform success with a handle that never resolves.
+                // Signup disabled, or this exact address is already someone ELSE's username (a
+                // cross-namespace collision `IdentifierCollisionCheck` guards elsewhere — the
+                // uniqueness constraint on `users_username_per_tenant` would otherwise turn this
+                // into an unhandled exception). Either way: uniform success with a handle that
+                // never resolves, so this endpoint stays a non-oracle for both cases alike.
+                if (!tenant.securityConfig.emailOtpSignupEnabled ||
+                    !normalizedEmail.matches(UsernamePolicy.USERNAME_PATTERN) ||
+                    userRepository.existsByUsername(tenant.id, normalizedEmail)
+                ) {
                     return OtpSendResult.Success(
                         challengeId = generateChallengeHandle(),
                         expiresAt = expiresAt,

--- a/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/EmailOtpService.kt
@@ -88,7 +88,7 @@ class EmailOtpService(
                 // into an unhandled exception). Either way: uniform success with a handle that
                 // never resolves, so this endpoint stays a non-oracle for both cases alike.
                 if (!tenant.securityConfig.emailOtpSignupEnabled ||
-                    !normalizedEmail.matches(UsernamePolicy.USERNAME_PATTERN) ||
+                    !UsernamePolicy.isValid(normalizedEmail) ||
                     userRepository.existsByUsername(tenant.id, normalizedEmail)
                 ) {
                     return OtpSendResult.Success(

--- a/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
+++ b/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
@@ -16,17 +16,26 @@ import com.kauth.domain.port.UserRepository
 class IdentifierCollisionCheck(
     private val userRepository: UserRepository,
 ) {
-    /** Returns a human-readable reason, or null when the pair is safe. */
+    /**
+     * Returns a human-readable reason, or null when the pair is safe.
+     *
+     * `username` is null when the caller isn't writing a username — the username→email
+     * direction is skipped in that case, since the stored username predates this check and may
+     * already legitimately (if historically) collide; only the email→username direction runs,
+     * because the email itself is always the thing being written.
+     */
     fun check(
         tenantId: TenantId,
-        username: String,
+        username: String?,
         email: String,
         excludingUserId: UserId? = null,
     ): String? {
-        userRepository
-            .findByEmail(tenantId, username)
-            ?.takeIf { it.id != excludingUserId }
-            ?.let { return "That username is already in use as another user's email address." }
+        if (username != null) {
+            userRepository
+                .findByEmail(tenantId, username)
+                ?.takeIf { it.id != excludingUserId }
+                ?.let { return "That username is already in use as another user's email address." }
+        }
 
         userRepository
             .findByUsernameIgnoreCase(tenantId, email)

--- a/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
+++ b/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
@@ -29,7 +29,7 @@ class IdentifierCollisionCheck(
             ?.let { return "That username is already in use as another user's email address." }
 
         userRepository
-            .findByUsername(tenantId, email)
+            .findByUsernameIgnoreCase(tenantId, email)
             ?.takeIf { it.id != excludingUserId }
             ?.let { return "That email address is already in use as another user's username." }
 

--- a/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
+++ b/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
@@ -17,26 +17,40 @@ class IdentifierCollisionCheck(
     private val userRepository: UserRepository,
 ) {
     /**
-     * Returns a human-readable reason, or null when the pair is safe.
+     * Returns a human-readable reason, or null when the pair is safe. Checks BOTH directions:
+     * `username` cannot equal a different user's email, and `email` cannot equal a different
+     * user's username.
      *
-     * `username` is null when the caller isn't writing a username — the username→email
-     * direction is skipped in that case, since the stored username predates this check and may
-     * already legitimately (if historically) collide; only the email→username direction runs,
-     * because the email itself is always the thing being written.
+     * Use this whenever a username is actually being written (created or renamed). When the
+     * caller isn't writing a username, use [checkEmailOnly] instead — a nullable `username`
+     * parameter here would let a caller silently skip the username→email direction with no
+     * diagnostic.
      */
     fun check(
         tenantId: TenantId,
-        username: String?,
+        username: String,
         email: String,
         excludingUserId: UserId? = null,
     ): String? {
-        if (username != null) {
-            userRepository
-                .findByEmail(tenantId, username)
-                ?.takeIf { it.id != excludingUserId }
-                ?.let { return "That username is already in use as another user's email address." }
-        }
+        userRepository
+            .findByEmail(tenantId, username)
+            ?.takeIf { it.id != excludingUserId }
+            ?.let { return "That username is already in use as another user's email address." }
 
+        return checkEmailOnly(tenantId, email, excludingUserId)
+    }
+
+    /**
+     * Runs only the email→username direction: rejects `email` when it equals a different user's
+     * username. Use this when a username isn't being written — e.g. a profile update that only
+     * touches `fullName`, where re-checking the stored username against every other user's email
+     * would reject users whose username predates this check.
+     */
+    fun checkEmailOnly(
+        tenantId: TenantId,
+        email: String,
+        excludingUserId: UserId? = null,
+    ): String? {
         userRepository
             .findByUsernameIgnoreCase(tenantId, email)
             ?.takeIf { it.id != excludingUserId }

--- a/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
+++ b/src/main/kotlin/com/kauth/domain/service/IdentifierCollisionCheck.kt
@@ -1,0 +1,38 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.UserId
+import com.kauth.domain.port.UserRepository
+
+/**
+ * Rejects a username that duplicates a different user's email, and vice versa.
+ *
+ * The two namespaces are separately unique, so the database permits a pair that cannot be
+ * resolved at sign-in under EITHER mode. Catch it where a human can still fix it.
+ *
+ * A user whose username *is* their own email is legal and must stay so — that is the shape
+ * integrators actually want.
+ */
+class IdentifierCollisionCheck(
+    private val userRepository: UserRepository,
+) {
+    /** Returns a human-readable reason, or null when the pair is safe. */
+    fun check(
+        tenantId: TenantId,
+        username: String,
+        email: String,
+        excludingUserId: UserId? = null,
+    ): String? {
+        userRepository
+            .findByEmail(tenantId, username)
+            ?.takeIf { it.id != excludingUserId }
+            ?.let { return "That username is already in use as another user's email address." }
+
+        userRepository
+            .findByUsername(tenantId, email)
+            ?.takeIf { it.id != excludingUserId }
+            ?.let { return "That email address is already in use as another user's username." }
+
+        return null
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/service/JitProvisioningService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/JitProvisioningService.kt
@@ -84,7 +84,16 @@ class JitProvisioningService(
                 ?.trim()
                 ?.lowercase()
                 ?.ifBlank { null }
-        if (email == null || !isDomainAllowed(email, provider.jitAllowedDomains)) {
+        // The address is also the username (see below), so it must satisfy UsernamePolicy too —
+        // an IdP-supplied local part is not guaranteed to. Folded into the same refusal bucket as
+        // the domain check rather than a new category: both mean "this address is not one we can
+        // provision an account for here", and a distinct message would only tell an attacker more
+        // about which half of the address rule tripped.
+        val addressUsable =
+            email != null &&
+                isDomainAllowed(email, provider.jitAllowedDomains) &&
+                email.matches(UsernamePolicy.USERNAME_PATTERN)
+        if (!addressUsable) {
             return refuse(tenant, provider, profile, JitRefusal.DOMAIN_NOT_ALLOWED, ipAddress, userAgent)
         }
 

--- a/src/main/kotlin/com/kauth/domain/service/JitProvisioningService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/JitProvisioningService.kt
@@ -92,7 +92,7 @@ class JitProvisioningService(
         val addressUsable =
             email != null &&
                 isDomainAllowed(email, provider.jitAllowedDomains) &&
-                email.matches(UsernamePolicy.USERNAME_PATTERN)
+                UsernamePolicy.isValid(email)
         if (!addressUsable) {
             return refuse(tenant, provider, profile, JitRefusal.DOMAIN_NOT_ALLOWED, ipAddress, userAgent)
         }

--- a/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
@@ -230,15 +230,18 @@ class SocialLoginService(
             return SocialLoginResult.Failure(SocialLoginError.RegistrationDisabled)
         }
 
-        val username = chosenUsername.trim()
+        // Normalize FIRST, then validate — "Dave" becomes "dave" and is accepted.
+        val username = UsernamePolicy.normalize(chosenUsername)
         if (username.length < 3 || username.length > 50) {
             return SocialLoginResult.Failure(
                 SocialLoginError.InvalidUsername("Username must be between 3 and 50 characters."),
             )
         }
-        if (!username.matches(Regex("^[a-zA-Z0-9_]+$"))) {
+        if (!username.matches(UsernamePolicy.USERNAME_PATTERN)) {
             return SocialLoginResult.Failure(
-                SocialLoginError.InvalidUsername("Username may only contain letters, numbers, and underscores."),
+                SocialLoginError.InvalidUsername(
+                    "Username may only contain letters, digits, dots, underscores, hyphens, @, and +.",
+                ),
             )
         }
 

--- a/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/SocialLoginService.kt
@@ -64,6 +64,7 @@ class SocialLoginService(
     private val passwordHasher: PasswordHasher,
     private val auditLog: AuditLogPort,
     private val providerResolver: SocialProviderResolver,
+    private val collisionCheck: IdentifierCollisionCheck,
     private val applicationRepository: ApplicationRepository? = null,
     private val roleRepository: RoleRepository? = null,
     /** Null wires no gate at all, which is JIT switched off for every provider. */
@@ -277,6 +278,13 @@ class SocialLoginService(
         if (userRepository.existsByUsername(tenant.id, username)) {
             return SocialLoginResult.Failure(SocialLoginError.UsernameConflict)
         }
+
+        // Same-namespace duplicates are ruled out above; this catches the cross-namespace
+        // pair — this username equal to a DIFFERENT user's email, or vice versa — that the
+        // database's separate unique constraints would otherwise allow through.
+        collisionCheck
+            .check(tenant.id, username, normalizedEmail)
+            ?.let { return SocialLoginResult.Failure(SocialLoginError.InvalidUsername(it)) }
 
         // Create the new user — social users get an unusable password hash so they cannot
         // log in via password until they explicitly set one through the self-service portal.

--- a/src/main/kotlin/com/kauth/domain/service/UserIdentifierResolver.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserIdentifierResolver.kt
@@ -1,0 +1,61 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.LoginIdentifierMode
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.port.UserRepository
+
+/** Outcome of matching a submitted login identifier against a tenant's users. */
+sealed interface IdentifierResolution {
+    data class Found(
+        val user: User,
+    ) : IdentifierResolution
+
+    data object NotFound : IdentifierResolution
+
+    /** A username and an email matched two different accounts. Treated as a failure. */
+    data object Ambiguous : IdentifierResolution
+}
+
+/**
+ * Matches what a user typed against a tenant's accounts, per the tenant's
+ * [LoginIdentifierMode].
+ *
+ * Not a port: it inverts no external dependency, it orchestrates over [UserRepository].
+ */
+class UserIdentifierResolver(
+    private val userRepository: UserRepository,
+) {
+    fun resolve(
+        tenantId: TenantId,
+        mode: LoginIdentifierMode,
+        submitted: String,
+    ): IdentifierResolution {
+        val value = submitted.trim()
+        // Guards the legacy `email NOT NULL DEFAULT ''` row from being reached by a blank submit.
+        if (value.isEmpty()) return IdentifierResolution.NotFound
+
+        return when (mode) {
+            LoginIdentifierMode.USERNAME ->
+                userRepository.findByUsername(tenantId, value).toResolution()
+
+            LoginIdentifierMode.EMAIL ->
+                userRepository.findByEmail(tenantId, value).toResolution()
+
+            LoginIdentifierMode.EITHER -> {
+                // Both lookups always run. Short-circuiting would make a miss cost two
+                // queries and a hit one, which is an observable timing difference.
+                val byUsername = userRepository.findByUsername(tenantId, value)
+                val byEmail = userRepository.findByEmail(tenantId, value)
+                when {
+                    byUsername != null && byEmail != null && byUsername.id != byEmail.id ->
+                        IdentifierResolution.Ambiguous
+                    else -> (byUsername ?: byEmail).toResolution()
+                }
+            }
+        }
+    }
+
+    private fun User?.toResolution(): IdentifierResolution =
+        if (this == null) IdentifierResolution.NotFound else IdentifierResolution.Found(this)
+}

--- a/src/main/kotlin/com/kauth/domain/service/UserIdentifierResolver.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UserIdentifierResolver.kt
@@ -36,8 +36,11 @@ class UserIdentifierResolver(
         if (value.isEmpty()) return IdentifierResolution.NotFound
 
         return when (mode) {
+            // Usernames are stored lowercased (see UsernamePolicy); lowercase what was submitted
+            // so "Dave" still finds "dave". Safe, not a loosening: (tenant_id, lower(username))
+            // is uniquely enforced (V66), so two distinct accounts can never differ only by case.
             LoginIdentifierMode.USERNAME ->
-                userRepository.findByUsername(tenantId, value).toResolution()
+                userRepository.findByUsername(tenantId, value.lowercase()).toResolution()
 
             LoginIdentifierMode.EMAIL ->
                 userRepository.findByEmail(tenantId, value).toResolution()
@@ -45,7 +48,7 @@ class UserIdentifierResolver(
             LoginIdentifierMode.EITHER -> {
                 // Both lookups always run. Short-circuiting would make a miss cost two
                 // queries and a hit one, which is an observable timing difference.
-                val byUsername = userRepository.findByUsername(tenantId, value)
+                val byUsername = userRepository.findByUsername(tenantId, value.lowercase())
                 val byEmail = userRepository.findByEmail(tenantId, value)
                 when {
                     byUsername != null && byEmail != null && byUsername.id != byEmail.id ->

--- a/src/main/kotlin/com/kauth/domain/service/UsernameGenerator.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UsernameGenerator.kt
@@ -26,7 +26,15 @@ class UsernameGenerator(
             val candidate = "$truncated.${randomSuffix()}"
             if (isAvailable(tenantId, candidate)) return candidate
         }
-        // Exhausting readable candidates is vanishingly unlikely; fall back to pure entropy.
+        // Exhausting readable candidates is vanishingly unlikely; fall back to pure entropy,
+        // still checked against both namespaces so this loop cannot manufacture a collision either.
+        repeat(MAX_ATTEMPTS) {
+            val candidate = "$NEUTRAL_STEM.${randomSuffix()}${randomSuffix()}"
+            if (isAvailable(tenantId, candidate)) return candidate
+        }
+        // Astronomically unlikely: every entropy candidate collided too. Return one anyway —
+        // createUser's downstream existsByUsername check turns a residual collision into a 409,
+        // not a 500, so this is a safe last resort rather than a silent gap.
         return "$NEUTRAL_STEM.${randomSuffix()}${randomSuffix()}"
     }
 

--- a/src/main/kotlin/com/kauth/domain/service/UsernameGenerator.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UsernameGenerator.kt
@@ -1,0 +1,62 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.UserRepository
+import kotlin.random.Random
+
+/**
+ * Builds a synthetic username for accounts provisioned without one.
+ *
+ * Integrators driving SCIM or the admin API should not have to invent an identifier
+ * their users have never seen. The result is readable, unique within the tenant, and
+ * editable by an admin afterwards.
+ */
+class UsernameGenerator(
+    private val userRepository: UserRepository,
+) {
+    fun generate(
+        tenantId: TenantId,
+        givenName: String?,
+        email: String,
+    ): String {
+        val stem = stemFrom(givenName) ?: stemFrom(email.substringBefore('@')) ?: NEUTRAL_STEM
+        val truncated = stem.take(MAX_LENGTH - SUFFIX_LENGTH - 1)
+
+        repeat(MAX_ATTEMPTS) {
+            val candidate = "$truncated.${randomSuffix()}"
+            if (isAvailable(tenantId, candidate)) return candidate
+        }
+        // Exhausting readable candidates is vanishingly unlikely; fall back to pure entropy.
+        return "$NEUTRAL_STEM.${randomSuffix()}${randomSuffix()}"
+    }
+
+    /** Checks BOTH namespaces so generation cannot manufacture the collision we reject elsewhere. */
+    private fun isAvailable(
+        tenantId: TenantId,
+        candidate: String,
+    ): Boolean =
+        userRepository.findByUsernameIgnoreCase(tenantId, candidate) == null &&
+            userRepository.findByEmail(tenantId, candidate) == null
+
+    private fun stemFrom(raw: String?): String? =
+        raw
+            ?.lowercase()
+            ?.replace(Regex("[^a-z0-9._-]"), "")
+            ?.trim('.', '_', '-')
+            ?.takeIf { it.isNotEmpty() }
+
+    private fun randomSuffix(): String =
+        (1..SUFFIX_LENGTH)
+            .map { ALPHABET[Random.nextInt(ALPHABET.length)] }
+            .joinToString("")
+
+    private companion object {
+        const val MAX_LENGTH = 50
+        const val SUFFIX_LENGTH = 6
+        const val MAX_ATTEMPTS = 10
+        const val NEUTRAL_STEM = "user"
+
+        // Omits l, o, 0, 1 so a generated handle can be read aloud without ambiguity.
+        const val ALPHABET = "abcdefghijkmnpqrstuvwxyz23456789"
+    }
+}

--- a/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
@@ -16,6 +16,9 @@ package com.kauth.domain.service
 object UsernamePolicy {
     val USERNAME_PATTERN = Regex("[a-zA-Z0-9._@+-]+")
 
+    /** Matches the `users.username` column width (`VARCHAR(255)`, widened by V60). */
+    const val MAX_LENGTH = 255
+
     /** Trims and lowercases. Callers must still validate the result against [USERNAME_PATTERN]. */
     fun normalize(raw: String): String = raw.trim().lowercase()
 }

--- a/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
@@ -19,6 +19,25 @@ object UsernamePolicy {
     /** Matches the `users.username` column width (`VARCHAR(255)`, widened by V60). */
     const val MAX_LENGTH = 255
 
-    /** Trims and lowercases. Callers must still validate the result against [USERNAME_PATTERN]. */
+    /** Trims and lowercases. Callers must still validate the result against [validate]. */
     fun normalize(raw: String): String = raw.trim().lowercase()
+
+    /** Why [validate] rejected an already-[normalize]d value. */
+    enum class Violation { INVALID_FORMAT, TOO_LONG }
+
+    /**
+     * The single entry point for "is this a storable username" — checks both [USERNAME_PATTERN]
+     * and [MAX_LENGTH] in one place, so every write path enforces the exact same bound instead of
+     * each one duplicating (and risking drifting from) the checks. [normalized] must already have
+     * been through [normalize]. Returns `null` when valid.
+     */
+    fun validate(normalized: String): Violation? =
+        when {
+            !normalized.matches(USERNAME_PATTERN) -> Violation.INVALID_FORMAT
+            normalized.length > MAX_LENGTH -> Violation.TOO_LONG
+            else -> null
+        }
+
+    /** Convenience boolean form of [validate] for callers that don't need to distinguish why. */
+    fun isValid(normalized: String): Boolean = validate(normalized) == null
 }

--- a/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
+++ b/src/main/kotlin/com/kauth/domain/service/UsernamePolicy.kt
@@ -1,0 +1,21 @@
+package com.kauth.domain.service
+
+/**
+ * The single definition of what a normalized username looks like, and how to get one.
+ *
+ * Product rule: usernames are ALWAYS stored trimmed, lowercased, and matching
+ * [USERNAME_PATTERN]. Every write path normalizes first, then validates — so `"Dave"`
+ * becomes `"dave"` and is accepted, while `"john doe"` is rejected rather than silently
+ * rewritten, because a human is expected to fix it by hand.
+ *
+ * Shared by every service that can create or rename a username — [AdminUserService],
+ * [AuthService], [SocialLoginService], [EmailOtpService], and [BackupImporterService] —
+ * so the character class cannot drift between admin-created, self-registered,
+ * socially-provisioned, JIT-provisioned, and restored users.
+ */
+object UsernamePolicy {
+    val USERNAME_PATTERN = Regex("[a-zA-Z0-9._@+-]+")
+
+    /** Trims and lowercases. Callers must still validate the result against [USERNAME_PATTERN]. */
+    fun normalize(raw: String): String = raw.trim().lowercase()
+}

--- a/src/main/kotlin/com/kauth/domain/service/WorkspaceSettingsService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/WorkspaceSettingsService.kt
@@ -243,6 +243,7 @@ class WorkspaceSettingsService(
                     emailOtpSignupEnabled = update.emailOtpSignupEnabled,
                     emailOtpLockoutThreshold = update.emailOtpLockoutThreshold.coerceIn(0, 50),
                     emailOtpLoginEnabled = update.emailOtpLoginEnabled,
+                    loginIdentifierMode = update.loginIdentifierMode,
                 ),
             passkeysEnabled = update.passkeysEnabled,
         )

--- a/src/main/resources/db/migration/V65__login_identifier_mode.sql
+++ b/src/main/resources/db/migration/V65__login_identifier_mode.sql
@@ -1,0 +1,6 @@
+-- V65: Per-tenant sign-in identifier mode (v1.24.0).
+-- USERNAME preserves pre-1.24 behaviour for every existing workspace.
+
+ALTER TABLE tenant_security_config
+    ADD COLUMN login_identifier_mode VARCHAR(10) NOT NULL DEFAULT 'USERNAME'
+    CHECK (login_identifier_mode IN ('USERNAME', 'EMAIL', 'EITHER'));

--- a/src/main/resources/db/migration/V66__normalize_usernames.sql
+++ b/src/main/resources/db/migration/V66__normalize_usernames.sql
@@ -7,9 +7,20 @@
 --   1. Aborts if normalizing would collide two rows within the same tenant — an operator
 --      must de-duplicate those by hand. Silently merging or dropping identity rows is not
 --      an acceptable failure mode.
---   2. Rewrites every existing username to its normalized form: lowercase; each run of
+--   2. Aborts if normalizing a row would produce an empty string or something that still
+--      fails the pattern — a username made entirely of characters outside [a-z0-9._@+-]
+--      (e.g. a non-Latin script like 'Иван' or '用户') collapses to '' under this migration's
+--      own rewrite rule, and '' would otherwise commit silently into a NOT NULL column,
+--      leaving a user who can never sign in by username again and no record of why. This
+--      matches the same reject-don't-rewrite policy every application write path now
+--      follows (see UsernamePolicy) — this is simply the one place that rewrite would be
+--      irreversible, so the check has to run before Step 3 instead of after.
+--   3. Rewrites every existing username to its normalized form: lowercase; each run of
 --      forbidden characters collapsed to a single '.'; leading/trailing '.', '_', '-' stripped.
---   3. Adds a unique index on (tenant_id, lower(username)) to enforce the rule going forward.
+--   4. Adds a CHECK (username = lower(username)) constraint — the unique index below enforces
+--      uniqueness on lower(username), but nothing previously enforced that storage is actually
+--      lowercase; that invariant rested entirely on application code with no database backstop.
+--   5. Adds a unique index on (tenant_id, lower(username)) to enforce the rule going forward.
 --      This also serves UserRepository.findByUsernameIgnoreCase — no separate index needed.
 --
 -- On CONCURRENTLY: verified against the running kotauth-db container (Flyway 12.11,
@@ -57,13 +68,44 @@ BEGIN
     END IF;
 END $$;
 
--- Step 2: normalize every existing username.
+-- Step 2: refuse to proceed if normalization would produce an empty or still-invalid value.
+-- The username itself is deliberately NOT included in the exception message — same reasoning
+-- as the collision case above, which names tenant and count rather than the raw values.
+DO $$
+DECLARE
+    offender RECORD;
+BEGIN
+    SELECT id, tenant_id
+    INTO offender
+    FROM users
+    WHERE pg_temp.kauth_normalize_username(username) = ''
+       OR pg_temp.kauth_normalize_username(username) !~ '^[a-z0-9._@+-]+$'
+    LIMIT 1;
+
+    IF FOUND THEN
+        RAISE EXCEPTION
+            'V66 aborted: tenant % has a user (id %) whose username normalizes to an empty or '
+            'invalid value — likely a username made entirely of characters outside '
+            '[a-z0-9._@+-] (e.g. a non-Latin script). Rename this user by hand (on the '
+            'pre-upgrade version) to something matching [a-z0-9._@+-]+ before re-running this '
+            'migration.',
+            offender.tenant_id, offender.id;
+    END IF;
+END $$;
+
+-- Step 3: normalize every existing username.
 UPDATE users
 SET username = pg_temp.kauth_normalize_username(username)
 WHERE username <> pg_temp.kauth_normalize_username(username);
 
 DROP FUNCTION pg_temp.kauth_normalize_username(text);
 
--- Step 3: enforce the rule going forward. Cannot use CONCURRENTLY inside Flyway's
+-- Step 4: back the "storage is always lowercase" invariant with a database constraint, not just
+-- application code. Deliberately not "= normalize(...)" — Postgres has no built-in equivalent of
+-- the collapse/strip rule above, and re-deriving it here would duplicate logic that only needs to
+-- hold once, at migration time; going forward every write path already normalizes before writing.
+ALTER TABLE users ADD CONSTRAINT users_username_lowercase_chk CHECK (username = lower(username));
+
+-- Step 5: enforce the rule going forward. Cannot use CONCURRENTLY inside Flyway's
 -- transactional migration — see comment above.
 CREATE UNIQUE INDEX users_username_lower_per_tenant ON users (tenant_id, lower(username));

--- a/src/main/resources/db/migration/V66__normalize_usernames.sql
+++ b/src/main/resources/db/migration/V66__normalize_usernames.sql
@@ -1,4 +1,4 @@
--- V66: Normalize usernames to trimmed, lowercased [a-z0-9._@+-]+ form (v1.25.0 hardening).
+-- V66: Normalize usernames to trimmed, lowercased [a-z0-9._@+-]+ form (v1.24.0 hardening).
 --
 -- New product rule: usernames are ALWAYS stored normalized — trimmed, lowercased, and
 -- matching [a-z0-9._@+-]+. Historically AuthService.register performed no username format

--- a/src/main/resources/db/migration/V66__normalize_usernames.sql
+++ b/src/main/resources/db/migration/V66__normalize_usernames.sql
@@ -1,0 +1,69 @@
+-- V66: Normalize usernames to trimmed, lowercased [a-z0-9._@+-]+ form (v1.25.0 hardening).
+--
+-- New product rule: usernames are ALWAYS stored normalized — trimmed, lowercased, and
+-- matching [a-z0-9._@+-]+. Historically AuthService.register performed no username format
+-- validation at all, so rows exist that are mixed case or contain arbitrary characters
+-- (e.g. "John Doe"). This migration, in order:
+--   1. Aborts if normalizing would collide two rows within the same tenant — an operator
+--      must de-duplicate those by hand. Silently merging or dropping identity rows is not
+--      an acceptable failure mode.
+--   2. Rewrites every existing username to its normalized form: lowercase; each run of
+--      forbidden characters collapsed to a single '.'; leading/trailing '.', '_', '-' stripped.
+--   3. Adds a unique index on (tenant_id, lower(username)) to enforce the rule going forward.
+--      This also serves UserRepository.findByUsernameIgnoreCase — no separate index needed.
+--
+-- On CONCURRENTLY: verified against the running kotauth-db container (Flyway 12.11,
+-- Postgres 15) that this project's migrations run inside a transaction by default —
+-- DatabaseFactory.init() calls Flyway.configure() with no per-script .conf file and no
+-- `mixed(true)`, and there is no repo-wide flyway.conf setting it either. CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block, so it is not usable here. This uses
+-- a plain CREATE UNIQUE INDEX instead, which takes a brief write lock on `users` for the
+-- duration of the build — acceptable for this table's size.
+
+-- Session-local helper so the normalization expression is defined exactly once. Explicitly
+-- scoped to pg_temp so it cannot leak into the permanent schema even if a later statement
+-- in this script fails before the DROP FUNCTION below runs (the whole script still rolls
+-- back as one transaction in that case, but this keeps the intent explicit either way).
+CREATE FUNCTION pg_temp.kauth_normalize_username(raw text) RETURNS text AS $$
+    SELECT regexp_replace(
+        regexp_replace(
+            regexp_replace(lower(trim(raw)), '[^a-z0-9._@+-]+', '.', 'g'),
+            '^[._-]+', ''
+        ),
+        '[._-]+$', ''
+    )
+$$ LANGUAGE sql IMMUTABLE;
+
+-- Step 1: refuse to proceed if normalization would collide within a tenant.
+DO $$
+DECLARE
+    collision RECORD;
+BEGIN
+    SELECT tenant_id, normalized, COUNT(*) AS cnt
+    INTO collision
+    FROM (
+        SELECT tenant_id, pg_temp.kauth_normalize_username(username) AS normalized
+        FROM users
+    ) n
+    GROUP BY tenant_id, normalized
+    HAVING COUNT(*) > 1
+    LIMIT 1;
+
+    IF FOUND THEN
+        RAISE EXCEPTION
+            'V66 aborted: tenant % has % existing usernames that would all normalize to ''%''. '
+            'De-duplicate them by hand (rename or merge the accounts) before re-running this migration.',
+            collision.tenant_id, collision.cnt, collision.normalized;
+    END IF;
+END $$;
+
+-- Step 2: normalize every existing username.
+UPDATE users
+SET username = pg_temp.kauth_normalize_username(username)
+WHERE username <> pg_temp.kauth_normalize_username(username);
+
+DROP FUNCTION pg_temp.kauth_normalize_username(text);
+
+-- Step 3: enforce the rule going forward. Cannot use CONCURRENTLY inside Flyway's
+-- transactional migration — see comment above.
+CREATE UNIQUE INDEX users_username_lower_per_tenant ON users (tenant_id, lower(username));

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -69,7 +69,7 @@ info:
       "type": "https://kotauth.dev/errors/422",
       "title": "Validation Error",
       "status": 422,
-      "detail": "Username may only contain letters, digits, dots, underscores, and hyphens."
+      "detail": "Username may only contain letters, digits, dots, underscores, hyphens, @, and +."
     }
     ```
 
@@ -160,9 +160,12 @@ components:
 
     CreateUserRequest:
       type: object
-      required: [username, email, fullName, password]
+      required: [email, fullName, password]
       properties:
-        username: { type: string, pattern: "^[a-zA-Z0-9._-]+$" }
+        username:
+          type: string
+          pattern: "^[a-zA-Z0-9._@+-]+$"
+          description: Generated from the name and email when omitted or blank.
         email:    { type: string, format: email }
         fullName: { type: string }
         password: { type: string, minLength: 4 }
@@ -173,16 +176,23 @@ components:
       properties:
         email:    { type: string, format: email }
         fullName: { type: string }
+        username:
+          type: string
+          pattern: "^[a-zA-Z0-9._@+-]+$"
+          description: Omit to leave the existing username unchanged.
 
     InviteUserRequest:
       type: object
-      required: [username, email, fullName]
+      required: [email, fullName]
       description: |
         Invite a new user without a password. The user will receive an email
         with a 72-hour invite link and set their own password on first login.
         The tenant must have SMTP configured.
       properties:
-        username: { type: string, maxLength: 128 }
+        username:
+          type: string
+          maxLength: 128
+          description: Generated from the name and email when omitted or blank.
         email:    { type: string, format: email }
         fullName: { type: string }
 

--- a/src/main/resources/openapi/v1.yaml
+++ b/src/main/resources/openapi/v1.yaml
@@ -165,6 +165,7 @@ components:
         username:
           type: string
           pattern: "^[a-zA-Z0-9._@+-]+$"
+          maxLength: 255
           description: Generated from the name and email when omitted or blank.
         email:    { type: string, format: email }
         fullName: { type: string }
@@ -179,6 +180,7 @@ components:
         username:
           type: string
           pattern: "^[a-zA-Z0-9._@+-]+$"
+          maxLength: 255
           description: Omit to leave the existing username unchanged.
 
     InviteUserRequest:
@@ -191,7 +193,8 @@ components:
       properties:
         username:
           type: string
-          maxLength: 128
+          pattern: "^[a-zA-Z0-9._@+-]+$"
+          maxLength: 255
           description: Generated from the name and email when omitted or blank.
         email:    { type: string, format: email }
         fullName: { type: string }

--- a/src/test/kotlin/com/kauth/adapter/web/LoginPagePasskeyRenderTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/LoginPagePasskeyRenderTest.kt
@@ -1,6 +1,7 @@
 package com.kauth.adapter.web
 
 import com.kauth.adapter.web.auth.AuthView
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.TenantTheme
 import com.kauth.infrastructure.EnglishOnlyTranslation
 import kotlinx.html.HTML
@@ -34,6 +35,7 @@ class LoginPagePasskeyRenderTest {
                     tenantSlug = "acme",
                     ctx = viewContext,
                     passkeysEnabled = true,
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -51,6 +53,7 @@ class LoginPagePasskeyRenderTest {
                     ctx = viewContext,
                     passkeysEnabled = true,
                     passwordLoginEnabled = false,
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -70,6 +73,7 @@ class LoginPagePasskeyRenderTest {
                     tenantSlug = "acme",
                     ctx = viewContext,
                     passkeysEnabled = false,
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeyFailureReportingTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeyFailureReportingTest.kt
@@ -289,6 +289,9 @@ class AdminApiKeyFailureReportingTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeyFailureReportingTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeyFailureReportingTest.kt
@@ -286,6 +286,9 @@ class AdminApiKeyFailureReportingTest {
                         passwordHasher = hasher,
                         auditLog = auditLogPort,
                         credentialFlowService = buildCredentialFlowService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -136,6 +136,9 @@ class AdminApiKeysTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -139,6 +139,9 @@ class AdminApiKeysTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutesTest.kt
@@ -133,6 +133,9 @@ class AdminApplicationRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutesTest.kt
@@ -136,6 +136,9 @@ class AdminApplicationRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminDisplayHelpersTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminDisplayHelpersTest.kt
@@ -70,6 +70,9 @@ class AdminDisplayHelpersTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(users),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(users),
             passwordPolicy = passwordPolicy,
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminDisplayHelpersTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminDisplayHelpersTest.kt
@@ -67,6 +67,9 @@ class AdminDisplayHelpersTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             credentialFlowService = credentialFlowService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(users),
             passwordPolicy = passwordPolicy,
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminGroupDeleteTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminGroupDeleteTest.kt
@@ -222,6 +222,9 @@ class AdminGroupDeleteTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminGroupDeleteTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminGroupDeleteTest.kt
@@ -219,6 +219,9 @@ class AdminGroupDeleteTest {
                         passwordHasher = hasher,
                         auditLog = auditLogPort,
                         credentialFlowService = credentialFlowService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutesTest.kt
@@ -223,6 +223,9 @@ class AdminRbacRoutesTest {
                         passwordHasher = hasher,
                         auditLog = auditLogPort,
                         credentialFlowService = credentialFlowService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRbacRoutesTest.kt
@@ -226,6 +226,9 @@ class AdminRbacRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutesTest.kt
@@ -137,6 +137,9 @@ class AdminResourceServerRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutesTest.kt
@@ -134,6 +134,9 @@ class AdminResourceServerRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
@@ -122,6 +122,9 @@ class AdminRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminRoutesTest.kt
@@ -125,6 +125,9 @@ class AdminRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminScimRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminScimRoutesTest.kt
@@ -643,6 +643,9 @@ class AdminScimRoutesTest {
                         passwordHasher = hasher,
                         auditLog = auditLogPort,
                         credentialFlowService = buildCredentialFlowService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminScimRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminScimRoutesTest.kt
@@ -646,6 +646,9 @@ class AdminScimRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -3,6 +3,7 @@ package com.kauth.adapter.web.admin
 import com.kauth.adapter.web.AppInfo
 import com.kauth.adapter.web.EnglishStrings
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.ProviderKind
@@ -356,6 +357,163 @@ class AdminSettingsTest {
 
             assertEquals(HttpStatusCode.Found, response.status)
             assertTrue(response.headers["Location"]?.contains("saved=true") == true)
+        }
+
+    // =========================================================================
+    // Security policy settings — sign-in identifier mode
+    // =========================================================================
+
+    @Test
+    fun `POST security settings persists sign-in identifier mode EITHER`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters =
+                        Parameters.build {
+                            append("loginIdentifierMode", "EITHER")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals(
+                LoginIdentifierMode.EITHER,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+        }
+
+    @Test
+    fun `POST security settings persists sign-in identifier mode EMAIL`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters =
+                        Parameters.build {
+                            append("loginIdentifierMode", "EMAIL")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals(
+                LoginIdentifierMode.EMAIL,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+        }
+
+    @Test
+    fun `POST security settings with a garbage identifier mode falls back to USERNAME without erroring`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters =
+                        Parameters.build {
+                            append("loginIdentifierMode", "NONSENSE")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals(
+                LoginIdentifierMode.USERNAME,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+        }
+
+    @Test
+    fun `POST security settings omitting the identifier field resets an EITHER tenant to USERNAME`() =
+        testApplication {
+            // KNOWN RISK (documented, not a fix): LoginIdentifierMode.fromStorage(null) falls back
+            // to USERNAME, so a POST that omits loginIdentifierMode silently resets a tenant already
+            // on EITHER or EMAIL. The rendered radio group always posts exactly one checked value,
+            // so this is not reachable through the shipped admin UI form — but a partial or
+            // programmatic POST (a hand-crafted request, or a future partial-form submit) would
+            // trigger it. This test documents the behavior; see the Task 8 report for the finding.
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            authed.submitForm(
+                url = "/admin/workspaces/acme/settings/security",
+                formParameters =
+                    Parameters.build {
+                        append("loginIdentifierMode", "EITHER")
+                    },
+            )
+            assertEquals(
+                LoginIdentifierMode.EITHER,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals(
+                LoginIdentifierMode.USERNAME,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+        }
+
+    @Test
+    fun `security policy page renders the three sign-in identifier options with the current one checked`() =
+        testApplication {
+            tenantRepo.update(
+                workspace.copy(
+                    securityConfig = workspace.securityConfig.copy(loginIdentifierMode = LoginIdentifierMode.EMAIL),
+                ),
+            )
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            val body = authed.get("/admin/workspaces/acme/settings/security").bodyAsText()
+
+            val radios =
+                Regex("""<input[^>]*name="loginIdentifierMode"[^>]*>""")
+                    .findAll(body)
+                    .map { it.value }
+                    .toList()
+            assertEquals(3, radios.size)
+
+            val usernameRadio = radios.first { it.contains("value=\"USERNAME\"") }
+            val emailRadio = radios.first { it.contains("value=\"EMAIL\"") }
+            val eitherRadio = radios.first { it.contains("value=\"EITHER\"") }
+
+            assertFalse(usernameRadio.contains("checked"))
+            assertTrue(emailRadio.contains("checked"))
+            assertFalse(eitherRadio.contains("checked"))
         }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -445,14 +445,11 @@ class AdminSettingsTest {
         }
 
     @Test
-    fun `POST security settings omitting the identifier field resets an EITHER tenant to USERNAME`() =
+    fun `POST security settings omitting the identifier field preserves an EITHER tenant`() =
         testApplication {
-            // KNOWN RISK (documented, not a fix): LoginIdentifierMode.fromStorage(null) falls back
-            // to USERNAME, so a POST that omits loginIdentifierMode silently resets a tenant already
-            // on EITHER or EMAIL. The rendered radio group always posts exactly one checked value,
-            // so this is not reachable through the shipped admin UI form — but a partial or
-            // programmatic POST (a hand-crafted request, or a future partial-form submit) would
-            // trigger it. This test documents the behavior; see the Task 8 report for the finding.
+            // The field is absent from a partial/programmatic POST here. loginIdentifierMode
+            // must fall back to the tenant's persisted value (not to USERNAME) so an operator
+            // saving unrelated fields on this form can never silently narrow the sign-in surface.
             application { installTestApp() }
             val authed =
                 createClient {
@@ -481,7 +478,47 @@ class AdminSettingsTest {
 
             assertEquals(HttpStatusCode.Found, response.status)
             assertEquals(
-                LoginIdentifierMode.USERNAME,
+                LoginIdentifierMode.EITHER,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+        }
+
+    @Test
+    fun `POST security settings omitting the identifier field preserves an EMAIL tenant`() =
+        testApplication {
+            // EMAIL mode performs only findByEmail (UserIdentifierResolver). Resetting this to
+            // USERNAME on a field omission would lock out every user who does not know a
+            // username, silently, behind an ordinary 302 — this is the case with real lockout
+            // consequences, not just a policy relaxation.
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            authed.submitForm(
+                url = "/admin/workspaces/acme/settings/security",
+                formParameters =
+                    Parameters.build {
+                        append("loginIdentifierMode", "EMAIL")
+                    },
+            )
+            assertEquals(
+                LoginIdentifierMode.EMAIL,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals(
+                LoginIdentifierMode.EMAIL,
                 tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
             )
         }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -149,6 +149,9 @@ class AdminSettingsTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -359,6 +359,36 @@ class AdminSettingsTest {
             assertTrue(response.headers["Location"]?.contains("saved=true") == true)
         }
 
+    @Test
+    fun `POST security settings omitting mfaPolicy preserves a required tenant`() =
+        testApplication {
+            // mfaPolicy is absent from a partial/programmatic POST here. It must fall back to
+            // the tenant's persisted value (not to "optional") so an operator saving unrelated
+            // fields on this form can never silently downgrade a required-MFA policy.
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            authed.submitForm(
+                url = "/admin/workspaces/acme/settings/security",
+                formParameters = Parameters.build { append("mfaPolicy", "required") },
+            )
+            assertEquals("required", tenantRepo.findBySlug("acme")!!.securityConfig.mfaPolicy)
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters = Parameters.build { },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals("required", tenantRepo.findBySlug("acme")!!.securityConfig.mfaPolicy)
+        }
+
     // =========================================================================
     // Security policy settings — sign-in identifier mode
     // =========================================================================

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -448,7 +448,49 @@ class AdminSettingsTest {
         }
 
     @Test
-    fun `POST security settings with a garbage identifier mode falls back to USERNAME without erroring`() =
+    fun `POST security settings with a garbage identifier mode is rejected and leaves the persisted mode unchanged`() =
+        testApplication {
+            // A present-but-unrecognised value must never coerce to USERNAME: for an EMAIL-mode
+            // workspace that coercion is a silent lockout for anyone who only knows their email.
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+
+            authed.submitForm(
+                url = "/admin/workspaces/acme/settings/security",
+                formParameters =
+                    Parameters.build {
+                        append("loginIdentifierMode", "EMAIL")
+                    },
+            )
+            assertEquals(
+                LoginIdentifierMode.EMAIL,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+            )
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/security",
+                    formParameters =
+                        Parameters.build {
+                            append("loginIdentifierMode", "NONSENSE")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            assertEquals(
+                LoginIdentifierMode.EMAIL,
+                tenantRepo.findBySlug("acme")!!.securityConfig.loginIdentifierMode,
+                "The persisted mode must not change on a rejected update",
+            )
+        }
+
+    @Test
+    fun `POST security settings persists sign-in identifier mode USERNAME`() =
         testApplication {
             application { installTestApp() }
             val authed =
@@ -458,12 +500,20 @@ class AdminSettingsTest {
                 }
             login(authed)
 
+            authed.submitForm(
+                url = "/admin/workspaces/acme/settings/security",
+                formParameters =
+                    Parameters.build {
+                        append("loginIdentifierMode", "EMAIL")
+                    },
+            )
+
             val response =
                 authed.submitForm(
                     url = "/admin/workspaces/acme/settings/security",
                     formParameters =
                         Parameters.build {
-                            append("loginIdentifierMode", "NONSENSE")
+                            append("loginIdentifierMode", "USERNAME")
                         },
                 )
 

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSettingsTest.kt
@@ -152,6 +152,9 @@ class AdminSettingsTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSidebarTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSidebarTest.kt
@@ -354,6 +354,9 @@ class AdminSidebarTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminSidebarTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminSidebarTest.kt
@@ -357,6 +357,9 @@ class AdminSidebarTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
@@ -369,6 +369,9 @@ class AdminUserAttributesAndClaimMappersTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserAttributesAndClaimMappersTest.kt
@@ -372,6 +372,9 @@ class AdminUserAttributesAndClaimMappersTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserPasskeyRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserPasskeyRoutesTest.kt
@@ -148,6 +148,9 @@ class AdminUserPasskeyRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserPasskeyRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserPasskeyRoutesTest.kt
@@ -151,6 +151,9 @@ class AdminUserPasskeyRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
@@ -485,6 +485,9 @@ class AdminUserRoutesTest {
                         passwordHasher = hasher,
                         auditLog = auditLogPort,
                         credentialFlowService = credentialFlowService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
@@ -392,6 +392,61 @@ class AdminUserRoutesTest {
         }
 
     @Test
+    fun `renaming a user's username succeeds and redirects`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+            val user = addWorkspaceUser("ada")
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/users/${user.id!!.value}/edit",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "ada.lovelace")
+                            append("email", "ada@example.com")
+                            append("fullName", "Ada Lovelace")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals("ada.lovelace", userRepo.findById(user.id!!, workspace.id)!!.username)
+        }
+
+    @Test
+    fun `renaming a user's username to one already taken does not silently succeed`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+            addWorkspaceUser("bob")
+            val user = addWorkspaceUser("ada")
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/users/${user.id!!.value}/edit",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "bob")
+                            append("email", "ada@example.com")
+                            append("fullName", "Ada Lovelace")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            assertEquals("ada", userRepo.findById(user.id!!, workspace.id)!!.username)
+        }
+
+    @Test
     fun `the edit form offers both name parts`() =
         testApplication {
             application { installTestApp() }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
@@ -447,6 +447,38 @@ class AdminUserRoutesTest {
         }
 
     @Test
+    fun `a colliding email in the same submission does not leave the username renamed`() =
+        testApplication {
+            application { installTestApp() }
+            val authed =
+                createClient {
+                    install(HttpCookies)
+                    followRedirects = false
+                }
+            login(authed)
+            addWorkspaceUser("bob")
+            val user = addWorkspaceUser("ada")
+
+            // Both fields change in one submission and only the email collides — the username
+            // rename must not land on its own write ahead of the email check failing.
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/users/${user.id!!.value}/edit",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "ada.lovelace")
+                            append("email", "bob@acme.test")
+                            append("fullName", "Ada Lovelace")
+                        },
+                )
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            val stored = userRepo.findById(user.id!!, workspace.id)!!
+            assertEquals("ada", stored.username)
+            assertEquals("ada@acme.test", stored.email)
+        }
+
+    @Test
     fun `the edit form offers both name parts`() =
         testApplication {
             application { installTestApp() }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminUserRoutesTest.kt
@@ -488,6 +488,9 @@ class AdminUserRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 applicationManagementService =
                     com.kauth.domain.service.ApplicationManagementService(

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -143,6 +143,9 @@ class AdminWebhooksTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -140,6 +140,9 @@ class AdminWebhooksTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildAppMgmtService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AuthMethodsGridTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AuthMethodsGridTest.kt
@@ -163,6 +163,9 @@ class AuthMethodsGridTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private fun buildWorkspaceSettingsService() =

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AuthMethodsGridTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AuthMethodsGridTest.kt
@@ -160,6 +160,9 @@ class AuthMethodsGridTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = buildCredentialFlowService(),
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildWorkspaceSettingsService() =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
@@ -137,6 +137,9 @@ class ApiApplicationRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
@@ -134,6 +134,9 @@ class ApiApplicationRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
@@ -371,6 +371,9 @@ class ApiClaimMapperRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
@@ -368,6 +368,9 @@ class ApiClaimMapperRoutesTest {
                         passwordHasher = hasher,
                         auditLog = com.kauth.fakes.FakeAuditLogPort(),
                         credentialFlowService = buildFakeSelfService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
@@ -668,6 +668,9 @@ class ApiIdentityProviderRoutesTest {
                         passwordHasher = hasher,
                         auditLog = com.kauth.fakes.FakeAuditLogPort(),
                         credentialFlowService = buildFakeSelfService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
@@ -671,6 +671,9 @@ class ApiIdentityProviderRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
@@ -136,6 +136,9 @@ class ApiKeyManagementRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
@@ -133,6 +133,9 @@ class ApiKeyManagementRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -343,6 +343,9 @@ class ApiOtpRoutesTest {
         collisionCheck =
             com.kauth.domain.service
                 .IdentifierCollisionCheck(users),
+        usernameGenerator =
+            com.kauth.domain.service
+                .UsernameGenerator(users),
     )
 
     private fun stubMfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -340,6 +340,9 @@ class ApiOtpRoutesTest {
         passwordHasher = com.kauth.fakes.FakePasswordHasher(),
         auditLog = audit,
         credentialFlowService = stubSelfService(audit),
+        collisionCheck =
+            com.kauth.domain.service
+                .IdentifierCollisionCheck(users),
     )
 
     private fun stubMfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
@@ -145,6 +145,9 @@ class ApiPasskeyRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
@@ -148,6 +148,9 @@ class ApiPasskeyRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
@@ -133,6 +133,9 @@ class ApiRateLimitTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
@@ -130,6 +130,9 @@ class ApiRateLimitTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
@@ -128,6 +128,9 @@ class ApiRbacRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
@@ -131,6 +131,9 @@ class ApiRbacRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
@@ -123,6 +123,9 @@ class ApiReadRateLimitTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
@@ -120,6 +120,9 @@ class ApiReadRateLimitTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
@@ -154,6 +154,9 @@ class ApiResourceServerRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
@@ -151,6 +151,9 @@ class ApiResourceServerRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -161,6 +161,9 @@ class ApiRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -158,6 +158,9 @@ class ApiRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -450,6 +450,55 @@ class ApiRoutesTest {
             assertTrue(body.contains("charlie"))
         }
 
+    @Test
+    fun `POST users omitting username succeeds and returns a generated username`() =
+        testApplication {
+            application { installTestApp() }
+
+            val response =
+                client.post("/t/acme/api/v1/users") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{
+                        |"email":"generated@example.com",
+                        |"fullName":"Generated User",
+                        |"password":"StrongP@ss1"
+                        |}
+                        """.trimMargin(),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"username\""))
+            assertTrue(!body.contains("\"username\":null"), "expected a generated username, got: $body")
+        }
+
+    @Test
+    fun `POST users invite omitting username succeeds and returns a generated username`() =
+        testApplication {
+            application { installTestApp() }
+
+            val response =
+                client.post("/t/acme/api/v1/users/invite") {
+                    bearerAuth(rawApiKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{
+                        |"email":"invited@example.com",
+                        |"fullName":"Invited User"
+                        |}
+                        """.trimMargin(),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"username\""))
+            assertTrue(!body.contains("\"username\":null"), "expected a generated username, got: $body")
+        }
+
     // =========================================================================
     // Audit log query
     // =========================================================================

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
@@ -128,6 +128,9 @@ class ApiSessionAuditRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
@@ -125,6 +125,9 @@ class ApiSessionAuditRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
@@ -382,6 +382,9 @@ class ApiUserAttributeRoutesTest {
                         passwordHasher = hasher,
                         auditLog = com.kauth.fakes.FakeAuditLogPort(),
                         credentialFlowService = buildFakeSelfService(),
+                        collisionCheck =
+                            com.kauth.domain.service
+                                .IdentifierCollisionCheck(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
@@ -385,6 +385,9 @@ class ApiUserAttributeRoutesTest {
                         collisionCheck =
                             com.kauth.domain.service
                                 .IdentifierCollisionCheck(userRepo),
+                        usernameGenerator =
+                            com.kauth.domain.service
+                                .UsernameGenerator(userRepo),
                     ),
                 mfaService =
                     com.kauth.domain.service.MfaService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
@@ -144,6 +144,9 @@ class ApiUserLifecycleRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
@@ -147,6 +147,9 @@ class ApiUserLifecycleRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
@@ -123,6 +123,9 @@ class ApiUserRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
@@ -126,6 +126,9 @@ class ApiUserRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
@@ -134,6 +134,9 @@ class ApiUserStateTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
@@ -131,6 +131,9 @@ class ApiUserStateTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
@@ -132,6 +132,9 @@ class ApiWebhookRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
@@ -135,6 +135,9 @@ class ApiWebhookRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
@@ -151,6 +151,9 @@ class ApiWorkspaceRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
@@ -148,6 +148,9 @@ class ApiWorkspaceRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthErrorToMessageTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthErrorToMessageTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
  * render the same generic message as a wrong-password attempt.
  */
 class AuthErrorToMessageTest {
-    private val generic = "Invalid username or password."
+    private val generic = "Invalid sign-in details."
 
     @Test
     fun `InvalidCredentials renders the generic message`() {

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -7,6 +7,7 @@ import com.kauth.domain.model.ApplicationId
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.AuthorizationCode
 import com.kauth.domain.model.GrantType
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.ResourceServer
 import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
@@ -405,7 +406,7 @@ class AuthRoutesTest {
             assertEquals(HttpStatusCode.Unauthorized, response.status)
             val body = response.bodyAsText()
             assertTrue(
-                body.contains("Invalid username or password"),
+                body.contains("Invalid sign-in details"),
                 "Expired-password path must show the generic message, was: ${body.take(300)}",
             )
             assertFalse(body.contains("expired", ignoreCase = true), "Must not leak the expired state")
@@ -3602,6 +3603,192 @@ class AuthRoutesTest {
             val stored = authCodeRepo.findByCode(code)
             assertNotNull(stored, "Issued code must be persisted in the repository")
             assertEquals(listOf("https://api.example.com"), stored.resources)
+        }
+
+    // =========================================================================
+    // GET /t/{slug}/authorize — login identifier field per workspace mode (Task 9)
+    // =========================================================================
+
+    @Test
+    fun `GET authorize labels identifier field for email as email address`() =
+        testApplication {
+            resetFixtures()
+            tenantRepo.clear()
+            tenantRepo.add(
+                tenant.copy(
+                    securityConfig = tenant.securityConfig.copy(loginIdentifierMode = LoginIdentifierMode.EMAIL),
+                ),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.get(
+                    "/t/acme/authorize" +
+                        "?response_type=code&client_id=spa-app" +
+                        "&redirect_uri=https://app.example.com/callback" +
+                        "&scope=openid",
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Email address"), "EMAIL mode must label the field 'Email address'")
+            assertTrue(body.contains("""type="email""""), "EMAIL mode must render an email input")
+            // Tenant default has passkeys enabled, so the base "email" autocomplete value
+            // gets the " webauthn" suffix appended, per the existing passkey behaviour.
+            assertTrue(body.contains("""autocomplete="email webauthn""""), "EMAIL mode must set autocomplete=email")
+            assertTrue(body.contains("""name="username""""), "Form field name must remain 'username'")
+        }
+
+    @Test
+    fun `GET authorize labels identifier field for either as username or email`() =
+        testApplication {
+            resetFixtures()
+            tenantRepo.clear()
+            tenantRepo.add(
+                tenant.copy(
+                    securityConfig = tenant.securityConfig.copy(loginIdentifierMode = LoginIdentifierMode.EITHER),
+                ),
+            )
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.get(
+                    "/t/acme/authorize" +
+                        "?response_type=code&client_id=spa-app" +
+                        "&redirect_uri=https://app.example.com/callback" +
+                        "&scope=openid",
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Username or email"), "EITHER mode must label the field 'Username or email'")
+            assertTrue(
+                !body.contains("""type="email""""),
+                "EITHER mode must stay type=text so a real username is not blocked by native validation",
+            )
+            assertTrue(body.contains("""name="username""""), "Form field name must remain 'username'")
+        }
+
+    @Test
+    fun `GET authorize renders unchanged username label in default USERNAME mode`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response =
+                client.get(
+                    "/t/acme/authorize" +
+                        "?response_type=code&client_id=spa-app" +
+                        "&redirect_uri=https://app.example.com/callback" +
+                        "&scope=openid",
+                )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(">Username<"), "USERNAME mode must keep the plain 'Username' label")
+            assertTrue(body.contains("""name="username""""), "Form field name must remain 'username'")
+            assertTrue(
+                !body.contains("""type="email""""),
+                "USERNAME mode identifier field must not be type=email",
+            )
+        }
+
+    @Test
+    fun `POST authorize with wrong password renders the shared generic message`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val authContextCookie =
+                buildAuthContextCookie(
+                    clientId = "spa-app",
+                    redirectUri = "https://app.example.com/callback",
+                )
+
+            val noFollow = createClient { followRedirects = false }
+            val response =
+                noFollow.submitForm(
+                    url = "/t/acme/authorize",
+                    formParameters =
+                        Parameters.build {
+                            append("username", "alice")
+                            append("password", "wrong-pass")
+                        },
+                ) {
+                    header("Cookie", "KOTAUTH_AUTH_CONTEXT=$authContextCookie")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Invalid sign-in details."), "Must show the mode-agnostic failure message")
+            assertTrue(
+                !body.contains("Invalid username or password."),
+                "Old username-specific wording must not appear",
+            )
         }
 
     // Utility

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -16,6 +16,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
@@ -189,6 +190,7 @@ class AuthRoutesTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildOAuthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -19,6 +19,7 @@ import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthResult
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -187,6 +188,7 @@ class AuthRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun buildOAuthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthShellLayoutTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthShellLayoutTest.kt
@@ -1,6 +1,7 @@
 package com.kauth.adapter.web.auth
 
 import com.kauth.adapter.web.ViewContext
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.TenantTheme
 import com.kauth.infrastructure.EnglishOnlyTranslation
@@ -134,8 +135,22 @@ class AuthShellLayoutTest {
         val centeredCtx = viewContext.copy(theme = TenantTheme.DEFAULT.copy(loginLayout = LoginLayout.CENTERED))
         val splitCtx = viewContext.copy(theme = TenantTheme.DEFAULT.copy(loginLayout = LoginLayout.SPLIT))
 
-        val centeredHtml = render(AuthView.loginPage(tenantSlug = "acme", ctx = centeredCtx))
-        val splitHtml = render(AuthView.loginPage(tenantSlug = "acme", ctx = splitCtx))
+        val centeredHtml =
+            render(
+                AuthView.loginPage(
+                    tenantSlug = "acme",
+                    ctx = centeredCtx,
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
+                ),
+            )
+        val splitHtml =
+            render(
+                AuthView.loginPage(
+                    tenantSlug = "acme",
+                    ctx = splitCtx,
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
+                ),
+            )
 
         assertTrue(centeredHtml.contains("card-title"), "CENTERED login page must render the card title")
         assertTrue(splitHtml.contains("card-title"), "SPLIT login page must render the card title")

--- a/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
@@ -12,6 +12,7 @@ import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.EmailOtpService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
@@ -139,6 +140,7 @@ class EmailOtpLoginRoutesTest {
             auditLog = auditLog,
             sessionRepository = sessions,
             identifierResolver = UserIdentifierResolver(users),
+            collisionCheck = IdentifierCollisionCheck(users),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/EmailOtpLoginRoutesTest.kt
@@ -13,6 +13,7 @@ import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.EmailOtpService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -137,6 +138,7 @@ class EmailOtpLoginRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessions,
+            identifierResolver = UserIdentifierResolver(users),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
@@ -13,6 +13,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
@@ -181,6 +182,7 @@ class MagicLinkRoutesTest {
             auditLog = auditLog,
             sessionRepository = sessions,
             identifierResolver = UserIdentifierResolver(users),
+            collisionCheck = IdentifierCollisionCheck(users),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/MagicLinkRoutesTest.kt
@@ -14,6 +14,7 @@ import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -179,6 +180,7 @@ class MagicLinkRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessions,
+            identifierResolver = UserIdentifierResolver(users),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/PasskeyAuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/PasskeyAuthRoutesTest.kt
@@ -7,6 +7,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.model.WebAuthnCredential
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.domain.service.WebAuthnService
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
@@ -153,6 +154,7 @@ class PasskeyAuthRoutesTest {
                             passwordHasher = hasher,
                             auditLog = auditLog,
                             sessionRepository = sessions,
+                            identifierResolver = UserIdentifierResolver(userRepo),
                         ),
                     oauthService = buildOAuthService(),
                     tenantRepository = tenantRepo,

--- a/src/test/kotlin/com/kauth/adapter/web/auth/PasskeyAuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/PasskeyAuthRoutesTest.kt
@@ -155,6 +155,9 @@ class PasskeyAuthRoutesTest {
                             auditLog = auditLog,
                             sessionRepository = sessions,
                             identifierResolver = UserIdentifierResolver(userRepo),
+                            collisionCheck =
+                                com.kauth.domain.service
+                                    .IdentifierCollisionCheck(userRepo),
                         ),
                     oauthService = buildOAuthService(),
                     tenantRepository = tenantRepo,

--- a/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
@@ -14,6 +14,7 @@ import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -117,6 +118,7 @@ class PromptParamTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/PromptParamTest.kt
@@ -12,6 +12,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
@@ -119,6 +120,7 @@ class PromptParamTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
@@ -12,6 +12,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
@@ -122,6 +123,7 @@ class SilentAuthTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SilentAuthTest.kt
@@ -14,6 +14,7 @@ import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -120,6 +121,7 @@ class SilentAuthTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SocialButtonLabelTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SocialButtonLabelTest.kt
@@ -2,6 +2,7 @@ package com.kauth.adapter.web.auth
 
 import com.kauth.adapter.web.ViewContext
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.ProviderKind
 import com.kauth.domain.model.TenantId
@@ -55,6 +56,7 @@ class SocialButtonLabelTest {
                     tenantSlug = "acme",
                     ctx = ctx,
                     enabledProviders = listOf(row(acmeKey, "ACME Single Sign-On")).asLoginProviders(),
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -70,6 +72,7 @@ class SocialButtonLabelTest {
                     tenantSlug = "acme",
                     ctx = ctx,
                     enabledProviders = listOf(row(acmeKey, null)).asLoginProviders(),
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -84,6 +87,7 @@ class SocialButtonLabelTest {
                     tenantSlug = "acme",
                     ctx = ctx,
                     enabledProviders = listOf(row(acmeKey, "   ")).asLoginProviders(),
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -98,6 +102,7 @@ class SocialButtonLabelTest {
                     tenantSlug = "acme",
                     ctx = ctx,
                     enabledProviders = listOf(row(acmeKey, "ACME Single Sign-On")).asLoginProviders(),
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 
@@ -113,6 +118,7 @@ class SocialButtonLabelTest {
                     tenantSlug = "acme",
                     ctx = ctx,
                     enabledProviders = listOf(row(ProviderKey.GOOGLE, null)).asLoginProviders(),
+                    loginIdentifierMode = LoginIdentifierMode.USERNAME,
                 ),
             )
 

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
@@ -8,6 +8,7 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.BrokeredReferenceHasher
 import com.kauth.domain.model.GrantType
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
@@ -1203,6 +1204,34 @@ class SocialLoginRoutesTest {
             assertTrue(
                 response.bodyAsText().contains("Login with Acme Workforce SSO was cancelled or failed."),
                 "The cancelled-login page must name the operator's label, got: ${response.bodyAsText()}",
+            )
+        }
+
+    @Test
+    fun `the callback error re-render labels the identifier field per the workspace's EMAIL mode`() =
+        testApplication {
+            resetFixtures()
+            tenantRepo.clear()
+            tenantRepo.add(
+                tenant.copy(
+                    securityConfig = tenant.securityConfig.copy(loginIdentifierMode = LoginIdentifierMode.EMAIL),
+                ),
+            )
+            idpRepo.seed(TenantId(1), "google")
+            installSocialRoutes()
+
+            // Same IdP-returned-error re-render as the label test above, on an EMAIL-mode
+            // workspace: the recovery path from a failed social login must not tell the user
+            // to type a "Username" they were never given one of.
+            val response = client.get("/t/acme/auth/social/google/callback?error=access_denied")
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Email address"), "EMAIL-mode error re-render must say 'Email address'")
+            assertTrue(body.contains("""type="email""""), "EMAIL-mode error re-render must use an email input")
+            assertTrue(
+                !body.contains(">Username<"),
+                "EMAIL-mode error re-render must not fall back to the 'Username' label",
             )
         }
 

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
@@ -18,6 +18,7 @@ import com.kauth.domain.port.RateLimiterPort
 import com.kauth.domain.port.SocialUserProfile
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.JitProvisioningService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginService
@@ -117,6 +118,7 @@ class SocialLoginRoutesTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun buildOAuthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
@@ -21,6 +21,7 @@ import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.JitProvisioningService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.SocialLoginService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.domain.util.Pkce
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
@@ -115,6 +116,7 @@ class SocialLoginRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun buildOAuthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SocialLoginRoutesTest.kt
@@ -148,6 +148,7 @@ class SocialLoginRoutesTest {
                 StaticSocialProviderResolver(
                     mapOf(ProviderKey.GOOGLE to googleAdapter, orianaKey to orianaAdapter),
                 ),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
             jitProvisioning =
                 JitProvisioningService(
                     userRepository = userRepo,

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
@@ -14,6 +14,7 @@ import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -144,6 +145,7 @@ class SsoCookieTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoCookieTest.kt
@@ -12,6 +12,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
@@ -146,6 +147,7 @@ class SsoCookieTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
@@ -11,6 +11,7 @@ import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
+import com.kauth.domain.service.IdentifierCollisionCheck
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
 import com.kauth.domain.service.UserIdentifierResolver
@@ -117,6 +118,7 @@ class SsoLogoutTest {
             auditLog = auditLog,
             sessionRepository = sessionRepo,
             identifierResolver = UserIdentifierResolver(userRepo),
+            collisionCheck = IdentifierCollisionCheck(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/SsoLogoutTest.kt
@@ -13,6 +13,7 @@ import com.kauth.domain.service.AuthService
 import com.kauth.domain.service.CredentialFlowService
 import com.kauth.domain.service.MfaService
 import com.kauth.domain.service.OAuthService
+import com.kauth.domain.service.UserIdentifierResolver
 import com.kauth.fakes.FakeApplicationRepository
 import com.kauth.fakes.FakeAuditLogPort
 import com.kauth.fakes.FakeAuthorizationCodeRepository
@@ -115,6 +116,7 @@ class SsoLogoutTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessionRepo,
+            identifierResolver = UserIdentifierResolver(userRepo),
         )
 
     private fun oauthService() =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
@@ -140,6 +140,9 @@ class ScimDiscoveryRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
@@ -143,6 +143,9 @@ class ScimDiscoveryRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
@@ -322,7 +322,7 @@ class ScimDiscoveryRoutesTest {
         }
 
     @Test
-    fun `the User schema advertises userName as case-sensitive and immutable`() =
+    fun `the User schema advertises userName as case-insensitive and immutable`() =
         testApplication {
             application { installTestApp() }
 
@@ -341,9 +341,10 @@ class ScimDiscoveryRoutesTest {
                     .first { it.jsonObject["name"]!!.jsonPrimitive.content == "userName" }
                     .jsonObject
 
-            // Matching is case-sensitive end to end (ScimFilter, PostgresUserRepository), and a
-            // PUT/PATCH rename is rejected — the schema must not claim otherwise.
-            assertEquals(true, userName["caseExact"]?.jsonPrimitive?.boolean)
+            // Storage is always lowercase and matching is case-insensitive end to end
+            // (ScimUserMapper normalizes on write, PostgresUserRepository's lookup is
+            // IgnoreCase); a PUT/PATCH rename is still rejected — the schema must reflect both.
+            assertEquals(false, userName["caseExact"]?.jsonPrimitive?.boolean)
             assertEquals("immutable", userName["mutability"]?.jsonPrimitive?.content)
         }
 

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
@@ -155,6 +155,9 @@ class ScimGroupRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
@@ -1057,7 +1057,7 @@ class ScimGroupRoutesTest {
             // with just the one member the connector sent, losing every role it granted.
             val existingMembers = (1..400).map { addUser("u$it") }
             val group = addGroup("Engineering", members = existingMembers)
-            val newMember = addUser("newHire")
+            val newMember = addUser("newhire")
 
             val response =
                 client.patch(groupUrl(group.id!!.value)) {
@@ -1295,7 +1295,7 @@ class ScimGroupRoutesTest {
             val u1 = addUser("u1")
             val u2 = addUser("u2")
             val u3 = addUser("u3")
-            val newMember = addUser("newMember")
+            val newMember = addUser("newmember")
             val group = addGroup("Engineering", members = listOf(u1, u2, u3))
 
             val response =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
@@ -152,6 +152,9 @@ class ScimGroupRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
@@ -130,6 +130,9 @@ class ScimRateLimitTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
@@ -133,6 +133,9 @@ class ScimRateLimitTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
@@ -142,6 +142,9 @@ class ScimRequestBodySizeLimitTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
@@ -145,6 +145,9 @@ class ScimRequestBodySizeLimitTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
@@ -170,6 +170,9 @@ class ScimUserRoutesTest {
             collisionCheck =
                 com.kauth.domain.service
                     .IdentifierCollisionCheck(userRepo),
+            usernameGenerator =
+                com.kauth.domain.service
+                    .UsernameGenerator(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
@@ -167,6 +167,9 @@ class ScimUserRoutesTest {
             passwordHasher = hasher,
             auditLog = auditLogPort,
             credentialFlowService = accountSelfService,
+            collisionCheck =
+                com.kauth.domain.service
+                    .IdentifierCollisionCheck(userRepo),
         )
 
     private val mfaService =

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
@@ -961,6 +961,49 @@ class ScimUserRoutesTest {
             assertEquals("uniqueness", body["scimType"]?.jsonPrimitive?.content)
         }
 
+    // Regression coverage for the cross-namespace collision check wired into AdminUserService's
+    // createUser/resolveUsername paths (Task 4/6): the two namespaces are separately unique in the
+    // schema, so without this check SCIM could still create a pair no login mode can resolve.
+    @Test
+    fun `a userName equal to a different user's email is rejected`() =
+        testApplication {
+            application { installTestApp() }
+            addUser("alice")
+
+            val response =
+                client.post("/t/acme/scim/v2/Users") {
+                    bearerAuth(scimKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(createBody("alice@example.com"))
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            val body = jsonCodec.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals("invalidValue", body["scimType"]?.jsonPrimitive?.content)
+            assertNull(userRepo.findByUsername(acme.id, "alice@example.com"))
+        }
+
+    @Test
+    fun `a user whose own userName equals their own email is created successfully`() =
+        testApplication {
+            application { installTestApp() }
+
+            val response =
+                client.post("/t/acme/scim/v2/Users") {
+                    bearerAuth(scimKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],""" +
+                            """"userName":"sameident@example.com",""" +
+                            """"emails":[{"value":"sameident@example.com","type":"work"}]}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val stored = userRepo.findByUsername(acme.id, "sameident@example.com")
+            assertEquals("sameident@example.com", stored?.email)
+        }
+
     // -------------------------------------------------------------------------
     // GET /Users/{id}
     // -------------------------------------------------------------------------
@@ -1057,6 +1100,32 @@ class ScimUserRoutesTest {
             val stored = userRepo.findById(putUser.id!!, acme.id)
             assertNull(stored?.givenName)
             assertNull(stored?.familyName)
+        }
+
+    // Regression coverage for the cross-namespace collision check that runs unconditionally
+    // inside AdminUserService.resolveUsername (Task 6), reached here via PUT -> replaceUserProfile.
+    @Test
+    fun `PUT changing email to equal a different user's username is rejected`() =
+        testApplication {
+            application { installTestApp() }
+            addUser("shared@example.com")
+            val target = addUser("carol")
+
+            val response =
+                client.put("/t/acme/scim/v2/Users/${target.id!!.value}") {
+                    bearerAuth(scimKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],""" +
+                            """"userName":"carol",""" +
+                            """"emails":[{"value":"shared@example.com","type":"work"}]}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            val body = jsonCodec.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals("invalidValue", body["scimType"]?.jsonPrimitive?.content)
+            assertEquals("carol@example.com", userRepo.findById(target.id!!, acme.id)?.email)
         }
 
     @Test

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
@@ -577,6 +577,53 @@ class ScimUserRoutesTest {
         }
 
     @Test
+    fun `a mixed-case userName round-trips through create, PUT, and filter by either case`() =
+        testApplication {
+            application { installTestApp() }
+
+            // Okta/Entra commonly send a mixed-case UPN as userName.
+            val created =
+                client.post("/t/acme/scim/v2/Users") {
+                    bearerAuth(scimKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(createBody("Dave.Smith"))
+                }
+            assertEquals(HttpStatusCode.Created, created.status)
+            val createdBody = jsonCodec.parseToJsonElement(created.bodyAsText()).jsonObject
+            assertEquals("dave.smith", createdBody["userName"]!!.jsonPrimitive.content)
+            val userId = createdBody["id"]!!.jsonPrimitive.content
+
+            // Resending the SAME mixed-case value the connector originally used must succeed —
+            // it normalizes to what's already stored, so it is not a rename.
+            val put =
+                client.put("/t/acme/scim/v2/Users/$userId") {
+                    bearerAuth(scimKey)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"Dave.Smith",""" +
+                            """"emails":[{"value":"dave.smith@example.com","type":"work"}]}""",
+                    )
+                }
+            assertEquals(HttpStatusCode.OK, put.status)
+            assertEquals("dave.smith", userRepo.findByUsernameIgnoreCase(acme.id, "dave.smith")?.username)
+
+            val filterMixedCase =
+                client.get(usersUrl("""userName eq "Dave.Smith"""")) { bearerAuth(scimKey) }
+            assertEquals(HttpStatusCode.OK, filterMixedCase.status)
+            val mixedCaseResources =
+                jsonCodec.parseToJsonElement(filterMixedCase.bodyAsText()).jsonObject["Resources"]!!.jsonArray
+            assertEquals(1, mixedCaseResources.size)
+            assertEquals("dave.smith", mixedCaseResources[0].jsonObject["userName"]!!.jsonPrimitive.content)
+
+            val filterLowerCase =
+                client.get(usersUrl("""userName eq "dave.smith"""")) { bearerAuth(scimKey) }
+            assertEquals(HttpStatusCode.OK, filterLowerCase.status)
+            val lowerCaseResources =
+                jsonCodec.parseToJsonElement(filterLowerCase.bodyAsText()).jsonObject["Resources"]!!.jsonArray
+            assertEquals(1, lowerCaseResources.size)
+        }
+
+    @Test
     fun `filter by externalId returns only the matching user`() =
         testApplication {
             application { installTestApp() }

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -760,6 +760,55 @@ class AdminServicesTest {
         assertEquals("alice", result.value.username)
     }
 
+    @Test
+    fun `updateUser - audit records the new username only when it actually changed`() {
+        auditLog.clear()
+        userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "alice.renamed")
+        val event = auditLog.events.last { it.eventType == AuditEventType.ADMIN_USER_UPDATED }
+        assertEquals("alice.renamed", event.details["newUsername"])
+    }
+
+    @Test
+    fun `updateUser - audit omits newUsername when the username is unchanged`() {
+        auditLog.clear()
+        userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), fullName = "Alice Renamed")
+        val event = auditLog.events.last { it.eventType == AuditEventType.ADMIN_USER_UPDATED }
+        assertTrue(!event.details.containsKey("newUsername"))
+    }
+
+    @Test
+    fun `replaceUserProfile - username null leaves the existing username untouched`() {
+        val result =
+            userSvc.replaceUserProfile(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "alice@example.com",
+                fullName = "Alice Test",
+                externalId = null,
+                givenName = null,
+                familyName = null,
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice", result.value.username)
+    }
+
+    @Test
+    fun `replaceUserProfile - renames the username when provided`() {
+        val result =
+            userSvc.replaceUserProfile(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "alice@example.com",
+                fullName = "Alice Test",
+                externalId = null,
+                givenName = null,
+                familyName = null,
+                username = "alice.renamed",
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice.renamed", result.value.username)
+    }
+
     // =========================================================================
     // setUserEnabled
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -740,6 +740,32 @@ class AdminServicesTest {
     }
 
     @Test
+    fun `updateUser rejects an email equal to another user's username even when no rename is requested`() {
+        users.add(alice.copy(id = UserId(20), username = "bob@example.com", email = "bob@other.com"))
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), email = "bob@example.com")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `replaceUserProfile rejects an email equal to another user's username even when no rename is requested`() {
+        users.add(alice.copy(id = UserId(20), username = "bob@example.com", email = "bob@other.com"))
+        val result =
+            userSvc.replaceUserProfile(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "bob@example.com",
+                fullName = "Alice Test",
+                externalId = null,
+                givenName = null,
+                familyName = null,
+                username = null,
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
     fun `updateUser - allows setting the username to the user's own email`() {
         val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "alice@example.com")
         assertIs<AdminResult.Success<User>>(result)

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -84,6 +84,8 @@ class AdminServicesTest {
             emailBrandingRepository = emailBranding,
         )
 
+    private val collisionCheck = IdentifierCollisionCheck(users)
+
     private val userSvc =
         AdminUserService(
             tenantRepository = tenants,
@@ -92,6 +94,7 @@ class AdminServicesTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             credentialFlowService = credentialFlowService,
+            collisionCheck = collisionCheck,
             passwordPolicy = passwordPolicy,
             emailPort = emailPort,
         )
@@ -361,6 +364,49 @@ class AdminServicesTest {
         assertEquals("bob", result.value.username)
         assertEquals(true, result.value.emailVerified, "Admin-created users should be email-verified")
         assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_CREATED))
+    }
+
+    @Test
+    fun `createUser rejects a username equal to another users email`() {
+        users.add(alice.copy(id = UserId(50), username = "bob", email = "carol@example.com"))
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "carol@example.com",
+                email = "newperson@example.com",
+                fullName = "New Person",
+                password = "password123",
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser rejects an email equal to another users username`() {
+        users.add(alice.copy(id = UserId(51), username = "dave@example.com", email = "dave-alt@example.com"))
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "eve",
+                email = "dave@example.com",
+                fullName = "Eve",
+                password = "password123",
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser allows a username equal to the same users own email`() {
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "frank@example.com",
+                email = "frank@example.com",
+                fullName = "Frank",
+                password = "password123",
+            )
+        assertIs<AdminResult.Success<User>>(result)
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -809,6 +809,71 @@ class AdminServicesTest {
         assertEquals("alice.renamed", result.value.username)
     }
 
+    @Test
+    fun `updateUser - unrelated fields updatable for a stored username that predates format validation`() {
+        users.add(alice.copy(username = "john doe"))
+        val result =
+            userSvc.updateUser(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "newalice@example.com",
+                fullName = "Alice Updated",
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("john doe", result.value.username)
+        assertEquals("newalice@example.com", result.value.email)
+        assertEquals("Alice Updated", result.value.fullName)
+    }
+
+    @Test
+    fun `updateUser - renaming a stored non-conforming username to an invalid format still fails`() {
+        users.add(alice.copy(username = "john doe"))
+        val result =
+            userSvc.updateUser(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                username = "not valid!",
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertEquals("john doe", users.findById(UserId(10), TenantId(1))!!.username)
+    }
+
+    @Test
+    fun `replaceUserProfile - unrelated fields updatable for a stored username that predates format validation`() {
+        users.add(alice.copy(username = "john doe"))
+        val result =
+            userSvc.replaceUserProfile(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "newalice@example.com",
+                fullName = "Alice Updated",
+                externalId = null,
+                givenName = null,
+                familyName = null,
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("john doe", result.value.username)
+        assertEquals("newalice@example.com", result.value.email)
+        assertEquals("Alice Updated", result.value.fullName)
+    }
+
+    @Test
+    fun `updateUser - a pre-existing colliding pair can still have unrelated fields updated`() {
+        // Legal before this feature existed: user 10's username equals user 20's email.
+        users.add(alice.copy(username = "taken@example.com"))
+        users.add(alice.copy(id = UserId(20), username = "zoe", email = "taken@example.com"))
+        val result =
+            userSvc.updateUser(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                fullName = "Alice Updated",
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("Alice Updated", result.value.fullName)
+        assertEquals("taken@example.com", result.value.username)
+    }
+
     // =========================================================================
     // setUserEnabled
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -714,6 +714,52 @@ class AdminServicesTest {
         assertEquals("Alice Test", result.value.fullName)
     }
 
+    @Test
+    fun `updateUser - changes the username`() {
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "alice.new")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice.new", result.value.username)
+        assertEquals("alice.new", users.findById(UserId(10), TenantId(1))!!.username)
+        assertTrue(auditLog.hasEvent(AuditEventType.ADMIN_USER_UPDATED))
+    }
+
+    @Test
+    fun `updateUser - rejects a username that is another user's email`() {
+        users.add(alice.copy(id = UserId(20), username = "zoe", email = "taken@example.com"))
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "taken@example.com")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateUser - rejects a username already taken as another user's username`() {
+        users.add(alice.copy(id = UserId(20), username = "zoe", email = "zoe@example.com"))
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "zoe")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Conflict>(result.error)
+    }
+
+    @Test
+    fun `updateUser - allows setting the username to the user's own email`() {
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "alice@example.com")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice@example.com", result.value.username)
+    }
+
+    @Test
+    fun `updateUser - rejects an invalid username format`() {
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "not valid!")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `updateUser - null username leaves the existing username untouched`() {
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), fullName = "Alice Renamed")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("alice", result.value.username)
+    }
+
     // =========================================================================
     // setUserEnabled
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -414,12 +414,15 @@ class AdminServicesTest {
 
     @Test
     fun `createUser rejects an email equal to another users username in different case`() {
-        users.add(alice.copy(id = UserId(52), username = "Dave@Example.com", email = "dave-alt2@example.com"))
+        // Production never stores a mixed-case username (see UsernamePolicy) — the case
+        // difference this test exercises comes from the NEW request's email instead, which
+        // createUser itself lowercases before the collision check runs.
+        users.add(alice.copy(id = UserId(52), username = "dave2@example.com", email = "dave-alt2@example.com"))
         val result =
             userSvc.createUser(
                 tenantId = TenantId(1),
                 username = "gail",
-                email = "dave@example.com",
+                email = "Dave2@Example.com",
                 fullName = "Gail",
                 password = "password123",
             )

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -85,6 +85,7 @@ class AdminServicesTest {
         )
 
     private val collisionCheck = IdentifierCollisionCheck(users)
+    private val usernameGenerator = UsernameGenerator(users)
 
     private val userSvc =
         AdminUserService(
@@ -95,6 +96,7 @@ class AdminServicesTest {
             auditLog = auditLog,
             credentialFlowService = credentialFlowService,
             collisionCheck = collisionCheck,
+            usernameGenerator = usernameGenerator,
             passwordPolicy = passwordPolicy,
             emailPort = emailPort,
         )
@@ -226,17 +228,18 @@ class AdminServicesTest {
     }
 
     @Test
-    fun `createUser - blank username`() {
+    fun `createUser generates a username when none is supplied`() {
         val result =
             userSvc.createUser(
                 tenantId = TenantId(1),
                 username = "  ",
-                email = "bob@x.com",
-                fullName = "Bob",
+                email = "ana@company-a.com",
+                fullName = "Ana Ruiz",
                 password = "password123",
+                givenName = "Ana",
             )
-        assertIs<AdminResult.Failure>(result)
-        assertIs<AdminError.Validation>(result.error)
+        assertIs<AdminResult.Success<User>>(result)
+        assertTrue(result.value.username.startsWith("ana"), "got ${result.value.username}")
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -409,6 +409,49 @@ class AdminServicesTest {
         assertIs<AdminResult.Success<User>>(result)
     }
 
+    @Test
+    fun `createUser rejects an email equal to another users username in different case`() {
+        users.add(alice.copy(id = UserId(52), username = "Dave@Example.com", email = "dave-alt2@example.com"))
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "gail",
+                email = "dave@example.com",
+                fullName = "Gail",
+                password = "password123",
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser rejects a username equal to another users email in different case`() {
+        users.add(alice.copy(id = UserId(53), username = "harold", email = "Carol2@Example.com"))
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "carol2@example.com",
+                email = "newperson2@example.com",
+                fullName = "New Person 2",
+                password = "password123",
+            )
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `createUser allows a username equal to the same users own email in different case`() {
+        val result =
+            userSvc.createUser(
+                tenantId = TenantId(1),
+                username = "Frank2@Example.com",
+                email = "frank2@example.com",
+                fullName = "Frank Two",
+                password = "password123",
+            )
+        assertIs<AdminResult.Success<User>>(result)
+    }
+
     // =========================================================================
     // createUser — invite mode
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -5,6 +5,7 @@ import com.kauth.domain.model.Application
 import com.kauth.domain.model.ApplicationId
 import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.GrantType
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.RequiredAction
 import com.kauth.domain.model.SecurityConfig
 import com.kauth.domain.model.Tenant
@@ -1295,6 +1296,7 @@ class AdminServicesTest {
             emailOtpLockoutThreshold = 5,
             emailOtpLoginEnabled = false,
             passkeysEnabled = true,
+            loginIdentifierMode = LoginIdentifierMode.USERNAME,
         )
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminServicesTest.kt
@@ -766,6 +766,44 @@ class AdminServicesTest {
     }
 
     @Test
+    fun `updateUser allows a fullName-only change when the user's OWN stored email already collides`() {
+        // Alice's stored email happens to equal another user's username — a pre-existing,
+        // already-tolerated pair. It must not block an update that never touches the email.
+        users.add(alice.copy(id = UserId(20), username = "alice@example.com", email = "other@example.com"))
+        val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), fullName = "Alice Renamed")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("Alice Renamed", result.value.fullName)
+        assertEquals("alice@example.com", result.value.email)
+    }
+
+    @Test
+    fun `updateUser still rejects a NEWLY set email that collides with another user's username`() {
+        users.add(alice.copy(id = UserId(20), username = "newname@example.com", email = "other@example.com"))
+        val result =
+            userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), email = "newname@example.com")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+    }
+
+    @Test
+    fun `replaceUserProfile allows a fullName-only change when the user's OWN stored email already collides`() {
+        users.add(alice.copy(id = UserId(20), username = "alice@example.com", email = "other@example.com"))
+        val result =
+            userSvc.replaceUserProfile(
+                userId = UserId(10),
+                tenantId = TenantId(1),
+                email = "alice@example.com",
+                fullName = "Alice Renamed",
+                externalId = null,
+                givenName = null,
+                familyName = null,
+                username = null,
+            )
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("Alice Renamed", result.value.fullName)
+    }
+
+    @Test
     fun `updateUser - allows setting the username to the user's own email`() {
         val result = userSvc.updateUser(userId = UserId(10), tenantId = TenantId(1), username = "alice@example.com")
         assertIs<AdminResult.Success<User>>(result)

--- a/src/test/kotlin/com/kauth/domain/service/AdminUserServiceUsernameNormalizationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminUserServiceUsernameNormalizationTest.kt
@@ -1,0 +1,142 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeEmailPort
+import com.kauth.fakes.FakeEmailVerificationTokenRepository
+import com.kauth.fakes.FakePasswordHasher
+import com.kauth.fakes.FakePasswordResetTokenRepository
+import com.kauth.fakes.FakeSessionRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Part A of the login-identifier hardening wave: [AdminUserService.createUser] and the rename
+ * path shared by `updateUser`/`replaceUserProfile` (`resolveUsername`) must normalize a username
+ * (trim + lowercase) FIRST, then validate against [UsernamePolicy.USERNAME_PATTERN] — accepting
+ * a merely differently-cased or padded value, rejecting one that is still invalid afterward.
+ */
+class AdminUserServiceUsernameNormalizationTest {
+    private val tenants = FakeTenantRepository()
+    private val users = FakeUserRepository()
+    private val sessions = FakeSessionRepository()
+    private val hasher = FakePasswordHasher()
+    private val auditLog = FakeAuditLogPort()
+    private val emailPort = FakeEmailPort()
+
+    private val credentialFlowService =
+        CredentialFlowService(
+            userRepository = users,
+            tenantRepository = tenants,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            evTokenRepo = FakeEmailVerificationTokenRepository(),
+            prTokenRepo = FakePasswordResetTokenRepository(),
+            emailPort = emailPort,
+        )
+
+    private val svc =
+        AdminUserService(
+            tenantRepository = tenants,
+            userRepository = users,
+            sessionRepository = sessions,
+            passwordHasher = hasher,
+            auditLog = auditLog,
+            credentialFlowService = credentialFlowService,
+            collisionCheck = IdentifierCollisionCheck(users),
+            usernameGenerator = UsernameGenerator(users),
+        )
+
+    private val tenantId = TenantId(1)
+
+    @BeforeTest
+    fun setup() {
+        tenants.clear()
+        users.clear()
+        tenants.add(Tenant(id = tenantId, slug = "acme", displayName = "Acme", issuerUrl = null))
+    }
+
+    // -------------------------------------------------------------------------
+    // createUser
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createUser normalizes a mixed-case username to lowercase`() {
+        val result = svc.createUser(tenantId, "Dave", "dave@x.com", "Dave", password = "Password8!")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("dave", result.value.username)
+    }
+
+    @Test
+    fun `createUser trims surrounding whitespace from the username`() {
+        val result = svc.createUser(tenantId, "  ana  ", "ana@x.com", "Ana", password = "Password8!")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("ana", result.value.username)
+    }
+
+    @Test
+    fun `createUser rejects a username with characters outside the allowed set even after normalizing`() {
+        val result = svc.createUser(tenantId, "john doe", "johndoe@x.com", "John Doe", password = "Password8!")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertEquals(null, users.findByEmail(tenantId, "johndoe@x.com"))
+    }
+
+    // -------------------------------------------------------------------------
+    // resolveUsername (via updateUser)
+    // -------------------------------------------------------------------------
+
+    private fun seedUser(username: String = "carol"): User =
+        users.add(
+            User(
+                tenantId = tenantId,
+                username = username,
+                email = "carol@x.com",
+                fullName = "Carol",
+                passwordHash = hasher.hash("x"),
+                enabled = true,
+            ),
+        )
+
+    @Test
+    fun `updateUser rename normalizes a mixed-case username to lowercase`() {
+        val user = seedUser()
+        val result = svc.updateUser(user.id!!, tenantId, username = "Dave")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("dave", result.value.username)
+    }
+
+    @Test
+    fun `updateUser rename trims surrounding whitespace from the username`() {
+        val user = seedUser()
+        val result = svc.updateUser(user.id!!, tenantId, username = "  dave  ")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("dave", result.value.username)
+    }
+
+    @Test
+    fun `updateUser rename rejects a username with characters outside the allowed set`() {
+        val user = seedUser()
+        val result = svc.updateUser(user.id!!, tenantId, username = "john doe")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        // The stored username must be unchanged.
+        assertEquals("carol", users.findById(user.id, tenantId)!!.username)
+    }
+
+    @Test
+    fun `updateUser resubmitting the same username in a different case is not treated as a rename`() {
+        val user = seedUser("dave")
+        // Normalizes to the already-stored value — must succeed as a no-op rename, not a collision.
+        val result = svc.updateUser(user.id!!, tenantId, username = "Dave")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals("dave", result.value.username)
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/AdminUserServiceUsernameNormalizationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AdminUserServiceUsernameNormalizationTest.kt
@@ -89,6 +89,23 @@ class AdminUserServiceUsernameNormalizationTest {
         assertEquals(null, users.findByEmail(tenantId, "johndoe@x.com"))
     }
 
+    @Test
+    fun `createUser rejects a username longer than the column allows`() {
+        val tooLong = "a".repeat(UsernamePolicy.MAX_LENGTH + 1)
+        val result = svc.createUser(tenantId, tooLong, "toolong@x.com", "Too Long", password = "Password8!")
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertEquals(null, users.findByEmail(tenantId, "toolong@x.com"))
+    }
+
+    @Test
+    fun `createUser accepts a username at exactly the column limit`() {
+        val maxLength = "a".repeat(UsernamePolicy.MAX_LENGTH)
+        val result = svc.createUser(tenantId, maxLength, "atlimit@x.com", "At Limit", password = "Password8!")
+        assertIs<AdminResult.Success<User>>(result)
+        assertEquals(maxLength, result.value.username)
+    }
+
     // -------------------------------------------------------------------------
     // resolveUsername (via updateUser)
     // -------------------------------------------------------------------------
@@ -138,5 +155,15 @@ class AdminUserServiceUsernameNormalizationTest {
         val result = svc.updateUser(user.id!!, tenantId, username = "Dave")
         assertIs<AdminResult.Success<User>>(result)
         assertEquals("dave", result.value.username)
+    }
+
+    @Test
+    fun `updateUser rename rejects a username longer than the column allows`() {
+        val user = seedUser()
+        val tooLong = "a".repeat(UsernamePolicy.MAX_LENGTH + 1)
+        val result = svc.updateUser(user.id!!, tenantId, username = tooLong)
+        assertIs<AdminResult.Failure>(result)
+        assertIs<AdminError.Validation>(result.error)
+        assertEquals("carol", users.findById(user.id, tenantId)!!.username)
     }
 }

--- a/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
@@ -277,6 +277,41 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `register normalizes a mixed-case username to lowercase before storing`() {
+        val result =
+            svc.register("acme", "Dave", "dave@x.com", "Dave", "Password8!", "Password8!", "http://localhost")
+        assertIs<AuthResult.Success<User>>(result)
+        assertEquals("dave", result.value.username)
+    }
+
+    @Test
+    fun `register trims surrounding whitespace from the username before storing`() {
+        val result =
+            svc.register("acme", "  ana  ", "ana@x.com", "Ana", "Password8!", "Password8!", "http://localhost")
+        assertIs<AuthResult.Success<User>>(result)
+        assertEquals("ana", result.value.username)
+    }
+
+    @Test
+    fun `register rejects a username with characters outside the allowed set even after normalizing`() {
+        // register previously had NO username format validation at all — this is the
+        // regression test for that gap.
+        val result =
+            svc.register(
+                "acme",
+                "john doe",
+                "johndoe@x.com",
+                "John Doe",
+                "Password8!",
+                "Password8!",
+                "http://localhost",
+            )
+        assertIs<AuthResult.Failure>(result)
+        assertIs<AuthError.ValidationError>(result.error)
+        assertTrue(users.findByEmail(TenantId(1), "johndoe@x.com") == null, "invalid username must not be persisted")
+    }
+
+    @Test
     fun `register returns ValidationError when passwords do not match`() {
         val result = svc.register("acme", "bob", "bob@x.com", "Bob", "passA1!x", "passB1!x", "http://localhost")
         assertIs<AuthResult.Failure>(result)
@@ -713,6 +748,32 @@ class AuthServiceTest {
         )
         assertIs<AuthResult.Success<User>>(svc.authenticate("acme", "alice", "correct-pass"))
         assertIs<AuthResult.Success<User>>(svc.authenticate("acme", "alice@example.com", "correct-pass"))
+    }
+
+    @Test
+    fun `authenticate matches a stored lowercase username case-insensitively in USERNAME mode`() {
+        users.add(activeUser.copy(id = UserId(30), username = "dave", email = "dave@example.com"))
+        for (typed in listOf("Dave", "DAVE", "  dave  ")) {
+            val result = svc.authenticate("acme", typed, "correct-pass")
+            assertIs<AuthResult.Success<User>>(result, "expected success for submitted '$typed'")
+            assertEquals("dave", result.value.username)
+        }
+    }
+
+    @Test
+    fun `authenticate matches a stored lowercase username case-insensitively in EITHER mode`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EITHER),
+            ),
+        )
+        users.add(activeUser.copy(id = UserId(31), username = "dave", email = "dave@example.com"))
+        for (typed in listOf("Dave", "DAVE", "  dave  ")) {
+            val result = svc.authenticate("acme", typed, "correct-pass")
+            assertIs<AuthResult.Success<User>>(result, "expected success for submitted '$typed'")
+            assertEquals("dave", result.value.username)
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
@@ -337,6 +337,114 @@ class AuthServiceTest {
         assertTrue(auditLog.hasEvent(AuditEventType.REGISTER_SUCCESS))
     }
 
+    @Test
+    fun `register rejects a username equal to a different user's email`() {
+        users.add(
+            User(
+                tenantId = TenantId(1),
+                username = "carol",
+                email = "taken@example.com",
+                fullName = "Carol",
+                passwordHash = hasher.hash("x"),
+                enabled = true,
+            ),
+        )
+
+        val result =
+            svc.register(
+                "acme",
+                "taken@example.com",
+                "newguy@example.com",
+                "New Guy",
+                "Password8!",
+                "Password8!",
+                "http://localhost",
+            )
+
+        assertIs<AuthResult.Failure>(result)
+        // Pins the deliberate choice: neither UserAlreadyExists nor EmailAlreadyExists fits a
+        // cross-namespace collision, so it must come back as ValidationError.
+        assertIs<AuthError.ValidationError>(result.error)
+    }
+
+    @Test
+    fun `register rejects an email equal to a different user's username`() {
+        users.add(
+            User(
+                tenantId = TenantId(1),
+                username = "dave@example.com",
+                email = "dave-actual@example.com",
+                fullName = "Dave",
+                passwordHash = hasher.hash("x"),
+                enabled = true,
+            ),
+        )
+
+        val result =
+            svc.register(
+                "acme",
+                "newguy2",
+                "dave@example.com",
+                "New Guy Two",
+                "Password8!",
+                "Password8!",
+                "http://localhost",
+            )
+
+        assertIs<AuthResult.Failure>(result)
+        assertIs<AuthError.ValidationError>(result.error)
+    }
+
+    @Test
+    fun `register allows a username equal to the registrant's own email`() {
+        // This is the legal shape integrators want; the collision check must not reject a user
+        // colliding only with themselves.
+        val result =
+            svc.register(
+                "acme",
+                "frank@example.com",
+                "frank@example.com",
+                "Frank",
+                "Password8!",
+                "Password8!",
+                "http://localhost",
+            )
+
+        assertIs<AuthResult.Success<User>>(result)
+        assertEquals("frank@example.com", result.value.username)
+        assertEquals("frank@example.com", result.value.email)
+    }
+
+    @Test
+    fun `register collision check compares the same normalised values that get persisted`() {
+        users.add(
+            User(
+                tenantId = TenantId(1),
+                username = "erin",
+                email = "taken@example.com",
+                fullName = "Erin",
+                passwordHash = hasher.hash("x"),
+                enabled = true,
+            ),
+        )
+
+        // register persists username.trim() — untrimmed, differently-cased whitespace around the
+        // raw parameter must not let this slip past the check.
+        val result =
+            svc.register(
+                "acme",
+                "  TAKEN@example.com  ",
+                "newguy3@example.com",
+                "New Guy Three",
+                "Password8!",
+                "Password8!",
+                "http://localhost",
+            )
+
+        assertIs<AuthResult.Failure>(result)
+        assertIs<AuthError.ValidationError>(result.error)
+    }
+
     // =========================================================================
     // login()
     // =========================================================================

--- a/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
@@ -49,6 +49,7 @@ class AuthServiceTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             sessionRepository = sessions,
+            identifierResolver = UserIdentifierResolver(users),
         )
 
     // -------------------------------------------------------------------------
@@ -653,5 +654,16 @@ class AuthServiceTest {
 
         assertEquals(1, ambiguousHashes)
         assertEquals(missHashes, ambiguousHashes)
+    }
+
+    @Test
+    fun `authenticate trims surrounding whitespace from the submitted identifier`() {
+        // USERNAME mode is the tenant default (testTenant / @BeforeTest).
+        val trimmed = svc.authenticate("acme", "  alice  ", "correct-pass")
+        val exact = svc.authenticate("acme", "alice", "correct-pass")
+
+        assertIs<AuthResult.Success<User>>(trimmed)
+        assertIs<AuthResult.Success<User>>(exact)
+        assertEquals(exact.value.id, trimmed.value.id)
     }
 }

--- a/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
@@ -1,7 +1,9 @@
 package com.kauth.domain.service
 
 import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.RequiredAction
+import com.kauth.domain.model.SecurityConfig
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.User
@@ -18,6 +20,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -559,5 +562,96 @@ class AuthServiceTest {
         val before = hasher.verifyCallCount
         svc.authenticate("acme", "alice", "correct-pass")
         assertTrue(hasher.verifyCallCount > before, "Dummy verify must run when the user has a pending invite")
+    }
+
+    // -------------------------------------------------------------------------
+    // Login identifier resolution (username / email / either)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `authenticate succeeds by email in EMAIL mode`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EMAIL),
+            ),
+        )
+        val result = svc.authenticate("acme", "alice@example.com", "correct-pass")
+        assertIs<AuthResult.Success<User>>(result)
+    }
+
+    @Test
+    fun `authenticate rejects username in EMAIL mode`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EMAIL),
+            ),
+        )
+        val result = svc.authenticate("acme", "alice", "correct-pass")
+        assertIs<AuthResult.Failure>(result)
+        assertIs<AuthError.InvalidCredentials>(result.error)
+    }
+
+    @Test
+    fun `authenticate accepts both identifiers in EITHER mode`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EITHER),
+            ),
+        )
+        assertIs<AuthResult.Success<User>>(svc.authenticate("acme", "alice", "correct-pass"))
+        assertIs<AuthResult.Success<User>>(svc.authenticate("acme", "alice@example.com", "correct-pass"))
+    }
+
+    @Test
+    fun `ambiguous identifier fails with the same error as a miss and is audited`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EITHER),
+            ),
+        )
+        users.clear()
+        users.add(activeUser.copy(id = UserId(20), username = "shared@example.com", email = "one@example.com"))
+        users.add(activeUser.copy(id = UserId(21), username = "two", email = "shared@example.com"))
+
+        val ambiguous = svc.authenticate("acme", "shared@example.com", "correct-pass")
+        assertIs<AuthResult.Failure>(ambiguous)
+        assertIs<AuthError.InvalidCredentials>(ambiguous.error)
+
+        val event = auditLog.events.last()
+        assertEquals(AuditEventType.LOGIN_FAILED, event.eventType)
+        assertEquals("ambiguous_identifier", event.details["reason"])
+        assertNull(event.userId, "must not identify either colliding account")
+        assertTrue(
+            event.details.values.none { it.contains("shared@example.com") },
+            "must not record the raw submitted identifier",
+        )
+    }
+
+    @Test
+    fun `ambiguous and missing identifiers both perform exactly one hash operation`() {
+        tenants.clear()
+        tenants.add(
+            testTenant.copy(
+                securityConfig = SecurityConfig(loginIdentifierMode = LoginIdentifierMode.EITHER),
+            ),
+        )
+        users.clear()
+        users.add(activeUser.copy(id = UserId(20), username = "shared@example.com", email = "one@example.com"))
+        users.add(activeUser.copy(id = UserId(21), username = "two", email = "shared@example.com"))
+
+        hasher.verifyCount = 0
+        svc.authenticate("acme", "shared@example.com", "correct-pass")
+        val ambiguousHashes = hasher.verifyCount
+
+        hasher.verifyCount = 0
+        svc.authenticate("acme", "nobody-at-all", "correct-pass")
+        val missHashes = hasher.verifyCount
+
+        assertEquals(1, ambiguousHashes)
+        assertEquals(missHashes, ambiguousHashes)
     }
 }

--- a/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/AuthServiceTest.kt
@@ -50,6 +50,7 @@ class AuthServiceTest {
             auditLog = auditLog,
             sessionRepository = sessions,
             identifierResolver = UserIdentifierResolver(users),
+            collisionCheck = IdentifierCollisionCheck(users),
         )
 
     // -------------------------------------------------------------------------

--- a/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
@@ -10,12 +10,14 @@ import com.kauth.domain.model.BackupExportV1
 import com.kauth.domain.model.GrantType
 import com.kauth.domain.model.Group
 import com.kauth.domain.model.IdentityProvider
+import com.kauth.domain.model.LoginIdentifierMode
 import com.kauth.domain.model.LoginLayout
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.model.RequiredAction
 import com.kauth.domain.model.Role
 import com.kauth.domain.model.RoleScope
 import com.kauth.domain.model.SecurityConfig
+import com.kauth.domain.model.SecurityConfigBackup
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantClaimMapper
 import com.kauth.domain.model.TenantId
@@ -577,6 +579,44 @@ class BackupExportImportTest {
         assertEquals("#1FBCFF", branding.brandColorHex)
         assertEquals("support@acme.test", branding.supportEmail)
         assertEquals("Acme Support", branding.fromDisplayName)
+    }
+
+    @Test
+    fun `backup round-trips loginIdentifierMode`() {
+        val source = sourceTenants.findBySlug("acme")!!
+        sourceTenants.update(
+            source.copy(
+                securityConfig = source.securityConfig.copy(loginIdentifierMode = LoginIdentifierMode.EITHER),
+            ),
+        )
+
+        val export = exportSuccessful(ExportOptions())
+        val r = importer().import(export, newSlug = "acme-identifier", currentSchemaVersion = 38)
+        val summary = (r as BackupResult.Success).value
+        val restored = destTenants.findBySlug(summary.newTenantSlug)!!
+
+        assertEquals(LoginIdentifierMode.EITHER, restored.securityConfig.loginIdentifierMode)
+    }
+
+    @Test
+    fun `backup without loginIdentifierMode defaults to USERNAME`() {
+        val legacy =
+            SecurityConfigBackup(
+                passwordMinLength = 8,
+                passwordRequireSpecial = false,
+                passwordRequireUppercase = false,
+                passwordRequireNumber = false,
+                passwordHistoryCount = 0,
+                passwordMaxAgeDays = 0,
+                passwordBlacklistEnabled = false,
+                mfaPolicy = "optional",
+                lockoutMaxAttempts = 0,
+                lockoutDurationMinutes = 15,
+                corsAllowCredentials = false,
+                hibpCheckEnabled = false,
+                magicLinkEnabled = false,
+            )
+        assertEquals(LoginIdentifierMode.USERNAME, legacy.loginIdentifierMode)
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupExportImportTest.kt
@@ -40,6 +40,7 @@ import com.kauth.fakes.FakeThemeRepository
 import com.kauth.fakes.FakeTransactionRunner
 import com.kauth.fakes.FakeUserAttributeRepository
 import com.kauth.fakes.FakeUserRepository
+import kotlinx.serialization.decodeFromString
 import java.time.Instant
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -617,6 +618,37 @@ class BackupExportImportTest {
                 magicLinkEnabled = false,
             )
         assertEquals(LoginIdentifierMode.USERNAME, legacy.loginIdentifierMode)
+    }
+
+    @Test
+    fun `a real pre-1_24 backup JSON payload missing loginIdentifierMode still decodes to USERNAME`() {
+        // A pre-1.24 backup's JSON never had a "loginIdentifierMode" key at all — it didn't
+        // exist yet. Unlike the constructor-based test above (which only proves the Kotlin
+        // default-parameter mechanism works), this decodes a literal JSON string through the
+        // exact `Json { ignoreUnknownKeys = true }` instance the importer itself uses, so it
+        // proves an actual archived backup file still imports.
+        val legacyJson =
+            """
+            {
+                "passwordMinLength": 8,
+                "passwordRequireSpecial": false,
+                "passwordRequireUppercase": false,
+                "passwordRequireNumber": false,
+                "passwordHistoryCount": 0,
+                "passwordMaxAgeDays": 0,
+                "passwordBlacklistEnabled": false,
+                "mfaPolicy": "optional",
+                "lockoutMaxAttempts": 0,
+                "lockoutDurationMinutes": 15,
+                "corsAllowCredentials": false,
+                "hibpCheckEnabled": false,
+                "magicLinkEnabled": false
+            }
+            """.trimIndent()
+
+        val decoded = backupJson().decodeFromString<SecurityConfigBackup>(legacyJson)
+
+        assertEquals(LoginIdentifierMode.USERNAME, decoded.loginIdentifierMode)
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/BackupImporterAuditLinkTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupImporterAuditLinkTest.kt
@@ -1,0 +1,142 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.AuditEventBackup
+import com.kauth.domain.model.AuditEventType
+import com.kauth.domain.model.BackupExportV1
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeAuditLogPort
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakeIdentityProviderRepository
+import com.kauth.fakes.FakePortalConfigRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import com.kauth.fakes.FakeTenantEmailBrandingRepository
+import com.kauth.fakes.FakeTenantKeyRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeThemeRepository
+import com.kauth.fakes.FakeTransactionRunner
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+/**
+ * Restoring a legacy (pre-1.24) backup must not silently drop the user link on audit events whose
+ * `username` was captured before usernames were normalized to trimmed-lowercase form. See FIX 2 of
+ * the login-identifier code review: `userPkByUsername` was keyed only by the normalized username,
+ * while audit events were resolved against the original exported (possibly mixed-case) value.
+ */
+class BackupImporterAuditLinkTest {
+    private val sourceTenants = FakeTenantRepository()
+    private val sourceUsers = FakeUserRepository()
+
+    private val destTenants = FakeTenantRepository()
+    private val destUsers = FakeUserRepository()
+    private val destApps = FakeApplicationRepository()
+    private val destRoles = FakeRoleRepository()
+    private val destGroups = FakeGroupRepository()
+    private val destMappers = FakeTenantClaimMapperRepository()
+    private val destIdps = FakeIdentityProviderRepository()
+    private val destKeys = FakeTenantKeyRepository()
+    private val destThemes = FakeThemeRepository()
+    private val destPortal = FakePortalConfigRepository()
+    private val destAttrs = FakeUserAttributeRepository()
+    private val destEmailBranding = FakeTenantEmailBrandingRepository()
+    private val destAuditLog = FakeAuditLogPort()
+
+    private fun exporter() =
+        BackupExporterService(
+            tenantRepository = sourceTenants,
+            userRepository = sourceUsers,
+            applicationRepository = FakeApplicationRepository(),
+            roleRepository = FakeRoleRepository(),
+            groupRepository = FakeGroupRepository(),
+            claimMapperRepository = FakeTenantClaimMapperRepository(),
+            identityProviderRepository = FakeIdentityProviderRepository(),
+            tenantKeyRepository = FakeTenantKeyRepository(),
+            userAttributeRepository = FakeUserAttributeRepository(),
+            auditLogRepository = null,
+        )
+
+    private fun importer() =
+        BackupImporterService(
+            tenantRepository = destTenants,
+            userRepository = destUsers,
+            applicationRepository = destApps,
+            roleRepository = destRoles,
+            groupRepository = destGroups,
+            claimMapperRepository = destMappers,
+            identityProviderRepository = destIdps,
+            tenantKeyRepository = destKeys,
+            themeRepository = destThemes,
+            portalConfigRepository = destPortal,
+            userAttributeRepository = destAttrs,
+            emailBrandingRepository = destEmailBranding,
+            auditLogPort = destAuditLog,
+            transactionRunner = FakeTransactionRunner(destUsers, destGroups),
+        )
+
+    private fun exportAcme(): BackupExportV1 {
+        val tenant =
+            sourceTenants.add(
+                Tenant(
+                    id = TenantId(0),
+                    slug = "acme",
+                    displayName = "Acme Corp",
+                    issuerUrl = "https://acme.example.com",
+                ),
+            )
+        sourceUsers.add(
+            User(
+                id = null,
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.example.com",
+                fullName = "Alice Adams",
+                passwordHash = "\$2a\$10\$AAAAAAAAAAAAAAAAAAAAAA",
+            ),
+        )
+        val result = exporter().export("acme", ExportOptions(), kotauthVersion = "test", currentSchemaVersion = 1)
+        return (result as BackupResult.Success).value
+    }
+
+    @Test
+    fun `import links an audit event that references the original, non-normalized username`() {
+        val export = exportAcme()
+        // Simulate a pre-1.24 backup: the stored username was normalized to "alice" on restore,
+        // but the audit event was captured back when the exported record still carried "Dave"-style
+        // mixed case — here "Alice" is the original, unnormalized casing.
+        val legacyExport =
+            export.copy(
+                users = listOf(export.users.single().copy(username = "Alice")),
+                auditLog =
+                    listOf(
+                        AuditEventBackup(
+                            createdAt = 1_700_000_000L,
+                            username = "Alice",
+                            clientId = null,
+                            eventType = AuditEventType.LOGIN_SUCCESS.name,
+                            ipAddress = null,
+                            userAgent = null,
+                            details = emptyMap(),
+                        ),
+                    ),
+            )
+
+        val result = importer().import(legacyExport, newSlug = "acme-restored", currentSchemaVersion = 1)
+
+        assertIs<BackupResult.Success<ImportSummary>>(result)
+        val restoredTenant = destTenants.findBySlug("acme-restored")!!
+        val restoredUser = destUsers.findByTenantId(restoredTenant.id, null, 100, 0).single()
+        assertEquals("alice", restoredUser.username)
+
+        val restoredEvent = destAuditLog.events.single()
+        assertNotNull(restoredEvent.userId, "Audit event must still be linked to the restored user")
+        assertEquals(restoredUser.id, restoredEvent.userId)
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/BackupImporterUsernameValidationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupImporterUsernameValidationTest.kt
@@ -111,6 +111,45 @@ class BackupImporterUsernameValidationTest {
         return (result as BackupResult.Success).value
     }
 
+    private fun seedSourceTenantWithTwoUsers(): TenantId {
+        val tenant =
+            sourceTenants.add(
+                Tenant(
+                    id = TenantId(0),
+                    slug = "acme",
+                    displayName = "Acme Corp",
+                    issuerUrl = "https://acme.example.com",
+                ),
+            )
+        sourceUsers.add(
+            User(
+                id = null,
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.example.com",
+                fullName = "Alice Adams",
+                passwordHash = "\$2a\$10\$AAAAAAAAAAAAAAAAAAAAAA",
+            ),
+        )
+        sourceUsers.add(
+            User(
+                id = null,
+                tenantId = tenant.id,
+                username = "bob",
+                email = "bob@acme.example.com",
+                fullName = "Bob Baker",
+                passwordHash = "\$2a\$10\$AAAAAAAAAAAAAAAAAAAAAA",
+            ),
+        )
+        return tenant.id
+    }
+
+    private fun exportAcmeWithTwoUsers(): BackupExportV1 {
+        seedSourceTenantWithTwoUsers()
+        val result = exporter().export("acme", ExportOptions(), kotauthVersion = "test", currentSchemaVersion = 1)
+        return (result as BackupResult.Success).value
+    }
+
     @Test
     fun `import rejects a record whose username is invalid after normalization`() {
         val export = exportAcme()
@@ -124,6 +163,38 @@ class BackupImporterUsernameValidationTest {
         assertContains(error.message, "john doe")
         assertContains(error.message, "alice@acme.example.com")
         // No user was persisted on the destination — validation runs before the save.
+        val createdTenant = destTenants.findBySlug("acme-restored")
+        if (createdTenant != null) {
+            assertTrue(destUsers.findByTenantId(createdTenant.id, null, 100, 0).isEmpty())
+        }
+    }
+
+    @Test
+    fun `import reports every offending record in one failure, not just the first`() {
+        val export = exportAcmeWithTwoUsers()
+        val badExport =
+            export.copy(
+                users =
+                    export.users.map {
+                        when (it.username) {
+                            "alice" -> it.copy(username = "john doe")
+                            "bob" -> it.copy(username = "a".repeat(UsernamePolicy.MAX_LENGTH + 1))
+                            else -> it
+                        }
+                    },
+            )
+
+        val result = importer().import(badExport, newSlug = "acme-restored", currentSchemaVersion = 1)
+
+        assertIs<BackupResult.Failure>(result)
+        val error = result.error
+        assertIs<BackupError.InvalidPayload>(error)
+        // Both offenders are named in the SAME failure — an operator restoring many users must
+        // see the full list at once, not discover them one aborted retry at a time.
+        assertContains(error.message, "john doe")
+        assertContains(error.message, "alice@acme.example.com")
+        assertContains(error.message, "bob@acme.example.com")
+        // No user was persisted on the destination — validation runs before any save.
         val createdTenant = destTenants.findBySlug("acme-restored")
         if (createdTenant != null) {
             assertTrue(destUsers.findByTenantId(createdTenant.id, null, 100, 0).isEmpty())

--- a/src/test/kotlin/com/kauth/domain/service/BackupImporterUsernameValidationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/BackupImporterUsernameValidationTest.kt
@@ -1,0 +1,145 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.BackupExportV1
+import com.kauth.domain.model.Tenant
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.fakes.FakeApplicationRepository
+import com.kauth.fakes.FakeGroupRepository
+import com.kauth.fakes.FakeIdentityProviderRepository
+import com.kauth.fakes.FakePortalConfigRepository
+import com.kauth.fakes.FakeRoleRepository
+import com.kauth.fakes.FakeTenantClaimMapperRepository
+import com.kauth.fakes.FakeTenantEmailBrandingRepository
+import com.kauth.fakes.FakeTenantKeyRepository
+import com.kauth.fakes.FakeTenantRepository
+import com.kauth.fakes.FakeThemeRepository
+import com.kauth.fakes.FakeTransactionRunner
+import com.kauth.fakes.FakeUserAttributeRepository
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Part D of the login-identifier hardening wave: a restored backup must never silently rewrite an
+ * invalid username (that could break an integrator's stored references to it), and must never
+ * insert one that violates [UsernamePolicy] either — it must reject the whole import and name the
+ * offending record. Separate from [BackupExportImportTest] (which this wave does not touch) since
+ * it exercises a failure path that test's fixtures don't cover.
+ */
+class BackupImporterUsernameValidationTest {
+    private val sourceTenants = FakeTenantRepository()
+    private val sourceUsers = FakeUserRepository()
+
+    private val destTenants = FakeTenantRepository()
+    private val destUsers = FakeUserRepository()
+    private val destApps = FakeApplicationRepository()
+    private val destRoles = FakeRoleRepository()
+    private val destGroups = FakeGroupRepository()
+    private val destMappers = FakeTenantClaimMapperRepository()
+    private val destIdps = FakeIdentityProviderRepository()
+    private val destKeys = FakeTenantKeyRepository()
+    private val destThemes = FakeThemeRepository()
+    private val destPortal = FakePortalConfigRepository()
+    private val destAttrs = FakeUserAttributeRepository()
+    private val destEmailBranding = FakeTenantEmailBrandingRepository()
+
+    private fun exporter() =
+        BackupExporterService(
+            tenantRepository = sourceTenants,
+            userRepository = sourceUsers,
+            applicationRepository = FakeApplicationRepository(),
+            roleRepository = FakeRoleRepository(),
+            groupRepository = FakeGroupRepository(),
+            claimMapperRepository = FakeTenantClaimMapperRepository(),
+            identityProviderRepository = FakeIdentityProviderRepository(),
+            tenantKeyRepository = FakeTenantKeyRepository(),
+            userAttributeRepository = FakeUserAttributeRepository(),
+            auditLogRepository = null,
+        )
+
+    private fun importer() =
+        BackupImporterService(
+            tenantRepository = destTenants,
+            userRepository = destUsers,
+            applicationRepository = destApps,
+            roleRepository = destRoles,
+            groupRepository = destGroups,
+            claimMapperRepository = destMappers,
+            identityProviderRepository = destIdps,
+            tenantKeyRepository = destKeys,
+            themeRepository = destThemes,
+            portalConfigRepository = destPortal,
+            userAttributeRepository = destAttrs,
+            emailBrandingRepository = destEmailBranding,
+            auditLogPort = null,
+            // Rolls back the entities the fakes can snapshot on a thrown exception. Full
+            // cross-entity atomicity (including tenant creation) is only modeled against a real
+            // Postgres transaction — see BackupExportImportTest's class doc for the same caveat.
+            transactionRunner = FakeTransactionRunner(destUsers, destGroups),
+        )
+
+    private fun seedSourceTenantWithOneUser(): TenantId {
+        val tenant =
+            sourceTenants.add(
+                Tenant(
+                    id = TenantId(0),
+                    slug = "acme",
+                    displayName = "Acme Corp",
+                    issuerUrl = "https://acme.example.com",
+                ),
+            )
+        sourceUsers.add(
+            User(
+                id = null,
+                tenantId = tenant.id,
+                username = "alice",
+                email = "alice@acme.example.com",
+                fullName = "Alice Adams",
+                passwordHash = "\$2a\$10\$AAAAAAAAAAAAAAAAAAAAAA",
+            ),
+        )
+        return tenant.id
+    }
+
+    private fun exportAcme(): BackupExportV1 {
+        seedSourceTenantWithOneUser()
+        val result = exporter().export("acme", ExportOptions(), kotauthVersion = "test", currentSchemaVersion = 1)
+        return (result as BackupResult.Success).value
+    }
+
+    @Test
+    fun `import rejects a record whose username is invalid after normalization`() {
+        val export = exportAcme()
+        val badExport = export.copy(users = listOf(export.users.single().copy(username = "john doe")))
+
+        val result = importer().import(badExport, newSlug = "acme-restored", currentSchemaVersion = 1)
+
+        assertIs<BackupResult.Failure>(result)
+        val error = result.error
+        assertIs<BackupError.InvalidPayload>(error)
+        assertContains(error.message, "john doe")
+        assertContains(error.message, "alice@acme.example.com")
+        // No user was persisted on the destination — validation runs before the save.
+        val createdTenant = destTenants.findBySlug("acme-restored")
+        if (createdTenant != null) {
+            assertTrue(destUsers.findByTenantId(createdTenant.id, null, 100, 0).isEmpty())
+        }
+    }
+
+    @Test
+    fun `import accepts a username that normalizes cleanly`() {
+        val export = exportAcme()
+        val messyExport = export.copy(users = listOf(export.users.single().copy(username = "  Alice ")))
+
+        val result = importer().import(messyExport, newSlug = "acme-restored", currentSchemaVersion = 1)
+
+        assertIs<BackupResult.Success<ImportSummary>>(result)
+        val restoredTenant = destTenants.findBySlug("acme-restored")!!
+        val restoredUser = destUsers.findByTenantId(restoredTenant.id, null, 100, 0).single()
+        assertEquals("alice", restoredUser.username)
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
@@ -54,6 +54,7 @@ class ClientDefaultRolesRegistrationTest {
             applicationRepository = apps,
             roleRepository = roles,
             identifierResolver = UserIdentifierResolver(users),
+            collisionCheck = IdentifierCollisionCheck(users),
         )
 
     private val socialService =

--- a/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
@@ -53,6 +53,7 @@ class ClientDefaultRolesRegistrationTest {
             sessionRepository = sessions,
             applicationRepository = apps,
             roleRepository = roles,
+            identifierResolver = UserIdentifierResolver(users),
         )
 
     private val socialService =

--- a/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ClientDefaultRolesRegistrationTest.kt
@@ -68,6 +68,7 @@ class ClientDefaultRolesRegistrationTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             providerResolver = StaticSocialProviderResolver(emptyMap()),
+            collisionCheck = IdentifierCollisionCheck(users),
             applicationRepository = apps,
             roleRepository = roles,
         )

--- a/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/EmailOtpServiceTest.kt
@@ -175,6 +175,30 @@ class EmailOtpServiceTest {
     }
 
     @Test
+    fun `sendOtp returns uniform success without creating a user when the email is already someone's username`() {
+        // Cross-namespace collision: a DIFFERENT user's username happens to be this exact address.
+        // Without a guard, `save` would violate users_username_per_tenant and 500 — an oracle
+        // against the endpoint's uniform response. Mirrors JitProvisioningService's USERNAME_CONFLICT
+        // handling.
+        users.add(
+            User(
+                tenantId = tenant.id,
+                username = "claimed@acme.test",
+                email = "someone-else@acme.test",
+                fullName = "Someone Else",
+                passwordHash = User.SENTINEL_PASSWORD_HASH,
+            ),
+        )
+
+        val result = newService().sendOtp(tenant.slug, "claimed@acme.test", clientApp.clientId)
+
+        assertTrue(result is OtpSendResult.Success)
+        assertEquals(0, challenges.all().size)
+        assertEquals(0, email.otps.size)
+        assertTrue(audit.events.isEmpty(), "no audit event when nothing actually happened")
+    }
+
+    @Test
     fun `sendOtp resend invalidates the prior challenge for the same user`() {
         users.add(
             User(

--- a/src/test/kotlin/com/kauth/domain/service/SocialLoginJitBranchTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/SocialLoginJitBranchTest.kt
@@ -67,6 +67,7 @@ class SocialLoginJitBranchTest {
             passwordHasher = hasher,
             auditLog = auditLog,
             providerResolver = StaticSocialProviderResolver(mapOf(oriana to adapter)),
+            collisionCheck = IdentifierCollisionCheck(users),
             jitProvisioning = jit,
         )
 

--- a/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
@@ -60,6 +60,7 @@ class SocialLoginServiceTest {
                         ProviderKey.GITHUB to githubAdapter,
                     ),
                 ),
+            collisionCheck = IdentifierCollisionCheck(users),
         )
 
     private val tenant =
@@ -397,6 +398,44 @@ class SocialLoginServiceTest {
             )
         assertIs<SocialLoginResult.Failure>(result)
         assertEquals(SocialLoginError.UsernameConflict, result.error)
+    }
+
+    @Test
+    fun `completeSocialRegistration - chosen username equal to a different user's email is rejected`() {
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = ProviderKey.GOOGLE,
+                providerUserId = "brand-new-uid",
+                email = "brand-new@example.com",
+                providerName = "Brand New",
+                avatarUrl = null,
+                emailVerified = true,
+                // Collides with alice's email, not her username.
+                chosenUsername = "alice@example.com",
+            )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertIs<SocialLoginError.InvalidUsername>(result.error)
+        assertEquals(null, users.findByEmail(TenantId(1), "brand-new@example.com"), "No account should be created")
+    }
+
+    @Test
+    fun `completeSocialRegistration - email equal to a different user's username is rejected`() {
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = ProviderKey.GOOGLE,
+                providerUserId = "brand-new-uid",
+                // "alice" is an existing user's username, not their email.
+                email = "alice",
+                providerName = "Brand New",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "brandnewname",
+            )
+        assertIs<SocialLoginResult.Failure>(result)
+        assertIs<SocialLoginError.InvalidUsername>(result.error)
+        assertEquals(false, users.existsByUsername(TenantId(1), "brandnewname"), "No account should be created")
     }
 
     @Test

--- a/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/SocialLoginServiceTest.kt
@@ -428,6 +428,25 @@ class SocialLoginServiceTest {
     }
 
     @Test
+    fun `completeSocialRegistration - normalizes a mixed-case chosen username to lowercase`() {
+        val result =
+            svc.completeSocialRegistration(
+                tenantSlug = "acme",
+                provider = ProviderKey.GOOGLE,
+                providerUserId = "new-uid-1000",
+                email = "another-new@example.com",
+                providerName = "Another New User",
+                avatarUrl = null,
+                emailVerified = true,
+                chosenUsername = "BrandNew",
+                ipAddress = "1.2.3.4",
+                userAgent = "TestAgent",
+            )
+        assertIs<SocialLoginResult.Success<SocialLoginSuccess>>(result)
+        assertEquals("brandnew", result.value.user.username)
+    }
+
+    @Test
     fun `handleCallback - email matches existing user but provider says unverified rejects link`() {
         googleAdapter.profileToReturn = googleProfile.copy(emailVerified = false, providerUserId = "imposter-uid")
         val result = svc.handleCallback("acme", ProviderKey.GOOGLE, "code", "http://localhost")

--- a/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
@@ -43,6 +43,24 @@ class UserIdentifierResolverTest {
     }
 
     @Test
+    fun `USERNAME mode matches a stored lowercase username regardless of submitted case`() {
+        for (typed in listOf("Alice", "ALICE", "  alice  ")) {
+            val result = resolver.resolve(tenantId, LoginIdentifierMode.USERNAME, typed)
+            assertIs<IdentifierResolution.Found>(result, "expected a match for submitted '$typed'")
+            assertEquals("alice", result.user.username)
+        }
+    }
+
+    @Test
+    fun `EITHER mode matches a stored lowercase username regardless of submitted case`() {
+        for (typed in listOf("Alice", "ALICE", "  alice  ")) {
+            val result = resolver.resolve(tenantId, LoginIdentifierMode.EITHER, typed)
+            assertIs<IdentifierResolution.Found>(result, "expected a match for submitted '$typed'")
+            assertEquals("alice", result.user.username)
+        }
+    }
+
+    @Test
     fun `USERNAME mode does not match email`() {
         val result = resolver.resolve(tenantId, LoginIdentifierMode.USERNAME, "alice@example.com")
         assertIs<IdentifierResolution.NotFound>(result)

--- a/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
@@ -1,0 +1,120 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.LoginIdentifierMode
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class UserIdentifierResolverTest {
+    private val users = FakeUserRepository()
+    private val resolver = UserIdentifierResolver(users)
+    private val tenantId = TenantId(1)
+
+    private fun user(
+        id: Int,
+        username: String,
+        email: String,
+    ) = User(
+        id = UserId(id),
+        tenantId = tenantId,
+        username = username,
+        email = email,
+        fullName = "Test User",
+        passwordHash = "hash",
+    )
+
+    @BeforeTest
+    fun setup() {
+        users.clear()
+        users.add(user(1, "alice", "alice@example.com"))
+    }
+
+    @Test
+    fun `USERNAME mode matches username`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.USERNAME, "alice")
+        assertIs<IdentifierResolution.Found>(result)
+        assertEquals("alice", result.user.username)
+    }
+
+    @Test
+    fun `USERNAME mode does not match email`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.USERNAME, "alice@example.com")
+        assertIs<IdentifierResolution.NotFound>(result)
+    }
+
+    @Test
+    fun `EMAIL mode matches email case-insensitively`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EMAIL, "ALICE@Example.com")
+        assertIs<IdentifierResolution.Found>(result)
+        assertEquals("alice", result.user.username)
+    }
+
+    @Test
+    fun `EMAIL mode does not match username`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EMAIL, "alice")
+        assertIs<IdentifierResolution.NotFound>(result)
+    }
+
+    @Test
+    fun `EITHER mode matches username`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EITHER, "alice")
+        assertIs<IdentifierResolution.Found>(result)
+    }
+
+    @Test
+    fun `EITHER mode matches email`() {
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EITHER, "alice@example.com")
+        assertIs<IdentifierResolution.Found>(result)
+    }
+
+    @Test
+    fun `EITHER mode refuses when username and email match different users`() {
+        users.clear()
+        // User 1's username is the same string as user 2's email address.
+        users.add(user(1, "shared@example.com", "one@example.com"))
+        users.add(user(2, "two", "shared@example.com"))
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EITHER, "shared@example.com")
+        assertIs<IdentifierResolution.Ambiguous>(result)
+    }
+
+    @Test
+    fun `EITHER mode is not ambiguous when both hits are the same user`() {
+        users.clear()
+        users.add(user(1, "self@example.com", "self@example.com"))
+        val result = resolver.resolve(tenantId, LoginIdentifierMode.EITHER, "self@example.com")
+        assertIs<IdentifierResolution.Found>(result)
+        assertEquals(UserId(1), result.user.id)
+    }
+
+    @Test
+    fun `blank input never resolves the legacy empty-email row`() {
+        users.clear()
+        users.add(user(1, "legacy", ""))
+        for (mode in LoginIdentifierMode.entries) {
+            assertIs<IdentifierResolution.NotFound>(resolver.resolve(tenantId, mode, ""))
+            assertIs<IdentifierResolution.NotFound>(resolver.resolve(tenantId, mode, "   "))
+        }
+    }
+
+    @Test
+    fun `EITHER mode issues both lookups even when username hits`() {
+        users.callLog.clear()
+        resolver.resolve(tenantId, LoginIdentifierMode.EITHER, "alice")
+        assertEquals(
+            listOf("findByUsername", "findByEmail"),
+            users.callLog,
+            "EITHER must not short-circuit — a hit and a miss must cost the same lookups",
+        )
+    }
+
+    @Test
+    fun `does not cross tenant boundaries`() {
+        val result = resolver.resolve(TenantId(99), LoginIdentifierMode.EITHER, "alice")
+        assertIs<IdentifierResolution.NotFound>(result)
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UserIdentifierResolverTest.kt
@@ -19,9 +19,10 @@ class UserIdentifierResolverTest {
         id: Int,
         username: String,
         email: String,
+        forTenant: TenantId = tenantId,
     ) = User(
         id = UserId(id),
-        tenantId = tenantId,
+        tenantId = forTenant,
         username = username,
         email = email,
         fullName = "Test User",
@@ -114,6 +115,12 @@ class UserIdentifierResolverTest {
 
     @Test
     fun `does not cross tenant boundaries`() {
+        // A same-named user genuinely exists — under a different tenant. If the lookup weren't
+        // actually tenant-scoped (e.g. it silently ignored tenantId), this would incorrectly
+        // resolve. A tenant with no users at all wouldn't distinguish "scoped correctly" from
+        // "scoping is broken but there was nothing to find anyway".
+        users.add(user(2, "alice", "alice2@example.com", forTenant = TenantId(2)))
+
         val result = resolver.resolve(TenantId(99), LoginIdentifierMode.EITHER, "alice")
         assertIs<IdentifierResolution.NotFound>(result)
     }

--- a/src/test/kotlin/com/kauth/domain/service/UsernameGeneratorTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UsernameGeneratorTest.kt
@@ -1,0 +1,88 @@
+package com.kauth.domain.service
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.model.UserId
+import com.kauth.fakes.FakeUserRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class UsernameGeneratorTest {
+    private val users = FakeUserRepository()
+    private val generator = UsernameGenerator(users)
+    private val tenantId = TenantId(1)
+
+    private val allowed = Regex("[a-zA-Z0-9._@+-]+")
+
+    @BeforeTest
+    fun setup() = users.clear()
+
+    @Test
+    fun `derives the stem from givenName`() {
+        val name = generator.generate(tenantId, "Ana", "ana@company-a.com")
+        assertTrue(name.startsWith("ana"), "got $name")
+        assertTrue(name.matches(allowed), "got $name")
+    }
+
+    @Test
+    fun `falls back to the email local part when givenName is null`() {
+        val name = generator.generate(tenantId, null, "ana@company-a.com")
+        assertTrue(name.startsWith("ana"), "got $name")
+    }
+
+    @Test
+    fun `falls back to a neutral stem when both are unusable`() {
+        val name = generator.generate(tenantId, "", "@@@@")
+        assertTrue(name.startsWith("user"), "got $name")
+        assertTrue(name.matches(allowed), "got $name")
+    }
+
+    @Test
+    fun `strips characters the username validator rejects`() {
+        val name = generator.generate(tenantId, "Ana Sofía!", "ana@company-a.com")
+        assertTrue(name.matches(allowed), "got $name")
+    }
+
+    @Test
+    fun `never exceeds the fifty character column limit`() {
+        val name = generator.generate(tenantId, "a".repeat(200), "long@example.com")
+        assertTrue(name.length <= 50, "got ${name.length}")
+    }
+
+    @Test
+    fun `retries when the generated username already exists`() {
+        val first = generator.generate(tenantId, "Ana", "ana@company-a.com")
+        users.add(
+            User(
+                id = UserId(1),
+                tenantId = tenantId,
+                username = first,
+                email = "someone@example.com",
+                fullName = "Taken",
+                passwordHash = "hash",
+            ),
+        )
+        val second = generator.generate(tenantId, "Ana", "ana@company-a.com")
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun `never generates a username that collides with an existing email`() {
+        users.add(
+            User(
+                id = UserId(2),
+                tenantId = tenantId,
+                username = "someone",
+                email = "ana@company-a.com",
+                fullName = "Other",
+                passwordHash = "hash",
+            ),
+        )
+        repeat(20) {
+            val name = generator.generate(tenantId, "Ana", "ana@company-a.com")
+            assertNotEquals("ana@company-a.com", name)
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/domain/service/UsernameGeneratorTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/UsernameGeneratorTest.kt
@@ -3,6 +3,7 @@ package com.kauth.domain.service
 import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
+import com.kauth.domain.port.UserRepository
 import com.kauth.fakes.FakeUserRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -84,5 +85,54 @@ class UsernameGeneratorTest {
             val name = generator.generate(tenantId, "Ana", "ana@company-a.com")
             assertNotEquals("ana@company-a.com", name)
         }
+    }
+
+    @Test
+    fun `checks availability on the exhaustion fallback, not just the readable attempts`() {
+        // Every candidate this repository is asked about is reported as taken, forcing the
+        // generator through the readable-attempts loop AND the entropy-fallback loop. The
+        // generator must still terminate (bounded attempts) and must consult availability in
+        // both loops, not just the first — see UsernameGenerator's KDoc on the fallback.
+        var lookups = 0
+        val alwaysTaken =
+            object : UserRepository by users {
+                override fun findByUsernameIgnoreCase(
+                    tenantId: TenantId,
+                    username: String,
+                ): User? {
+                    lookups++
+                    return User(
+                        id = UserId(999),
+                        tenantId = tenantId,
+                        username = username,
+                        email = "taken@example.com",
+                        fullName = "Taken",
+                        passwordHash = "hash",
+                    )
+                }
+
+                override fun findByEmail(
+                    tenantId: TenantId,
+                    email: String,
+                ): User? {
+                    lookups++
+                    return User(
+                        id = UserId(999),
+                        tenantId = tenantId,
+                        username = "taken",
+                        email = email,
+                        fullName = "Taken",
+                        passwordHash = "hash",
+                    )
+                }
+            }
+
+        val name = UsernameGenerator(alwaysTaken).generate(tenantId, "Ana", "ana@company-a.com")
+
+        assertTrue(name.matches(allowed), "got $name")
+        // isAvailable's findByUsernameIgnoreCase check short-circuits findByEmail once it finds a
+        // hit, so each of the 10 readable attempts plus the 10 entropy-fallback attempts costs one
+        // lookup here — 20 total confirms BOTH loops actually called isAvailable.
+        assertTrue(lookups >= 20, "expected the fallback loop to also check availability, got $lookups lookups")
     }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakePasswordHasher.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakePasswordHasher.kt
@@ -17,6 +17,9 @@ class FakePasswordHasher : PasswordHasher {
     var verifyCallCount = 0
         private set
 
+    /** Counts verify calls — used to assert hash-operation invariance across outcomes. */
+    var verifyCount = 0
+
     override fun hash(rawPassword: String): String = "hashed:$rawPassword"
 
     override fun verify(
@@ -24,6 +27,7 @@ class FakePasswordHasher : PasswordHasher {
         hashedPassword: String,
     ): Boolean {
         verifyCallCount++
+        verifyCount++
         return hashedPassword == "hashed:$rawPassword"
     }
 }

--- a/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
@@ -55,9 +55,13 @@ class FakeUserRepository :
         }
     }
 
+    /** Records lookup method names in call order — used to assert timing-invariant lookup patterns. */
+    val callLog = mutableListOf<String>()
+
     fun clear() {
         store.clear()
         nextId = 1
+        callLog.clear()
     }
 
     override fun findById(
@@ -73,12 +77,18 @@ class FakeUserRepository :
     override fun findByUsername(
         tenantId: TenantId,
         username: String,
-    ) = store.values.find { it.tenantId == tenantId && it.username == username }
+    ): User? {
+        callLog += "findByUsername"
+        return store.values.find { it.tenantId == tenantId && it.username == username }
+    }
 
     override fun findByEmail(
         tenantId: TenantId,
         email: String,
-    ) = store.values.find { it.tenantId == tenantId && it.email == email }
+    ): User? {
+        callLog += "findByEmail"
+        return store.values.find { it.tenantId == tenantId && it.email.lowercase() == email.lowercase() }
+    }
 
     override fun findByExternalId(
         tenantId: TenantId,

--- a/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
@@ -29,11 +29,22 @@ class FakeUserRepository :
     }
 
     fun add(user: User): User {
-        requireUniquePerTenant(user)
-        val u = if (user.id == null) user.copy(id = UserId(nextId++)) else user
+        val normalized = user.normalizedForWrite()
+        requireUniquePerTenant(normalized)
+        val u = if (normalized.id == null) normalized.copy(id = UserId(nextId++)) else normalized
         store[u.id!!.value] = u
         return u
     }
+
+    /**
+     * Mirrors production's write-side normalization: `PostgresUserRepository.save`/`update`
+     * lowercase the email column, and every domain write path now normalizes (trim + lowercase)
+     * the username before it ever reaches a repository — see [com.kauth.domain.service.UsernamePolicy].
+     * Normalizing here too means a test cannot pass by relying on a mixed-case stored username
+     * that production would never actually persist.
+     */
+    private fun User.normalizedForWrite(): User =
+        copy(username = username.trim().lowercase(), email = email.trim().lowercase())
 
     /**
      * `UNIQUE (tenant_id, username)` and `UNIQUE (tenant_id, email)`, both from V1.
@@ -131,8 +142,9 @@ class FakeUserRepository :
     ): Long = findByTenantId(tenantId, search).size.toLong()
 
     override fun save(user: User): User {
-        requireUniquePerTenant(user)
-        val u = if (user.id == null) user.copy(id = UserId(nextId++)) else user
+        val normalized = user.normalizedForWrite()
+        requireUniquePerTenant(normalized)
+        val u = if (normalized.id == null) normalized.copy(id = UserId(nextId++)) else normalized
         store[u.id!!.value] = u
         return u
     }

--- a/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
@@ -82,6 +82,15 @@ class FakeUserRepository :
         return store.values.find { it.tenantId == tenantId && it.username == username }
     }
 
+    override fun findByUsernameIgnoreCase(
+        tenantId: TenantId,
+        username: String,
+    ): User? {
+        callLog += "findByUsernameIgnoreCase"
+        val needle = username.trim().lowercase()
+        return store.values.find { it.tenantId == tenantId && it.username.lowercase() == needle }
+    }
+
     override fun findByEmail(
         tenantId: TenantId,
         email: String,

--- a/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserRepository.kt
@@ -4,6 +4,7 @@ import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.User
 import com.kauth.domain.model.UserId
 import com.kauth.domain.port.UserRepository
+import com.kauth.domain.service.UsernamePolicy
 import java.time.Instant
 
 /**
@@ -37,14 +38,31 @@ class FakeUserRepository :
     }
 
     /**
-     * Mirrors production's write-side normalization: `PostgresUserRepository.save`/`update`
-     * lowercase the email column, and every domain write path now normalizes (trim + lowercase)
-     * the username before it ever reaches a repository — see [com.kauth.domain.service.UsernamePolicy].
-     * Normalizing here too means a test cannot pass by relying on a mixed-case stored username
-     * that production would never actually persist.
+     * Mirrors production's write-side normalization for email only: `PostgresUserRepository.save`
+     * lowercases the email column. The username is deliberately NOT silently fixed here — see
+     * [requireNormalizedUsername].
      */
-    private fun User.normalizedForWrite(): User =
-        copy(username = username.trim().lowercase(), email = email.trim().lowercase())
+    private fun User.normalizedForWrite(): User {
+        requireNormalizedUsername(username)
+        return copy(email = email.trim().lowercase())
+    }
+
+    /**
+     * Every domain write path now normalizes (trim + lowercase) a username before it ever reaches
+     * a repository — see [UsernamePolicy]. Production's `PostgresUserRepository.save`/`update`
+     * write the username verbatim, trusting that invariant rather than re-enforcing it. A fake
+     * that silently lowercased a non-normalized username instead of rejecting it would be MORE
+     * forgiving than production on exactly the invariant this release depends on: a future write
+     * path that forgets to normalize would get a green test here and an unreachable user in
+     * production. Throwing turns that into a failing test instead.
+     */
+    private fun requireNormalizedUsername(username: String) {
+        val normalized = UsernamePolicy.normalize(username)
+        check(username == normalized) {
+            "FakeUserRepository received a non-normalized username '$username' (production would " +
+                "store '$normalized'). The caller must normalize via UsernamePolicy before writing."
+        }
+    }
 
     /**
      * `UNIQUE (tenant_id, username)` and `UNIQUE (tenant_id, email)`, both from V1.
@@ -150,6 +168,7 @@ class FakeUserRepository :
     }
 
     override fun update(user: User): User {
+        requireNormalizedUsername(user.username)
         requireUniquePerTenant(user)
         store[user.id!!.value] = user
         return user

--- a/src/test/kotlin/com/kauth/fakes/FakeUserRepositoryUpdateFieldsTest.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeUserRepositoryUpdateFieldsTest.kt
@@ -1,0 +1,123 @@
+package com.kauth.fakes
+
+import com.kauth.domain.model.RequiredAction
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression guard for the class of bug where `PostgresUserRepository.update()` silently
+ * dropped a mutable [User] field — the username column was in the `UPDATE`'s `WHERE` clause but
+ * never its `SET` list, so an admin rename returned success while the row never changed.
+ *
+ * This enumerates every field `PostgresUserRepository.update()` is expected to persist, mutates
+ * it, calls `update()`, and re-reads. Against [FakeUserRepository] every one of these passes
+ * trivially — the fake stores the whole object on `update()` — so this test cannot catch a
+ * Postgres-only regression by itself. Its value is as a portable contract: the same assertions,
+ * pointed at a Postgres-backed repository in an integration suite, would have failed exactly the
+ * way the username bug should have been caught. Keep this list in sync with
+ * `PostgresUserRepository.update()`'s `SET` list when either changes.
+ *
+ * Deliberately excluded (see the harden-2 report for the full audit): `id`/`tenantId`/`createdAt`
+ * (immutable), `passwordHash`/`lastPasswordChangeAt` (written together by `updatePassword`), and
+ * `failedLoginAttempts`/`lockedUntil`/`failedOtpChallenges` (written by the dedicated
+ * lockout-tracking methods).
+ */
+class FakeUserRepositoryUpdateFieldsTest {
+    private val tenantId = TenantId(1)
+
+    private fun baseUser() =
+        User(
+            tenantId = tenantId,
+            username = "original",
+            email = "original@example.com",
+            fullName = "Original Name",
+            passwordHash = "hash",
+        )
+
+    private fun savedUser(repo: FakeUserRepository): User = repo.save(baseUser())
+
+    @Test
+    fun `update persists a changed username`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(username = "renamed"))
+        assertEquals("renamed", repo.findById(saved.id!!, tenantId)!!.username)
+    }
+
+    @Test
+    fun `update persists a changed email`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(email = "new@example.com"))
+        assertEquals("new@example.com", repo.findById(saved.id!!, tenantId)!!.email)
+    }
+
+    @Test
+    fun `update persists a changed fullName`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(fullName = "New Name"))
+        assertEquals("New Name", repo.findById(saved.id!!, tenantId)!!.fullName)
+    }
+
+    @Test
+    fun `update persists a changed externalId`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(externalId = "ext-42"))
+        assertEquals("ext-42", repo.findById(saved.id!!, tenantId)!!.externalId)
+    }
+
+    @Test
+    fun `update persists a changed givenName`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(givenName = "Ada"))
+        assertEquals("Ada", repo.findById(saved.id!!, tenantId)!!.givenName)
+    }
+
+    @Test
+    fun `update persists a changed familyName`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(familyName = "Lovelace"))
+        assertEquals("Lovelace", repo.findById(saved.id!!, tenantId)!!.familyName)
+    }
+
+    @Test
+    fun `update persists a changed emailVerified flag`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(emailVerified = true))
+        assertEquals(true, repo.findById(saved.id!!, tenantId)!!.emailVerified)
+    }
+
+    @Test
+    fun `update persists a changed enabled flag`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(enabled = false))
+        assertEquals(false, repo.findById(saved.id!!, tenantId)!!.enabled)
+    }
+
+    @Test
+    fun `update persists a changed mfaEnabled flag`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(mfaEnabled = true))
+        assertEquals(true, repo.findById(saved.id!!, tenantId)!!.mfaEnabled)
+    }
+
+    @Test
+    fun `update persists changed requiredActions`() {
+        val repo = FakeUserRepository()
+        val saved = savedUser(repo)
+        repo.update(saved.copy(requiredActions = setOf(RequiredAction.CHANGE_PASSWORD)))
+        assertEquals(
+            setOf(RequiredAction.CHANGE_PASSWORD),
+            repo.findById(saved.id!!, tenantId)!!.requiredActions,
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a per-workspace sign-in identifier setting, so a workspace can accept a **username**, an **email address**, or **either** at sign-in — and normalizes usernames so the two identifier spaces can never collide.

Today `AuthService.authenticate` resolves accounts with `findByUsername` only, while every other surface — invite mail, admin user list, the `email` claim in the ID token, SCIM payloads — speaks in email addresses. Users type their address and are told their credentials are wrong. Integrators provisioning users must also invent a username, because one was mandatory; the reporter's workaround mangled `ana@company-a.com` into `ana_company-a.com`, an identifier their users had never seen in either product.

Closes #127

**The feature**

- `LoginIdentifierMode` (`USERNAME` / `EMAIL` / `EITHER`) on `SecurityConfig`, with a radio control on the workspace Security Policy page.
- A pure-domain `UserIdentifierResolver` owning credential matching; `AuthService` keeps policy, lockout and audit.
- **Write-time collision prevention** across admin create, admin update, SCIM and self-registration — a username equal to a *different* user's email (or vice versa) is rejected at creation, where a human can fix it. A user whose username *is* their own email stays legal; that is the shape integrators want.
- **Auto-generated usernames** when provisioning omits one, reachable from the admin API and admin UI. SCIM still requires `userName`, per RFC 7643.
- **Usernames are now editable** by an admin via the UI and API; they were immutable after creation.
- The hosted login form's label, input type and autocomplete follow the workspace's mode.

**Username normalization (new rule)**

Usernames are now **always stored trimmed, lowercased, and matching `[a-z0-9._@+-]+`**, at every write path — admin create/rename, self-registration (which previously had *no* username validation at all), social, JIT, email-OTP and backup import. Sign-in lowercases the submitted identifier to match. A `CHECK (username = lower(username))` constraint and a unique index on `(tenant_id, lower(username))` back the invariant at the database level rather than leaving it to application code.

## Upgrade impact — please read before merging

`V66` **rewrites existing usernames in place**: lowercased, trimmed, and runs of forbidden characters collapsed to `.`, so a user stored as `"John Doe"` becomes `john.doe`. **Their sign-in identifier changes** and operators must tell them.

`V66` **aborts the upgrade** rather than damaging data, in two cases:
- two usernames in one tenant would normalize to the same value (e.g. `Dave` and `dave`);
- a username would normalize to an empty or invalid value (e.g. an all-non-Latin username such as `Иван`).

Both abort messages name the tenant and row. `docs/guides/sign-in-identifier.md` carries pre-flight queries for both cases, verified to use the same expression as the migration itself.

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Documentation

## How was this tested?

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [x] Tested manually — describe steps below

**2463 tests, 0 failures** across 182 suites. `make nuke` + `make up` re-applied **all 66 migrations from an empty database**, the app reached `KotAuth v1.24.0 started`, and `/health/ready` returned ready.

Migration behaviour proven against live Postgres:
- a deliberately colliding pair aborts the migration and leaves the schema at v65;
- an all-non-Latin username aborts with a message naming tenant and row id;
- the `CHECK` constraint rejects a direct mixed-case insert;
- the docs' pre-flight queries return `(0 rows)` on clean data and correctly catch injected collisions.

Notable coverage:
- `EITHER` mode issues **both** lookups unconditionally — asserted via a call-order log, so reintroducing a short-circuit fails the test.
- Ambiguous, missing and wrong-password outcomes each perform exactly **one** hash operation.
- A colliding email in the same admin submission does not leave the username renamed (asserts repository state, not just HTTP status).
- Changing a user's email to another user's username is rejected **when no rename is requested** — verified by temporarily moving the check and confirming the test fails.
- A SCIM round-trip using a **mixed-case** `userName` throughout — verified to fail without the fix.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [x] New domain logic has no framework imports (hexagonal architecture constraint)
- [x] New database changes include a Flyway migration (`V65`, `V66`)
- [x] Public API changes are reflected in `src/main/resources/openapi/v1.yaml`
- [x] Security-sensitive changes are noted in the description

## Security notes

This touches the authentication path, so the anti-enumeration posture was treated as a hard constraint:

- **Ambiguity is refused, not guessed.** If a submitted value matches one account's username and a *different* account's email, sign-in is refused — with the byte-identical generic error, the same lookup count, and the same single hash operation as any other failure. Visible only as `reason=ambiguous_identifier` in the audit log.
- **`EITHER` never short-circuits.** Running both lookups only on a miss would make a miss cost two queries and a hit one — a measurable timing oracle.
- **The failure message is mode-agnostic.** `"Invalid username or password."` becomes `"Invalid sign-in details."`, still shared by all five collapsed outcomes. No message branches on the mode, which would leak the workspace's configuration.
- **Case-insensitive sign-in is safe here specifically** because `(tenant_id, lower(username))` is uniquely enforced — two accounts cannot differ only by case, so lowercasing input cannot resolve a different account. Flyway runs before the app serves traffic, so no replica can run the new resolver against a pre-V66 database.
- **Email sign-in does not require a verified address.** Deliberate: username sign-in has never checked `emailVerified`, and gating email sign-in would lock out invite- and SCIM-provisioned users who never completed verification — exactly the users this feature serves.
- Blank input can never reach an email lookup (`email` is `NOT NULL DEFAULT ''`, so a legacy row may hold an empty string).

## Bugs found and fixed along the way

Two of these predate this feature's work and were only exposed by it:

1. **Admin username renames never persisted.** `PostgresUserRepository.update()` never wrote the `username` column, so renames returned success, wrote an audit event, and changed nothing in the database. Invisible to the test suite because `FakeUserRepository` stores the whole object. A full audit of `User`'s properties against the columns `update()` writes confirmed `username` was the only genuine drop.
2. **Username lowercasing broke SCIM.** A mixed-case `userName` from Okta/Entra (a UPN, commonly `Dave.Smith@corp.com`) would be stored lowercase, then every subsequent `PUT` returned 400 and the connector's `userName` filter found nothing — leaving the user unreconcilable with no operator remedy. Fixed by normalizing in the SCIM mapper, comparing normalized-to-normalized, routing the filter through a case-insensitive lookup, and correcting the advertised `caseExact`.
3. `mfaPolicy` and the password-policy integers silently reset to defaults when omitted from a settings POST.
4. `findByUsernameIgnoreCase` used `singleOrNull()`, returning null on a case-differing duplicate — making a deliberately fail-closed check fail open.

## Notes for reviewers

Worth your attention:

- `AdminUserService.resolveUsername` — username validation runs only when a rename is actually requested, while the email→username check runs whenever the email changes. Validating stored state on every update permanently blocked SCIM sync for users with legacy usernames.
- `FakeUserRepository` now **throws** on a non-normalized username rather than silently fixing it, so a future missed write path becomes a red test instead of a user who cannot sign in.

**Known follow-ups (filed separately, none blocking):**

1. `ScimFilter.matches` still compares `userName` case-exactly on compound filters, so discovery's `caseExact: false` and that path disagree. Contract drift, not a regression — behaviour is unchanged from before this PR.
2. Restoring a pre-1.24 backup containing an invalid username now fails the import, while V66 rewrites the same value in place — two policies for one value, and the suggested remedy (edit the export) is impractical since exports are encrypted envelopes.
3. Email-OTP and JIT use the email address as the username; addresses that aren't username-shaped (apostrophes, internationalized) are black-holed or misdiagnosed. Both should fall back to `UsernameGenerator`.
4. Email-OTP signup has a timing difference between the taken-username branch and the mail-sending branch.
5. V66 runs collision detection before empty/invalid detection, so an all-non-Latin tenant gets the less specific diagnostic.

**Testing this branch:** V66's checksum changed after `b67ca11`. If you booted an earlier commit of this branch locally, run `make nuke` before `make up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kngyyNrSGVFLnCc3oU4yZ
