### PR TITLE
RFC 8252 loopback redirect matching, discovery none, and v1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.24.1] - 2026-09-07
+
+### Fixed
+
+- **Loopback redirect URIs now match on any port, for public clients** (RFC 8252 §7.3). A native
+  application binds an ephemeral port at sign-in time and cannot know it in advance, so exact
+  string matching made the standard native-app pattern unusable — the workaround was registering
+  a handful of fixed ports and hoping one was free. A public client can now register
+  `http://127.0.0.1/cb` and be redirected to whatever port the operating system hands out. See
+  [ADR-22](docs/adr/ADR-22-rfc8252-loopback-redirect-matching.md).
+- **Discovery advertises `none` in `token_endpoint_auth_methods_supported`.** The server has
+  always let public clients call the token endpoint without a secret; the discovery document did
+  not say so. A conforming OIDC library configured as a public client could read that list, find
+  no auth method it could satisfy, and refuse before sending a request — surfacing as a client
+  misconfiguration rather than a discovery gap.
+- **Creating an API key with a name that already exists in the workspace returns a validation
+  error instead of a 500.** Thanks to the external contributor who reported and fixed this.
+
+### Security
+
+The loopback relaxation is deliberately narrow, and each boundary is covered by a test:
+
+- `http` on the literal addresses `127.0.0.1` and `[::1]` only. **`localhost` is excluded** — it
+  resolves through the name service and can be redirected, which the literals cannot.
+- Only the port is ignored. Scheme, host, path, query and fragment must still match, and a URI
+  carrying userinfo never matches.
+- **Public clients only.** Confidential clients keep exact matching, as does every `https` URI
+  and every named host.
+- The `redirect_uri` presented at the token endpoint is still compared **exactly** against the
+  value stored on the authorization code. A code issued for one loopback port cannot be redeemed
+  while claiming another.
+
+A deployment with no public client holding an `http` loopback registration is unaffected.
+
+### Changed
+
+- The JVM compile target is pinned to 17 in `build.gradle.kts` (`--release 17` /
+  `-Xjdk-release=17`) rather than following whichever JDK builds the image, so a newer build JDK
+  cannot silently raise the bytecode target or link against APIs absent on 17.
+
+### Docs
+
+- `docs/ROADMAP.md` rewritten for v1.24.0. The architecture-decisions table was misaligned with
+  the files in `docs/adr/` from ADR-07 onward and is now generated from them; decisions with no
+  ADR are listed separately as candidates. Work that had shipped — passkeys, magic links, email
+  OTP, Redis, i18n, admin impersonation — was still listed as unscheduled future work.
+- Stack versions in `README.md` and `CLAUDE.md` corrected to Ktor 3.5.1, Exposed 1.3.1,
+  Gradle 9.4.1.
+
+### Chore
+
+- Dependency bumps: Ktor 3.5.2, Exposed 1.4.0, JUnit 6.1.3, Testcontainers 1.21.4.
+- CI action bumps: `actions/setup-java` 6, `gradle/actions` 6.2.0.
+
+---
+
 ## [1.24.0] - 2026-09-04
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.24.0"
+version = "1.24.1"
 
 // Pin the compile target explicitly rather than letting it follow whichever JDK
 // happens to build. `release`/`-Xjdk-release` also stop a newer build JDK from

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,6 +395,7 @@ Recorded ADRs live in [`docs/adr/`](adr/). This table is generated from those fi
 | [ADR-19](adr/ADR-19-merged-scim-resource.md) | `MergedScimResource` — a PATCH body reaches persistence only through the merge engine |
 | [ADR-20](adr/ADR-20-scim-dialects-selected-per-key.md) | A SCIM dialect is selected per API key, never sniffed from the request |
 | [ADR-21](adr/ADR-21-just-in-time-provisioning.md) | Just-in-time provisioning only creates; linking happens before the gate |
+| [ADR-22](adr/ADR-22-rfc8252-loopback-redirect-matching.md) | Loopback redirect URIs match on any port, for public clients only |
 
 ### Decisions without an ADR
 

--- a/docs/adr/ADR-22-rfc8252-loopback-redirect-matching.md
+++ b/docs/adr/ADR-22-rfc8252-loopback-redirect-matching.md
@@ -1,0 +1,86 @@
+# ADR-22 — Loopback redirect URIs match on any port, for public clients only
+
+**Status:** Accepted — v1.24.1
+**Context:** RFC 8252 §7.3, §8.3 · RFC 6749 §3.1.2.3
+
+## Context
+
+A native application has no fixed redirect target. The established pattern is to bind an
+ephemeral port on the loopback interface at sign-in time and use `http://127.0.0.1:<port>/cb`,
+where the port is whatever the operating system hands out that second and differs on every
+launch.
+
+Kotauth compared the requested `redirect_uri` against the client's registered URIs with exact
+string equality, so an ephemeral port never matched. RFC 8252 §7.3 addresses this directly:
+
+> The authorization server MUST allow any port to be specified at the time of the request for
+> loopback IP redirect URIs, to accommodate clients that obtain an available ephemeral port
+> from the operating system at the time of the request.
+
+This surfaced from a real integration — a Compose Desktop point-of-sale terminal — which
+worked around it by registering three fixed loopback ports and binding the first free one.
+That works until all three are taken, and the number three is arbitrary.
+
+## Decision
+
+Loopback redirect URIs match on any port. The exception is deliberately narrow, and every
+boundary below is enforced by a test in `RedirectUriMatcherTest`.
+
+**Scope of the relaxation**
+
+- `http` scheme only, on the literal loopback addresses `127.0.0.1` and `[::1]`.
+- Only the port is ignored. Scheme, host, path, query and fragment must all still match.
+- A URI carrying userinfo never matches, rather than the matcher deciding what
+  `http://evil@127.0.0.1/cb` ought to mean next to a registration that has none.
+- Applied only when the client's `accessType` is `PUBLIC`.
+
+**`localhost` is excluded.** It resolves through the name service and can be pointed elsewhere
+by a hosts-file entry or a DNS answer, so it is not equivalent to the literal addresses.
+RFC 8252 §8.3 recommends the literals for exactly this reason.
+
+**Restricted to public clients.** RFC 8252 concerns native apps, which are public clients by
+definition. A confidential client has no legitimate reason to use a loopback callback, so
+extending the relaxation there would widen the matching surface with no use case to justify
+it. Public clients are also the ones for which Kotauth already forces PKCE with `S256`
+(`OAuthService.issueAuthorizationCode`), which is the mitigation the RFC relies on.
+
+**Two call sites change; a third does not.**
+
+Changed — both compare a request against the client's *registered* URIs:
+
+- `OAuthService.validateRedirectUri` — the open-redirect guard on the `prompt=none` error path.
+- `OAuthService.issueAuthorizationCode` — the authorize path.
+
+Unchanged, and deliberately so:
+
+- `OAuthService.exchangeAuthorizationCode` compares the token request's `redirect_uri` against
+  the value stored **on the authorization code**. That binds a code to the exact callback it
+  was issued for. Relaxing it would let a code issued for one loopback port be redeemed while
+  claiming another, which is the local interception PKCE exists to blunt. It stays exact, and
+  a test asserts that a differing port at the token endpoint still fails.
+
+## Consequences
+
+A native client can bind whatever port the OS gives it and register a single loopback URI. The
+port component of a registered loopback URI becomes advisory for public clients — registering
+`http://127.0.0.1/cb` with no port is the clearest form.
+
+Nothing changes for any deployment without a public client holding an `http` loopback
+registration. Exact matches continue to match, and no relaxation reaches `https`, any named
+host, or any confidential client.
+
+The residual risk is the one the RFC accepts: another process on the same machine can bind the
+port and receive the authorization code. PKCE with `S256` is what makes that code unusable, and
+Kotauth requires it for every public client.
+
+## Alternatives considered
+
+**Leave it, and let integrators register fixed ports.** What the reporting integration did. It
+fails when the chosen ports are already in use, and the number to register is a guess.
+
+**Allow any port for any host.** Removes the reason redirect URIs are registered at all.
+
+**Include `localhost`.** Convenient, and specifically warned against by RFC 8252 §8.3 — the
+name can be redirected, the literals cannot.
+
+**Allow it for confidential clients too.** No use case, so purely additional surface.

--- a/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/auth/OAuthProtocolRoutes.kt
@@ -120,6 +120,10 @@ internal fun Route.oauthProtocolRoutes(
                     buildJsonArray {
                         add("client_secret_post")
                         add("client_secret_basic")
+                        // Public clients authenticate with no secret at all (RFC 6749 §2.1,
+                        // OIDC Core §9). The server has always supported it; omitting it here
+                        // made conforming libraries refuse to start against a public client.
+                        add("none")
                     },
                 )
                 val baselineScopes = listOf("openid", "profile", "email")

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -107,7 +107,11 @@ class OAuthService(
         val tenant = tenantRepository.findBySlug(tenantSlug) ?: return false
         val client = applicationRepository.findByClientId(tenant.id, clientId) ?: return false
         if (!client.enabled) return false
-        return client.redirectUris.contains(redirectUri)
+        return RedirectUriMatcher.matches(
+            client.redirectUris,
+            redirectUri,
+            allowAnyLoopbackPort = client.accessType == AccessType.PUBLIC,
+        )
     }
 
     /**
@@ -189,8 +193,14 @@ class OAuthService(
             )
         }
 
-        // Validate redirect URI — exact match required (RFC 6749 §3.1.2.3)
-        if (!client.redirectUris.contains(redirectUri)) {
+        // Exact match per RFC 6749 §3.1.2.3, except that a public client's loopback URI
+        // matches on any port — RFC 8252 §7.3, see RedirectUriMatcher.
+        if (!RedirectUriMatcher.matches(
+                client.redirectUris,
+                redirectUri,
+                allowAnyLoopbackPort = client.accessType == AccessType.PUBLIC,
+            )
+        ) {
             return OAuthResult.Failure(OAuthError.InvalidRedirectUri(redirectUri))
         }
 
@@ -311,7 +321,10 @@ class OAuthService(
             return OAuthResult.Failure(OAuthError.InvalidGrant("Authorization code is expired or already used"))
         }
 
-        // Validate redirect URI matches exactly what was used to obtain the code
+        // Exact, and deliberately not routed through RedirectUriMatcher: this compares the
+        // token request against the URI stored on the code, binding a code to the exact
+        // callback it was issued for. Relaxing it would let a code issued for one loopback
+        // port be redeemed while claiming another — the interception PKCE exists to blunt.
         if (authCode.redirectUri != redirectUri) {
             return OAuthResult.Failure(OAuthError.InvalidGrant("redirect_uri mismatch"))
         }

--- a/src/main/kotlin/com/kauth/domain/service/RedirectUriMatcher.kt
+++ b/src/main/kotlin/com/kauth/domain/service/RedirectUriMatcher.kt
@@ -1,0 +1,77 @@
+package com.kauth.domain.service
+
+import java.net.URI
+
+/**
+ * Matches a requested `redirect_uri` against a client's registered URIs.
+ *
+ * The default is exact string comparison, as RFC 6749 §3.1.2.3 requires. The one exception
+ * is the loopback interface: RFC 8252 §7.3 states the authorization server MUST allow any
+ * port for loopback redirect URIs, because a native app binds an ephemeral port at login
+ * time and cannot know it in advance.
+ *
+ * The exception is deliberately narrow — see [ADR-22](../../../../../../docs/adr/ADR-22-rfc8252-loopback-redirect-matching.md):
+ *
+ *  - `http` scheme only, on the literal loopback addresses `127.0.0.1` and `[::1]`.
+ *    `localhost` is excluded on purpose: it resolves through the name service and can be
+ *    pointed elsewhere by a hosts-file entry or a DNS answer (RFC 8252 §8.3).
+ *  - Only the port is ignored. Scheme, host, path, query and fragment must all match, and
+ *    a URI carrying userinfo never matches.
+ *  - Gated behind [allowAnyLoopbackPort], which callers set for public clients only.
+ *
+ * This governs which URIs a client may be *sent* to. It is not used to check the
+ * `redirect_uri` presented at the token endpoint against the one stored on the authorization
+ * code — that comparison stays exact, so a code issued for one port cannot be redeemed
+ * while claiming another.
+ */
+internal object RedirectUriMatcher {
+    private val LOOPBACK_HOSTS = setOf("127.0.0.1", "[::1]", "::1")
+
+    fun matches(
+        registeredUris: List<String>,
+        requestedUri: String,
+        allowAnyLoopbackPort: Boolean,
+    ): Boolean {
+        if (registeredUris.contains(requestedUri)) return true
+        if (!allowAnyLoopbackPort) return false
+
+        val requested = loopbackKeyOf(requestedUri) ?: return false
+        return registeredUris.any { loopbackKeyOf(it) == requested }
+    }
+
+    /**
+     * A comparison key for a loopback URI with the port removed, or null when the URI is not
+     * an `http` loopback URI we are willing to treat port-agnostically.
+     */
+    private fun loopbackKeyOf(raw: String): String? {
+        val uri =
+            try {
+                URI(raw)
+            } catch (_: Exception) {
+                return null
+            }
+
+        if (!uri.scheme.equals("http", ignoreCase = true)) return null
+        // Userinfo would let `http://evil@127.0.0.1/cb` sit alongside a registered URI that
+        // has none; refuse rather than deciding what it should mean.
+        if (uri.userInfo != null) return null
+
+        val host = uri.host ?: return null
+        if (host.lowercase() !in LOOPBACK_HOSTS) return null
+
+        // Port deliberately absent from the key — that is the whole exception.
+        return buildString {
+            append("http://")
+            append(host.lowercase())
+            append(uri.rawPath.orEmpty())
+            uri.rawQuery?.let {
+                append('?')
+                append(it)
+            }
+            uri.rawFragment?.let {
+                append('#')
+                append(it)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -2253,6 +2253,42 @@ class AuthRoutesTest {
     // =========================================================================
 
     @Test
+    fun `GET openid-configuration advertises none as a token endpoint auth method`() =
+        testApplication {
+            resetFixtures()
+
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    authRoutes(
+                        authService = buildAuthService(),
+                        oauthService = buildOAuthService(),
+                        tenantRepository = tenantRepo,
+                        loginRateLimiter = loginLimiter,
+                        registerRateLimiter = registerLimiter,
+                        tokenRateLimiter = tokenLimiter,
+                        credentialFlowService = selfService,
+                        encryptionService = encryptionService,
+                        translationPort = EnglishOnlyTranslation(),
+                    )
+                }
+            }
+
+            val response = client.get("/t/acme/.well-known/openid-configuration")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            val methods = Regex(""""token_endpoint_auth_methods_supported"\s*:\s*\[([^\]]*)\]""").find(body)
+            assertNotNull(methods, "token_endpoint_auth_methods_supported must be present")
+            val listed = methods.groupValues[1]
+            // Public clients call the token endpoint with no secret; a conforming library
+            // configured as one refuses to start if this list does not say so.
+            assertTrue(listed.contains("\"none\""), "must advertise none, got: $listed")
+            assertTrue(listed.contains("\"client_secret_post\""), "must keep client_secret_post, got: $listed")
+            assertTrue(listed.contains("\"client_secret_basic\""), "must keep client_secret_basic, got: $listed")
+        }
+
+    @Test
     fun `GET openid-configuration authorization_endpoint value contains canonical authorize path`() =
         testApplication {
             resetFixtures()

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -196,6 +196,115 @@ class OAuthServiceTest {
         assertIs<OAuthError.InvalidRedirectUri>(result.error)
     }
 
+    // -------------------------------------------------------------------------
+    // RFC 8252 §7.3 — loopback redirect URIs match on any port, for public clients only
+    // -------------------------------------------------------------------------
+
+    /** Public native client registered on a loopback URI with one fixed port. */
+    private val nativeClient
+        get() =
+            publicClient.copy(
+                id = ApplicationId(3),
+                clientId = "native-app",
+                redirectUris = listOf("http://127.0.0.1:47821/cb"),
+            )
+
+    /** Same loopback registration, but confidential — must NOT get the relaxation. */
+    private val confidentialLoopbackClient
+        get() =
+            confidentialClient.copy(
+                id = ApplicationId(4),
+                clientId = "backend-loopback",
+                redirectUris = listOf("http://127.0.0.1:47821/cb"),
+            )
+
+    @Test
+    fun `issueAuthorizationCode accepts an ephemeral loopback port for a PUBLIC client`() {
+        apps.add(nativeClient)
+        val result =
+            svc.issueAuthorizationCode(
+                tenantSlug = "acme",
+                userId = UserId(10),
+                clientId = "native-app",
+                redirectUri = "http://127.0.0.1:58139/cb",
+                scopes = "openid",
+                codeChallenge = pkceChallenge,
+                codeChallengeMethod = "S256",
+                nonce = null,
+                state = null,
+            )
+        assertIs<OAuthResult.Success<AuthorizationCode>>(result)
+    }
+
+    @Test
+    fun `issueAuthorizationCode refuses an ephemeral loopback port for a CONFIDENTIAL client`() {
+        apps.add(confidentialLoopbackClient, secretHash = hasher.hash("secret123"))
+        val result =
+            svc.issueAuthorizationCode(
+                tenantSlug = "acme",
+                userId = UserId(10),
+                clientId = "backend-loopback",
+                redirectUri = "http://127.0.0.1:58139/cb",
+                scopes = "openid",
+                codeChallenge = null,
+                codeChallengeMethod = null,
+                nonce = null,
+                state = null,
+            )
+        assertIs<OAuthResult.Failure>(result)
+        assertIs<OAuthError.InvalidRedirectUri>(result.error)
+    }
+
+    @Test
+    fun `issueAuthorizationCode still refuses a non-loopback host on a different port`() {
+        val result =
+            svc.issueAuthorizationCode(
+                tenantSlug = "acme",
+                userId = UserId(10),
+                clientId = "spa-app",
+                redirectUri = "https://app.example.com:9999/callback",
+                scopes = "openid",
+                codeChallenge = pkceChallenge,
+                codeChallengeMethod = "S256",
+                nonce = null,
+                state = null,
+            )
+        assertIs<OAuthResult.Failure>(result)
+        assertIs<OAuthError.InvalidRedirectUri>(result.error)
+    }
+
+    @Test
+    fun `the code stays bound to the exact loopback URI it was issued for`() {
+        apps.add(nativeClient)
+        val issued =
+            svc.issueAuthorizationCode(
+                tenantSlug = "acme",
+                userId = UserId(10),
+                clientId = "native-app",
+                redirectUri = "http://127.0.0.1:58139/cb",
+                scopes = "openid",
+                codeChallenge = pkceChallenge,
+                codeChallengeMethod = "S256",
+                nonce = null,
+                state = null,
+            )
+        assertIs<OAuthResult.Success<AuthorizationCode>>(issued)
+
+        // A different port at the token endpoint must still fail: the relaxation governs
+        // which URIs a client may be sent to, never the code-to-callback binding.
+        val redeemed =
+            svc.exchangeAuthorizationCode(
+                tenantSlug = "acme",
+                code = issued.value.code,
+                clientId = "native-app",
+                clientSecret = null,
+                redirectUri = "http://127.0.0.1:47821/cb",
+                codeVerifier = pkceVerifier,
+            )
+        assertIs<OAuthResult.Failure>(redeemed)
+        assertIs<OAuthError.InvalidGrant>(redeemed.error)
+    }
+
     @Test
     fun `issueAuthorizationCode returns PkceRequired for PUBLIC client without code_challenge`() {
         val result =

--- a/src/test/kotlin/com/kauth/domain/service/RedirectUriMatcherTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/RedirectUriMatcherTest.kt
@@ -1,0 +1,196 @@
+package com.kauth.domain.service
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * RFC 8252 §7.3 loopback matching.
+ *
+ * The relaxation is deliberately narrow: only `http` on a loopback *literal*, only the
+ * port is ignored, and only for clients that opted in (public clients). Every test that
+ * asserts `false` here is guarding a way the exception could be widened by accident.
+ */
+class RedirectUriMatcherTest {
+    private val registered = listOf("http://127.0.0.1:47821/cb")
+
+    // -------------------------------------------------------------------------
+    // The behaviour the RFC requires
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `loopback matches a different ephemeral port`() {
+        assertTrue(RedirectUriMatcher.matches(registered, "http://127.0.0.1:58139/cb", allowAnyLoopbackPort = true))
+    }
+
+    @Test
+    fun `loopback matches when the registered URI carries no port at all`() {
+        assertTrue(
+            RedirectUriMatcher.matches(
+                listOf("http://127.0.0.1/cb"),
+                "http://127.0.0.1:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `IPv6 loopback matches a different port`() {
+        assertTrue(
+            RedirectUriMatcher.matches(
+                listOf("http://[::1]:47821/cb"),
+                "http://[::1]:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `an exact match still works with the relaxation enabled`() {
+        assertTrue(RedirectUriMatcher.matches(registered, "http://127.0.0.1:47821/cb", allowAnyLoopbackPort = true))
+    }
+
+    // -------------------------------------------------------------------------
+    // The relaxation must not widen past loopback
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `localhost is excluded — it resolves through the name service and can be redirected`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://localhost:47821/cb"),
+                "http://localhost:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `https loopback is not loosened`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("https://127.0.0.1:47821/cb"),
+                "https://127.0.0.1:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a real host is never port-agnostic`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://app.example.com:8080/cb"),
+                "http://app.example.com:9090/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a host that merely starts with the loopback literal is not loopback`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://127.0.0.1.evil.example.com:47821/cb"),
+                "http://127.0.0.1.evil.example.com:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `another loopback-range address is not accepted`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://127.0.0.2:47821/cb"),
+                "http://127.0.0.2:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Only the port is ignored — everything else still has to match
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `path must still match`() {
+        assertFalse(RedirectUriMatcher.matches(registered, "http://127.0.0.1:58139/other", allowAnyLoopbackPort = true))
+    }
+
+    @Test
+    fun `query must still match`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://127.0.0.1:47821/cb?state=fixed"),
+                "http://127.0.0.1:58139/cb?state=other",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `userinfo cannot be smuggled in`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                registered,
+                "http://evil@127.0.0.1:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a loopback host cannot match a registered non-loopback URI`() {
+        assertFalse(
+            RedirectUriMatcher.matches(
+                listOf("http://app.example.com/cb"),
+                "http://127.0.0.1:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Opt-in gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `without the flag a differing port is refused`() {
+        assertFalse(RedirectUriMatcher.matches(registered, "http://127.0.0.1:58139/cb", allowAnyLoopbackPort = false))
+    }
+
+    @Test
+    fun `without the flag an exact match still works`() {
+        assertTrue(RedirectUriMatcher.matches(registered, "http://127.0.0.1:47821/cb", allowAnyLoopbackPort = false))
+    }
+
+    // -------------------------------------------------------------------------
+    // Malformed input must not throw or match
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `a malformed requested URI does not match and does not throw`() {
+        assertFalse(
+            RedirectUriMatcher.matches(registered, "http://127.0.0.1:not-a-port/cb", allowAnyLoopbackPort = true),
+        )
+        assertFalse(RedirectUriMatcher.matches(registered, ":::::", allowAnyLoopbackPort = true))
+        assertFalse(RedirectUriMatcher.matches(registered, "", allowAnyLoopbackPort = true))
+    }
+
+    @Test
+    fun `a malformed registered URI is skipped rather than throwing`() {
+        assertTrue(
+            RedirectUriMatcher.matches(
+                listOf(":::::", "http://127.0.0.1:47821/cb"),
+                "http://127.0.0.1:58139/cb",
+                allowAnyLoopbackPort = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `no registered URIs means no match`() {
+        assertFalse(RedirectUriMatcher.matches(emptyList(), "http://127.0.0.1:58139/cb", allowAnyLoopbackPort = true))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds RFC 8252 native-app support and cuts v1.24.1.

### Loopback redirect URIs match on any port, for public clients

A native app binds an ephemeral port at sign-in time, so exact string matching never matched a registration. RFC 8252 §7.3 requires the server to allow any port for loopback.

New `RedirectUriMatcher` (`domain/service/`, `internal`, uses only `java.net.URI`). The relaxation:

- `http` on the literal addresses `127.0.0.1` and `[::1]` only. `localhost` is excluded — it resolves through the name service and can be redirected (RFC 8252 §8.3).
- Only the port is ignored. Scheme, host, path, query and fragment must still match; a URI carrying userinfo never matches.
- Public clients only. Confidential clients keep exact matching.

Two call sites relaxed, one deliberately not:

| Site | Compares | Change |
|---|---|---|
| `OAuthService.validateRedirectUri` | request vs. registered URIs | relaxed |
| `OAuthService.issueAuthorizationCode` | request vs. registered URIs | relaxed |
| `OAuthService.exchangeAuthorizationCode` | token request vs. URI stored on the code | **unchanged, exact** |

The third binds a code to the callback it was issued for; relaxing it would let a code issued for one loopback port be redeemed claiming another. Rationale in [ADR-22](docs/adr/ADR-22-rfc8252-loopback-redirect-matching.md).

### Discovery advertises `none`

`token_endpoint_auth_methods_supported` listed only `client_secret_post` and `client_secret_basic`. The server has always allowed public clients to call the token endpoint without a secret; a conforming library reading that list would refuse before sending a request.

### v1.24.1

Version bumped and CHANGELOG entry covering the two fixes above plus what was already merged since v1.24.0: duplicate API key names returning a validation error instead of a 500 (#145), the roadmap rewrite and ADR-table correction, the pinned JVM 17 compile target, and the dependency and CI bumps.

Patch rather than minor: exact matches keep matching, only previously-rejected requests start succeeding, and a deployment with no public client on an `http` loopback registration is unaffected.

## Type of change

- [x] Bug fix
- [x] Documentation

## How was this tested?

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

2493 tests, 0 failures. `make lint` clean. Class-file major version verified still `0x3d` (Java 17).

- `RedirectUriMatcherTest` — 18 cases. Negative cases cover `localhost`, `https`, a named host, `127.0.0.1.evil.example.com`, `127.0.0.2`, differing path, differing query, smuggled userinfo, and the flag off. Malformed input on either side neither matches nor throws.
- `OAuthServiceTest` — ephemeral port accepted for a public client, refused for a confidential one, non-loopback host on a different port still refused, and a code issued for one loopback port cannot be redeemed claiming another.
- `AuthRoutesTest` — discovery advertises `none` while keeping both `client_secret_*` methods.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [x] New domain logic has no framework imports
- [ ] New database changes include a Flyway migration — n/a
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a, discovery is not described there
- [x] Security-sensitive changes are noted in the description
