### PR TITLE
Refuse duplicate API key names with a validation error instead of a 500

### DIFF
--- a/src/main/kotlin/com/kauth/domain/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ApiKeyService.kt
@@ -69,6 +69,18 @@ class ApiKeyService(
             return ApiKeyResult.Failure(ApiKeyError.Validation("At least one valid scope is required."))
         }
 
+        // Names are unique per tenant (`uq_api_keys_tenant_name`). Refuse a collision here so a
+        // duplicate surfaces as a validation error instead of a database constraint exception
+        // turning the request into an unhandled 500.
+        val trimmedName = name.trim()
+        apiKeyRepository.findByTenantAndName(tenantId, trimmedName)?.let {
+            return ApiKeyResult.Failure(
+                ApiKeyError.Validation(
+                    "An API key named \"$trimmedName\" already exists in this workspace.",
+                ),
+            )
+        }
+
         // Build raw key: kauth_<slug>_<32 random bytes base64url, no padding>
         val rawKey = "kauth_${tenant.slug}_${SecureTokens.randomBase64Url(32)}"
 
@@ -79,7 +91,7 @@ class ApiKeyService(
             apiKeyRepository.save(
                 ApiKey(
                     tenantId = tenantId,
-                    name = name.trim(),
+                    name = trimmedName,
                     keyPrefix = prefix,
                     keyHash = hash,
                     scopes = validScopes,

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminApiKeysTest.kt
@@ -227,6 +227,34 @@ class AdminApiKeysTest {
         }
 
     @Test
+    fun `POST api-keys with a duplicate name re-renders the form with a validation error`() =
+        testApplication {
+            application { installTestApp() }
+            val authed = createClient { install(HttpCookies) }
+            login(authed)
+
+            apiKeyService.create(TenantId(2), "Cobalto ERP", listOf(ApiScope.USERS_READ))
+
+            val response =
+                authed.submitForm(
+                    url = "/admin/workspaces/acme/settings/api-keys",
+                    formParameters =
+                        Parameters.build {
+                            append("name", "Cobalto ERP")
+                            append("scopes", ApiScope.USERS_READ)
+                        },
+                )
+
+            assertEquals(
+                HttpStatusCode.UnprocessableEntity,
+                response.status,
+                "a duplicate name must be a validation error, not a 500",
+            )
+            val body = response.bodyAsText()
+            assertTrue(body.contains("already exists"), "the form must name the duplicate-name constraint")
+        }
+
+    @Test
     fun `POST api-keys revoke redirects back to list`() =
         testApplication {
             application { installTestApp() }

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminBackupRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminBackupRoutesTest.kt
@@ -158,9 +158,9 @@ class AdminBackupRoutesTest {
         appRepo.add(acmeApp)
         userRepo.add(acmeUser)
 
-        fullScopeKey = createMasterKey(listOf(ApiScope.TENANTS_EXPORT, ApiScope.TENANTS_IMPORT))
-        exportOnlyKey = createMasterKey(listOf(ApiScope.TENANTS_EXPORT))
-        noScopeKey = createMasterKey(listOf(ApiScope.USERS_READ))
+        fullScopeKey = createMasterKey("full-scope", listOf(ApiScope.TENANTS_EXPORT, ApiScope.TENANTS_IMPORT))
+        exportOnlyKey = createMasterKey("export-only", listOf(ApiScope.TENANTS_EXPORT))
+        noScopeKey = createMasterKey("no-scope", listOf(ApiScope.USERS_READ))
         nonMasterKey =
             (
                 apiKeyService.create(
@@ -171,8 +171,11 @@ class AdminBackupRoutesTest {
             ).value.rawKey
     }
 
-    private fun createMasterKey(scopes: List<String>): String =
-        (apiKeyService.create(tenantId = master.id, name = "test", scopes = scopes) as ApiKeyResult.Success)
+    private fun createMasterKey(
+        name: String,
+        scopes: List<String>,
+    ): String =
+        (apiKeyService.create(tenantId = master.id, name = name, scopes = scopes) as ApiKeyResult.Success)
             .value.rawKey
 
     @Test

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
@@ -197,11 +197,14 @@ class ApiRateLimitTest {
         rawApiKey = createKeyFor(TenantId(1))
     }
 
-    private fun createKeyFor(tenantId: TenantId): String =
+    private fun createKeyFor(
+        tenantId: TenantId,
+        name: String = "Test Key",
+    ): String =
         (
             apiKeyService.create(
                 tenantId = tenantId,
-                name = "Test Key",
+                name = name,
                 scopes = listOf(ApiScope.USERS_WRITE, ApiScope.USERS_READ),
             ) as ApiKeyResult.Success
         ).value.rawKey
@@ -330,7 +333,7 @@ class ApiRateLimitTest {
             assertEquals(HttpStatusCode.TooManyRequests, blocked.status)
 
             // A second, distinct key (different keyPrefix) for the same tenant is unaffected.
-            val secondKey = createKeyFor(TenantId(1))
+            val secondKey = createKeyFor(TenantId(1), name = "Second Test Key")
             val allowed =
                 client.post("/t/acme/api/v1/users") {
                     bearerAuth(secondKey)

--- a/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/ApiKeyServiceTest.kt
@@ -143,6 +143,50 @@ class ApiKeyServiceTest {
         assertEquals(expiry, result.value.apiKey.expiresAt)
     }
 
+    @Test
+    fun `create - duplicate name in the same tenant is refused`() {
+        val first =
+            svc.create(
+                tenantId = TenantId(1),
+                name = "Duplicate Key",
+                scopes = listOf(ApiScope.USERS_READ),
+            )
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(first)
+
+        val second =
+            svc.create(
+                tenantId = TenantId(1),
+                name = "Duplicate Key",
+                scopes = listOf(ApiScope.USERS_READ),
+            )
+        assertIs<ApiKeyResult.Failure>(second)
+        assertIs<ApiKeyError.Validation>(second.error)
+        assertTrue(
+            second.error.message.contains("\"Duplicate Key\"") &&
+                second.error.message.contains("already exists"),
+        )
+        assertEquals(1, apiKeys.all().size, "a refused duplicate must not be persisted")
+    }
+
+    @Test
+    fun `create - the same name is allowed in a different tenant`() {
+        tenants.add(
+            Tenant(
+                id = TenantId(2),
+                slug = "globex",
+                displayName = "Globex",
+                issuerUrl = null,
+            ),
+        )
+
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(
+            svc.create(TenantId(1), "Shared Name", listOf(ApiScope.USERS_READ)),
+        )
+        assertIs<ApiKeyResult.Success<CreatedApiKey>>(
+            svc.create(TenantId(2), "Shared Name", listOf(ApiScope.USERS_READ)),
+        )
+    }
+
     // =========================================================================
     // validate
     // =========================================================================


### PR DESCRIPTION
## What happened

`POST /admin/workspaces/{slug}/settings/api-keys` with a `name` already used by another key in the same workspace responded **HTTP 500** instead of re-rendering the form with a validation message like every other admin form (`AdminError.Validation`).

The root cause: `ApiKeyService.create()` never checked name uniqueness, so a duplicate fell through to Postgres, hit the `uq_api_keys_tenant_name` constraint, and the resulting exception propagated as an unhandled 500.

This is exactly the reported bug — it surfaced on the **second run** of a provisioning script, and it is especially painful for reissuing a key whose raw value was already shown once.

## What changed

`ApiKeyService.create()` now checks `apiKeyRepository.findByTenantAndName(tenantId, name)` before generating or persisting anything, and returns the same validation path the rest of the console uses:

> An API key named "..." already exists in this workspace.

The existing `Failure` branch in `AdminApiKeyRoutes.kt` already renders that message in the form at **422** on the reported path, so no route change was needed.

## What I broke to prove the tests catch it

Reverting the service change (removing the uniqueness check) makes both new tests fail:

- `ApiKeyServiceTest > create - duplicate name in the same tenant is refused` — the second create returns `Success` instead of the expected validation `Failure`.
- `AdminApiKeysTest > POST api-keys with a duplicate name re-renders the form with a validation error` — the request returns 200 with a new key instead of 422 with the constraint message.

## Test fixtures fixed along the way

Two fixtures created multiple API keys with the **same name in the same tenant** — a state the production schema (`uq_api_keys_tenant_name`, Flyway V47) forbids, so the fake repo silently allowed what the database never could:

- `AdminBackupRoutesTest` — `createMasterKey` created three keys named `"test"`; they now have distinct names.
- `ApiRateLimitTest` — the second unconstrained-key test reused the name `"Test Key"`; it now passes a distinct name.

## Verification

- `./gradlew test` — BUILD SUCCESSFUL (full suite)
- `./gradlew ktlintCheck` — BUILD SUCCESSFUL
- `./gradlew buildFatJar` — BUILD SUCCESSFUL

Closes #125