### PR TITLE
Roadmap rewrite, ADR table correction, and a pinned JVM 17 compile target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Kotauth is a self-hosted identity and access management server built with Kotlin/Ktor. It provides multi-tenant authentication, authorization, user management, OAuth2/OIDC, MFA, and an admin UI.
 
-**Stack**: Kotlin 2.3.20 · Ktor 3.4.2 · Exposed 0.61.0 (ORM) · PostgreSQL 15 · JVM 17+ · Gradle 8.14 · LightningCSS (build-time only)
+**Stack**: Kotlin 2.3.20 · Ktor 3.5.1 · Exposed 1.3.1 (ORM) · PostgreSQL 15 · JVM 17 (compile target pinned in `build.gradle.kts`) · Gradle 9.4.1 · LightningCSS (build-time only)
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Pre-release tags (e.g. `1.19.0-rc1`) are published but do not move the `latest` 
 
 ## Under the hood
 
-**Stack:** Kotlin 2.3.20, Ktor 3.4.2, Exposed 0.61.0 (ORM), PostgreSQL 15, JVM 17, Gradle 8.14. The runtime image is ~120 MB; the JAR runs as an unprivileged user.
+**Stack:** Kotlin 2.3.20, Ktor 3.5.1, Exposed 1.3.1 (ORM), PostgreSQL 15, JVM 17, Gradle 9.4.1. The runtime image is ~120 MB; the JAR runs as an unprivileged user.
 
 **Architecture:** [hexagonal (Ports & Adapters)](https://alistair.cockburn.us/hexagonal-architecture/) — the domain layer (`domain/model`, `domain/port`, `domain/service`) has zero framework dependencies, so business logic is testable in-memory without Docker, a database, or HTTP. Adapters (`adapter/web`, `adapter/persistence`, `adapter/token`, `adapter/email`, `adapter/social`) sit at the edge.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,27 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 group = "com.kauth"
 version = "1.24.0"
 
+// Pin the compile target explicitly rather than letting it follow whichever JDK
+// happens to build. `release`/`-Xjdk-release` also stop a newer build JDK from
+// linking against APIs that do not exist on 17 — bytecode alone would not.
+// Deliberately not a toolchain: that would also pin the JVM tests run on, and
+// CI's [17, 21] matrix exists to check both.
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        freeCompilerArgs.add("-Xjdk-release=17")
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+}
+
 application {
     mainClass.set("com.kauth.ApplicationKt")
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # Kotauth — Product Roadmap
 
-> Last updated: 2026-06-23
-> Status: v1.19.2
+> Last updated: 2026-09-05
+> Status: v1.24.0
 
 ---
 
@@ -161,6 +161,63 @@ Phase 3 was the largest phase, delivered in four increments (3a–3d).
 
 ---
 
+### Audit Log Integrity ✅ Shipped — v1.19.0
+*Goal: An audit trail that can be shown to an auditor*
+
+- Audit detail payloads built with `kotlinx.serialization` rather than hand-concatenated strings
+- HMAC chain over the audit log — each row carries `prev_hash` and `row_hash`, so a deleted or edited row breaks the chain and is detectable
+- Recommended Postgres role separation for `audit_log` documented for operators who want append-only enforcement at the database level
+
+---
+
+### Resource Indicators ✅ Shipped — v1.19.3
+*Goal: A token scoped to the API it was requested for, not to everything*
+
+- RFC 8707 `resource` parameter on the authorization-code grant, bound to the issued code and carried through to the access token's `aud` claim
+- RFC 9068 §5 scope narrowing on issuance — a token targeting an API is narrowed to the intersection of the requested scopes and that API's declared scopes, across all three grant types
+- Scopes editor per API in the admin console; `scopes_supported` published in the discovery document
+
+Phase 4 of the resource-indicator work (introspection widening) remains open — see Known Gaps.
+
+---
+
+### Passwordless Authentication ✅ Shipped
+*Goal: Sign in without a password, without weakening the account*
+
+This is the phase previously listed below as "Phase 7 — Advanced Authentication Methods". It shipped across several releases and is recorded here rather than as future work.
+
+- **Magic links** — short-lived signed tokens delivered by email, per-workspace TTL ([ADR-10](adr/ADR-10-magic-link-passwordless-signin.md))
+- **Email OTP** — a one-time code as a passwordless primitive, with a per-workspace signup toggle and a cross-challenge lockout threshold ([ADR-15](adr/ADR-15-email-otp-passwordless-primitive.md))
+- **Passkeys / WebAuthn** (v1.20.0) — platform and roaming authenticators, conditional-mediation autofill, per-credential replay defence via the WebAuthn sign counter, AAGUID device-name lookup, admin and CLI reset paths. Passkeys are a sibling to password rather than an MFA method, and a passkey with user verification satisfies an `mfa_policy=required` workspace ([ADR-16](adr/ADR-16-passkeys-sibling-to-password.md))
+- **Passwordless-only workspaces** — password sign-in can be disabled per workspace, hard-gated on configured SMTP so an operator cannot strand their own users ([ADR-17](adr/ADR-17-smtp-hard-gate-passwordless-tenants.md))
+
+**SMS OTP remains unimplemented** and is the only part of the original Phase 7 still outstanding. The multi-channel OTP port is designed but unscheduled.
+
+---
+
+### Operational Foundations ✅ Shipped
+*Goal: The things a self-hosted operator needs before they trust it with real users*
+
+- **Internationalization** — UI strings resolved from volume-mounted JSON bundles; English ships inside the JAR, additional locales are mounted at deploy time and never baked into the image ([ADR-11](adr/ADR-11-i18n-volume-mounted-bundles.md))
+- **Redis sidecar** — distributed rate limiting and session state across replicas, fail-closed on the auth path ([ADR-12](adr/ADR-12-redis-sidecar.md))
+- **Silent SSO** — path-scoped witness cookie enabling `prompt=none` re-authentication without a shared session store ([ADR-13](adr/ADR-13-oidc-sso-witness-cookie.md))
+- **Admin impersonation** — an operator can act as a user with an explicit, separately-modelled session and a full audit trail ([ADR-14](adr/ADR-14-admin-impersonation-session-model.md)). This was previously listed under Phase 9
+- **File-based secret injection** (`*_FILE` convention), Gradle dependency locking, and Dependabot (v1.19.1)
+- **Two root compose files** and a rewritten deployment guide split into quickstart and production paths (v1.19.2)
+
+---
+
+### Machine-to-Machine Onboarding ✅ Shipped — v1.22.0
+*Goal: Register a service as a first-class client, not as a web app with the fields left blank*
+
+- Explicit grant types per application; the token endpoint refuses any grant the client is not registered for
+- Client secret issued at creation for confidential applications, shown once
+- Redirect URI conditional rather than mandatory — a client-credentials service does not need one
+- Token audience settable at creation; authorized APIs reachable from the application page
+- APIs moved beside Applications in the admin navigation
+
+---
+
 ### SCIM 2.0 Provisioning ✅ Shipped
 *Goal: Automated user and group provisioning from an external identity source*
 
@@ -193,51 +250,91 @@ Conformance target is OpenID Connect Core and Discovery. No identity provider ha
 
 ---
 
+### Sign-In Identifier ✅ Shipped — v1.24.0
+*Goal: Let people sign in with the identifier they actually know*
+
+- Per-workspace sign-in identifier mode — `username`, `email`, or `either`. Existing workspaces default to `username` and are unaffected until an operator changes it
+- Under `either`, a value matching one account's username and a different account's email is refused rather than guessed, with the same generic failure as any other outcome
+- Usernames are always stored trimmed and lowercased, enforced by a database constraint rather than by application code alone; sign-in matches case-insensitively
+- Cross-namespace collisions are rejected at write time across admin create, admin update, SCIM and self-registration
+- A username is generated when provisioning omits one, so an integrator no longer has to invent an identifier their users have never seen
+- Usernames are editable by an administrator; they were previously immutable
+
+---
+
+## Where the product stands
+
+Everything in Phases 0–5 shipped, as did the whole of the original Phase 7 except SMS OTP, the impersonation item from Phase 9, and the Redis work that Phase 8 anticipated. Federation (Phase 6) is the one large phase untouched.
+
+In protocol terms Kotauth is a compliant OAuth 2.0 / OIDC authorization server with SCIM 2.0 provisioning, OIDC identity brokering, and four sign-in methods (password, magic link, email OTP, passkey). The remaining distance to the enterprise checklist is SAML and LDAP.
+
+---
+
+## Known Gaps
+
+Recorded here because a roadmap that only lists future features overstates the present.
+
+**Scopes do not isolate clients from one another.** Authorizing a client against an API grants it every scope that API declares. There is no per-client scope allowlist, and `narrowScopes` filters against what the *resource server* declares rather than what the *client* is permitted. Measured on a live integration: a client created for a single ingest scope successfully minted a token carrying two others and read an admin endpoint across tenants. Separate credentials still buy independent revocation and a real `sub` in the audit trail — they do not buy least privilege, which is what the admin console implies they buy. Until the anticipated `allowedScopes` field exists, the only real isolation boundary is one resource server per privilege level. **This is the highest-priority open item.**
+
+**Identity provider configuration is partially excluded from backups.** A backup export does not carry most identity-provider configuration, so a restore does not reproduce a workspace's brokered sign-in setup.
+
+**Cross-namespace collision prevention is a read-before-write.** Two concurrent creates with mirrored identifiers can both pass the check, because no database constraint spans the username and email namespaces. The runtime refusal bounds the consequence to two users seeing a generic failure until an administrator intervenes.
+
+**No verification against live identity products is claimed.** SCIM targets RFC 7644/7643 and brokering targets OpenID Connect Core and Discovery. Neither has been certified against, nor verified end-to-end with, any particular vendor.
+
+---
+
 ## Post-V1 Roadmap
 
-The following phases are planned but not yet scheduled. Priority order reflects market demand and dependency on existing foundations.
+Priority order reflects adoption impact and dependency on existing foundations. Nothing below is scheduled.
 
 ---
 
 ### Phase 6 — Enterprise Federation
 *Goal: Connect Kotauth to corporate identity sources*
 
-The enterprise market requires LDAP and SAML. Without these, Kotauth cannot be adopted in organizations with existing Active Directory infrastructure or legacy SSO contracts.
+The largest remaining gap, and the most common adoption blocker. Organizations with Active Directory or an existing SSO contract cannot adopt Kotauth without these.
 
+- **SAML 2.0** — SP-initiated and IdP-initiated flows, assertion parsing, attribute mapping to the Kotauth user model
 - **LDAP / Active Directory sync** — read users and groups from a corporate directory, configurable sync interval, attribute mapping
-- **SAML 2.0** — SP-initiated and IdP-initiated flows, assertion parsing, attribute mapping to Kotauth user model
-- **Cross-tenant federation** — allow users from one workspace to authenticate in another via configured trust
+- **Claim-to-role mapping** — map inbound identity-provider claims onto Kotauth roles and groups. Smaller than the two above and useful on its own, since OIDC brokering already ships
+- **Cross-workspace federation** — allow users from one workspace to authenticate in another via configured trust
 
 ---
 
-### Phase 7 — Advanced Authentication Methods
-*Goal: Modern, phishing-resistant authentication*
+### Phase 7 — Authorization Depth
+*Goal: Make the authorization model as strong as the authentication model*
 
-- **WebAuthn / Passkeys** — the `MfaMethod` enum in the domain model is already extensible for this; implementation requires CBOR parsing and authenticator data verification
-- **Magic links** — passwordless email login, short-lived signed tokens
-- **SMS OTP** — noted as controversial due to SIM swap risk; implementation requires a pluggable SMS provider interface to avoid vendor lock-in
+Authentication is broadly complete; authorization is where the gaps now are.
+
+- **Per-client scope allowlists** — the `allowedScopes` field described in Known Gaps. This is the one item on this page that closes a security gap rather than adding a capability
+- **OAuth consent screen** — user-facing grant approval for third-party clients
+- **Resource-indicator phase 4** — introspection widening, and an ADR recording the immutable-identifier decision
+- **SMS OTP** — the last unshipped part of the original passwordless phase. The multi-channel port is designed; the adapters are not. Noted as controversial due to SIM-swap risk
 
 ---
 
 ### Phase 8 — Observability and Operations
-*Goal: Production-grade insight into a running Kotauth deployment*
+*Goal: Production-grade insight into a running deployment*
 
-- **Prometheus metrics** — login rates, error rates by type, token issuance volume, active session count, webhook delivery success rate
-- **Structured JSON log output** — the logstash encoder is already in the dependency tree; format finalization and field normalization
-- **Webhook retry background sweep** — the `findPending()` port exists; a scheduled background job to recover deliveries missed during downtime
-- **Key rotation** — admin-initiated rotation of per-tenant RS256 key pairs with a configurable overlap window for in-flight tokens
-- **Helm chart** — Kubernetes deployment manifest with configurable replicas, readiness/liveness probes, and secret management integration
-- **Zero-downtime rolling updates** — session and key state compatibility guarantees between adjacent versions
+- **Prometheus / Micrometer metrics** — login rates, error rates by type, token issuance volume, active sessions, webhook delivery success
+- **Key rotation** — admin-initiated rotation of per-workspace RS256 key pairs with a configurable overlap window for in-flight tokens
+- **Helm chart** — Kubernetes manifests with configurable replicas, probes, and secret integration
+- **Structured JSON log output** — the encoder is already in the dependency tree; field normalization remains
+- **Non-blocking webhook delivery** — replace blocking `HttpURLConnection` with Ktor's `HttpClient`, paired with SSRF hardening on operator-supplied URLs
+- **Audit log export** — scheduled export to object storage or a SIEM webhook
 
 ---
 
 ### Phase 9 — Platform Expansion
-*Goal: Kotauth as a programmable identity layer, not just an auth server*
+*Goal: Kotauth as a programmable identity layer*
 
-- **Admin REST API expansion** — bulk user operations, user impersonation with strict audit trail, cross-tenant admin endpoints
-- **SDK layer** — typed TypeScript/JavaScript client library wrapping the REST API and OIDC flows
-- **Email template customization** — per-tenant HTML email templates with variable substitution
-- **Audit log export** — scheduled export to S3-compatible object storage or a SIEM webhook
+- **Typed SDK** — a JVM client first, then a Kotlin Multiplatform client wrapping the REST API and OIDC flows
+- **Per-workspace email templates** — HTML templates with variable substitution, sharing the existing theme tokens
+- **Bulk user operations** over the admin API
+- **Live session activity stream** — a `SharedFlow` over server-sent events, so the admin session view stops being static
+- **IP allowlisting / geo-blocking** per workspace
+- **Login and session analytics** in the admin console
 
 ---
 
@@ -273,28 +370,51 @@ Keycloak's admin console is the cautionary tale. These principles are non-negoti
 
 ## Architecture Decisions
 
-Key architectural choices made during development, documented for future contributors.
+Recorded ADRs live in [`docs/adr/`](adr/). This table is generated from those files — if it disagrees with them, the files win.
 
-| ADR | Decision | Rationale |
-|---|---|---|
-| ADR-01 | Hexagonal (Ports & Adapters) — zero framework imports in domain | Domain logic is independently testable; adapters are swappable |
-| ADR-02 | Flyway for schema migrations | Versioned, irreversible migrations safe for CI/CD and production upgrades |
-| ADR-03 | Separate write-only (`AuditLogPort`) vs. read-only (`AuditLogRepository`) audit log paths | Auth path never blocks on query execution; read and write are independently scalable |
-| ADR-04 | All mutations routed through domain services, not directly through repositories | Validation and audit logging are centralized; no mutation path bypasses business rules |
-| ADR-05 | Client secret stored as bcrypt hash only — raw value shown once at creation | A database breach does not leak application secrets; lost secrets require regeneration |
-| ADR-06 | Domain services return `AdminResult<T>` sealed types, not exceptions | Error handling is explicit and exhaustive; no surprise runtime exceptions in route handlers |
-| ADR-07 | Portal login uses OAuth Authorization Code + PKCE via built-in `kotauth-portal` client | The portal and third-party apps authenticate identically; no separate session mechanism |
-| ADR-08 | Master tenant for platform admins | Platform operator role is cleanly separated from end-user tenants |
-| ADR-09 | Per-tenant RS256 key pairs, auto-provisioned | No single point of key failure; tokens are verifiable offline using JWKS; tenant isolation at the cryptographic level |
-| ADR-10 | Refresh token rotation on every use | A stolen refresh token has a limited replay window; reuse of a superseded token revokes the entire session chain |
-| ADR-11 | Audit events recorded eagerly in the request path | No auth flow succeeds without a corresponding audit record; background delivery risks silent loss |
-| ADR-12 | PKCE required for all public clients | Defense against authorization code interception and client ID enumeration |
-| ADR-13 | User lookup by `(tenant_id, username)` — no global username namespace | The same email exists independently in different workspaces; no cross-tenant information leakage |
-| ADR-14 | MFA pending state via HMAC-signed cookie, not server-side session | Stateless; no session table bloat; HMAC signature prevents userId forgery |
-| ADR-15 | OAuth `state` parameter carries HMAC-signed CSRF nonce + OAuth params as Base64 | No extra cookie or session required; the state parameter is self-contained and tamper-evident |
-| ADR-16 | Social login auto-links by email address | Reduces friction for users who have both a local and social account with the same email |
-| ADR-17 | Social OAuth adapters use `java.net.http` only — no new Gradle dependencies | Lean fat JAR; minimal attack surface; no transitive dependency risk |
-| ADR-18 | Social-registered users get a random unusable password hash | The account exists; password authentication is disabled until the user explicitly sets one |
-| ADR-19 | API keys use SHA-256, not bcrypt | 256-bit key entropy makes brute force infeasible; SHA-256 eliminates bcrypt latency on every API call |
-| ADR-20 | API key prefix stored for display — first 16 characters of the raw key | Human-friendly identification in the admin UI without exposing the full credential |
-| ADR-21 | Swagger UI loaded from CDN, not bundled | Saves ~7 MB from the fat JAR; no new Gradle dependencies required |
+| ADR | Decision |
+|---|---|
+| [ADR-01](adr/ADR-01-hexagonal-architecture.md) | Hexagonal (Ports & Adapters) — zero framework imports in the domain |
+| [ADR-02](adr/ADR-02-flyway-migrations.md) | Flyway for schema migrations |
+| [ADR-03](adr/ADR-03-audit-log-split.md) | Audit log split — write port vs. read repository |
+| [ADR-04](adr/ADR-04-admin-service-mutations.md) | Admin mutations go through `AdminService`, never directly through repositories |
+| [ADR-05](adr/ADR-05-client-secret-hashing.md) | Client secret — the raw value is never stored |
+| [ADR-06](adr/ADR-06-admin-result-sealed-class.md) | `AdminResult<T>` instead of throwing exceptions |
+| [ADR-07](adr/ADR-07-permissions-server-side.md) | Fine-grained permissions are server-side only |
+| [ADR-08](adr/ADR-08-multi-tenant-cors-policy.md) | Multi-tenant CORS policy |
+| [ADR-09](adr/ADR-09-tenant-scoped-csp-form-action.md) | Tenant-scoped CSP `form-action` |
+| [ADR-10](adr/ADR-10-magic-link-passwordless-signin.md) | Magic-link passwordless sign-in |
+| [ADR-11](adr/ADR-11-i18n-volume-mounted-bundles.md) | i18n via volume-mounted JSON bundles |
+| [ADR-12](adr/ADR-12-redis-sidecar.md) | Redis sidecar for distributed rate limiting and sessions |
+| [ADR-13](adr/ADR-13-oidc-sso-witness-cookie.md) | OIDC silent SSO via a path-scoped witness cookie |
+| [ADR-14](adr/ADR-14-admin-impersonation-session-model.md) | Admin impersonation session model |
+| [ADR-15](adr/ADR-15-email-otp-passwordless-primitive.md) | Email OTP as a passwordless primitive |
+| [ADR-16](adr/ADR-16-passkeys-sibling-to-password.md) | Passkeys as a sibling to password, not an MFA method |
+| [ADR-17](adr/ADR-17-smtp-hard-gate-passwordless-tenants.md) | SMTP hard-gate for passwordless-only workspaces |
+| [ADR-18](adr/ADR-18-group-delete-refuses-subgroups.md) | Deleting a group with subgroups is refused, not cascaded |
+| [ADR-19](adr/ADR-19-merged-scim-resource.md) | `MergedScimResource` — a PATCH body reaches persistence only through the merge engine |
+| [ADR-20](adr/ADR-20-scim-dialects-selected-per-key.md) | A SCIM dialect is selected per API key, never sniffed from the request |
+| [ADR-21](adr/ADR-21-just-in-time-provisioning.md) | Just-in-time provisioning only creates; linking happens before the gate |
+
+### Decisions without an ADR
+
+These are real, load-bearing choices that shape the codebase but were never written up. A previous version of this page listed them against ADR numbers that belong to other decisions. They are candidates for ADRs; until then this is the only place they are recorded.
+
+| Decision | Rationale |
+|---|---|
+| Master workspace for platform admins | The platform-operator role is cleanly separated from end-user workspaces |
+| Per-workspace RS256 key pairs, auto-provisioned on first use | No single point of key failure; tokens verify offline via JWKS; isolation at the cryptographic level |
+| Refresh token rotation on every use | A stolen refresh token has a limited replay window; reuse of a superseded token revokes the session chain |
+| PKCE required for all public clients | Defence against authorization-code interception |
+| Audit events recorded eagerly in the request path | No auth flow succeeds without its audit record; background delivery risks silent loss |
+| MFA pending state in an HMAC-signed cookie, not a server-side session | Stateless; no session-table bloat; the signature prevents userId forgery |
+| OAuth `state` carries an HMAC-signed CSRF nonce plus the OAuth parameters | No extra cookie or session needed; the parameter is self-contained and tamper-evident |
+| Portal login uses Authorization Code + PKCE via the built-in `kotauth-portal` client | The portal and third-party applications authenticate identically |
+| Social login auto-links by email address | Removes friction for users holding both a local and a social account |
+| Social OAuth adapters use `java.net.http` only | Lean fat JAR; no transitive dependency risk |
+| Social-registered users get an unusable password hash | The account exists; password sign-in stays disabled until the user sets one |
+| API keys hashed with SHA-256, not bcrypt | 256-bit key entropy makes brute force infeasible; avoids bcrypt latency on every API call |
+| API key prefix stored for display | Human-friendly identification without exposing the credential |
+| Swagger UI loaded from a CDN | Saves roughly 7 MB from the fat JAR |
+
+A fifteenth entry — *user lookup by `(tenant_id, username)`, no global username namespace* — was **superseded in v1.24.0**. The workspace-scoped namespace still holds, but lookup is now by the workspace's configured identifier (username, email, or either), and usernames are normalized and uniquely enforced case-insensitively.


### PR DESCRIPTION
## What does this PR do?

Housekeeping ahead of the dependency-update batch: brings `docs/ROADMAP.md` up to date, refreshes stale version claims in `README.md` and `CLAUDE.md`, and pins the JVM compile target so it cannot drift with whatever JDK builds the image.

Closes #

### 1. The ADR table was wrong, not just stale

`docs/ROADMAP.md` was last touched on 2026-06-23 and still declared `Status: v1.19.2` — five releases behind. More seriously, from ADR-07 onward every row of the architecture-decisions table named a different decision than the file carrying that number:

| The table said | The file actually is |
|---|---|
| ADR-10 — Refresh token rotation | Magic-link passwordless sign-in |
| ADR-14 — MFA pending via HMAC cookie | Admin impersonation session model |
| ADR-19 — API keys use SHA-256 | `MergedScimResource` merge engine |
| ADR-21 — Swagger UI from CDN | Just-in-time provisioning |

The table is now generated from the files in `docs/adr/`, with a note that the files win on any disagreement, and every link verified to resolve.

The fifteen decisions the old table described are all real — refresh rotation, PKCE enforcement, the master workspace, API key hashing and the rest — they simply have no ADR file. They now sit in a **Decisions without an ADR** section, labelled as candidates rather than presented as recorded. One, *user lookup by `(tenant_id, username)`*, is marked superseded by v1.24.0.

### 2. Shipped work the roadmap never recorded

It listed Phase 7 (passkeys, magic links) as unscheduled future work when ADR-10, ADR-15 and ADR-16 show all of it shipped — a prospective adopter reading that page would conclude Kotauth has no passwordless support. Also added: audit HMAC chain (v1.19.0), resource indicators (v1.19.3), i18n, Redis, silent SSO, admin impersonation, M2M onboarding (v1.22.0) and the sign-in identifier work (v1.24.0). Admin impersonation was listed under Phase 9 and Redis was anticipated by Phase 8; both shipped.

Post-V1 is restructured accordingly. Phase 7 is repurposed from "Advanced Authentication Methods" — essentially complete — to **Authorization Depth**, because that is where the gaps now are. A **Known Gaps** section is added, on the principle that a roadmap listing only future features overstates the present.

### 3. Pin the JVM 17 compile target

`build.gradle.kts` declared no `jvmTarget`, no `sourceCompatibility`/`targetCompatibility`, and no toolchain — so the compile target silently followed whichever JDK ran Gradle. That is 17 locally and 17 in CI today, which is why nothing has broken.

It becomes a problem the moment the build JDK moves. Dependabot #117 proposes exactly that (`eclipse-temurin:17-jdk` → `24-jdk`), which would have emitted Java 24 bytecode. The runtime image is `25-jre`, so the container would keep working and CI would stay green — `publish.yml` is the only workflow that builds the Dockerfile and it triggers on push, not `pull_request`. It would have broken silently, and only for people running the JAR directly on the JVM 17 the README promises.

This pins the target explicitly and adds `--release 17` / `-Xjdk-release=17`, which also stops a newer build JDK linking against APIs absent on 17 — something bytecode versioning alone does not prevent.

Deliberately **not** a `jvmToolchain(17)`: that pins the JVM tests run on as well, and CI's `java: [17, 21]` matrix exists to exercise both. With no toolchain resolver in `settings.gradle.kts`, the JDK 21 matrix entry would either fail to find a 17 toolchain or silently run on 17 — either way the matrix stops testing what it is for.

### 4. Stale stack lines

`README.md` and `CLAUDE.md` both claimed `Ktor 3.4.2, Exposed 0.61.0, Gradle 8.14`. Actual: **Ktor 3.5.1, Exposed 1.3.1, Gradle 9.4.1**. The `CHANGELOG.md` mentions of Ktor 3.4.x are historical entries and correctly left alone.

## Type of change

- [x] Documentation
- [x] CI / tooling

## How was this tested?

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

`./gradlew clean test` — **2467 tests, 0 failures**. `make lint` clean. Verified the emitted class-file major version is still `0x3d` (61 = Java 17) after the build change. Verified every `adr/ADR-*.md` link in the roadmap resolves, and that each ADR row matches the `# ` heading of the file it links to.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [ ] New domain logic has no framework imports — n/a
- [ ] New database changes include a Flyway migration — n/a
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a
- [x] Security-sensitive changes are noted in the description

## One decision to confirm before merge

The **Known Gaps** section discloses publicly that authorizing a client against an API grants it every scope that API declares — so separate client credentials buy independent revocation and a real `sub` in the audit trail, but not least privilege.

For publishing now: it requires an already-authorized client, so it is not remotely exploitable by an outsider — it is a privilege boundary between clients the operator themselves authorized. And the admin console currently implies a guarantee it does not deliver, which is worse than stating the limit plainly.

Against: it is an unfixed authorization weakness in a public repository.

Alternatives if you would rather not publish it yet: soften to "scopes partition capabilities within a trusted client, not trust between clients" without specifics, or drop the paragraph and restore it when the per-client `allowedScopes` fix lands.

## Notes for reviewers

The roadmap diff is large but almost entirely additive. The deletions are the incorrect ADR table and the Post-V1 section that described shipped work as planned.

Merging this first makes the dependency batch safer — #117 in particular becomes a no-op for correctness rather than a silent bytecode change.

