### PR TITLE
Correct stale documentation claims and stop duplicating versions in prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Kotauth is a self-hosted identity and access management server built with Kotlin/Ktor. It provides multi-tenant authentication, authorization, user management, OAuth2/OIDC, MFA, and an admin UI.
 
-**Stack**: Kotlin 2.3.20 · Ktor 3.5.1 · Exposed 1.3.1 (ORM) · PostgreSQL 15 · JVM 17 (compile target pinned in `build.gradle.kts`) · Gradle 9.4.1 · LightningCSS (build-time only)
+**Stack**: Kotlin · Ktor · Exposed (ORM) · PostgreSQL 15 · JVM 17 (compile target pinned in `build.gradle.kts`) · Gradle · LightningCSS (build-time only)
+
+Library versions are declared at the top of `build.gradle.kts` and pinned in `gradle.lockfile` — read them there rather than from prose, which goes stale within days of a Dependabot merge.
 
 ## Common Commands
 
@@ -33,7 +35,7 @@ Kotauth is a self-hosted identity and access management server built with Kotlin
 src/main/kotlin/com/kauth/
 ├── domain/
 │   ├── model/       # Pure data classes, value objects
-│   ├── port/        # ~27 interface contracts (repository, token, email, etc.)
+│   ├── port/        # 43 interface contracts (repository, token, email, etc.)
 │   └── service/     # Business logic, returns sealed Result types
 ├── adapter/
 │   ├── web/         # Ktor route handlers

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Pre-release tags (e.g. `1.19.0-rc1`) are published but do not move the `latest` 
 
 ## Under the hood
 
-**Stack:** Kotlin 2.3.20, Ktor 3.5.1, Exposed 1.3.1 (ORM), PostgreSQL 15, JVM 17, Gradle 9.4.1. The runtime image is ~410 MB, mostly the JRE base; the JAR runs as an unprivileged user.
+**Stack:** Kotlin on Ktor, Exposed for persistence, PostgreSQL 15, JVM 17, Gradle. Exact library versions live in [`build.gradle.kts`](build.gradle.kts) and are pinned in `gradle.lockfile`. The runtime image is ~410 MB, mostly the JRE base; the JAR runs as an unprivileged user.
 
 **Architecture:** [hexagonal (Ports & Adapters)](https://alistair.cockburn.us/hexagonal-architecture/) — the domain layer (`domain/model`, `domain/port`, `domain/service`) has zero framework dependencies, so business logic is testable in-memory without Docker, a database, or HTTP. Adapters (`adapter/web`, `adapter/persistence`, `adapter/token`, `adapter/email`, `adapter/social`) sit at the edge.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Pre-release tags (e.g. `1.19.0-rc1`) are published but do not move the `latest` 
 
 ## Under the hood
 
-**Stack:** Kotlin 2.3.20, Ktor 3.5.1, Exposed 1.3.1 (ORM), PostgreSQL 15, JVM 17, Gradle 9.4.1. The runtime image is ~120 MB; the JAR runs as an unprivileged user.
+**Stack:** Kotlin 2.3.20, Ktor 3.5.1, Exposed 1.3.1 (ORM), PostgreSQL 15, JVM 17, Gradle 9.4.1. The runtime image is ~410 MB, mostly the JRE base; the JAR runs as an unprivileged user.
 
 **Architecture:** [hexagonal (Ports & Adapters)](https://alistair.cockburn.us/hexagonal-architecture/) — the domain layer (`domain/model`, `domain/port`, `domain/service`) has zero framework dependencies, so business logic is testable in-memory without Docker, a database, or HTTP. Adapters (`adapter/web`, `adapter/persistence`, `adapter/token`, `adapter/email`, `adapter/social`) sit at the edge.
 

--- a/docs/FRONTEND_CSS.md
+++ b/docs/FRONTEND_CSS.md
@@ -673,39 +673,19 @@ tasks.named("processResources") {
 ## Dockerfile Integration
 
 ```
-Stage 1  css-build     — node:20-slim + npm ci + lightningcss-cli
-Stage 2  kotlin-build  — gradle:8-jdk17 (copies CSS from Stage 1, skips all CSS tasks)
-Stage 3  runtime       — eclipse-temurin:17-jre, no Node, no build tools (~85 MB total)
+Stage 1  frontend-build — node:26-slim + npm ci + lightningcss-cli
+Stage 2  kotlin-build   — eclipse-temurin:17-jdk (copies CSS from Stage 1, skips all CSS tasks)
+Stage 3  runtime        — eclipse-temurin:25-jre, no Node, no build tools
 ```
 
-```dockerfile
-# Stage 1: CSS compilation
-FROM node:20-slim AS css-build
-WORKDIR /build
-# Install from lockfile — layer cached until package-lock.json changes
-COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci
-# Copy source and compile
-COPY frontend/css ./css
-RUN ./node_modules/.bin/lightningcss --bundle --minify --targets '>= 0.5%' \
-    css/index-admin.css -o /build/kotauth-admin.css
-RUN ./node_modules/.bin/lightningcss --bundle --minify --targets '>= 0.5%' \
-    css/index-auth.css  -o /build/kotauth-auth.css
+The build compiles the CSS bundles in a Node stage, copies the output into the Kotlin stage,
+and runs Gradle with the CSS tasks excluded — so the runtime image carries no Node.js, no npm
+and no LightningCSS.
 
-# Stage 2: Kotlin build (CSS already compiled — skip all three CSS tasks)
-FROM gradle:8-jdk17 AS kotlin-build
-WORKDIR /home/gradle/src
-COPY --chown=gradle:gradle . .
-COPY --from=css-build /build/kotauth-admin.css src/main/resources/static/kotauth-admin.css
-COPY --from=css-build /build/kotauth-auth.css  src/main/resources/static/kotauth-auth.css
-RUN gradle buildFatJar -x installCssDeps -x compileCssAdmin -x compileCssAuth --no-daemon
+The authoritative version is the [`Dockerfile`](../Dockerfile) at the repository root. It is not
+reproduced here: a second copy drifts from the first, and this document previously described a
+`gradle:8-jdk17` build stage and an 85 MB runtime that had not been accurate for several releases.
 
-# Stage 3: Runtime — no Node.js, no npm, no LightningCSS
-FROM eclipse-temurin:17-jre
-COPY --from=kotlin-build /home/gradle/src/build/libs/*.jar /app/kauth.jar
-EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/kauth.jar"]
-```
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -280,6 +280,12 @@ Recorded here because a roadmap that only lists future features overstates the p
 
 **Cross-namespace collision prevention is a read-before-write.** Two concurrent creates with mirrored identifiers can both pass the check, because no database constraint spans the username and email namespaces. The runtime refusal bounds the consequence to two users seeing a generic failure until an administrator intervenes.
 
+**The runtime image is large.** Roughly 410 MB, of which the great majority is the
+`eclipse-temurin` JRE base. Swagger UI is bundled into the JAR (~1.6 MB of assets served from
+`/static/swagger/`) rather than loaded from a CDN, and the logstash encoder pulls in a Jackson
+runtime that nothing else uses. A slim-image pass — a jlink-derived runtime, unbundled Swagger,
+and a kotlinx.serialization log encoder — is scoped but unscheduled.
+
 **No verification against live identity products is claimed.** SCIM targets RFC 7644/7643 and brokering targets OpenID Connect Core and Discovery. Neither has been certified against, nor verified end-to-end with, any particular vendor.
 
 ---
@@ -416,6 +422,5 @@ These are real, load-bearing choices that shape the codebase but were never writ
 | Social-registered users get an unusable password hash | The account exists; password sign-in stays disabled until the user sets one |
 | API keys hashed with SHA-256, not bcrypt | 256-bit key entropy makes brute force infeasible; avoids bcrypt latency on every API call |
 | API key prefix stored for display | Human-friendly identification without exposing the credential |
-| Swagger UI loaded from a CDN | Saves roughly 7 MB from the fat JAR |
 
 A fifteenth entry — *user lookup by `(tenant_id, username)`, no global username namespace* — was **superseded in v1.24.0**. The workspace-scoped namespace still holds, but lookup is now by the workspace's configured identifier (username, email, or either), and usernames are normalized and uniquely enforced case-insensitively.


### PR DESCRIPTION
## What does this PR do?

Corrects factual errors in the docs, and removes the pattern that produced most of them.

### Corrections

- **`docs/ROADMAP.md` claimed Swagger UI is loaded from a CDN.** It is bundled — 1.6 MB in `src/main/resources/static/swagger/`, served from `/static/swagger/` (`ApiRoutes.kt:232,244-246`). The claim came from the pre-rewrite ADR table and was carried forward without being checked. Removed.
- **`README.md` claimed the runtime image is ~120 MB.** It is ~410 MB (`docker images`: 414 MB for `latest`, 413 MB for `1.22`), almost all of it the JRE base.
- **`docs/FRONTEND_CSS.md` claimed the runtime stage is `eclipse-temurin:17-jre` at ~85 MB.** It is `eclipse-temurin:25-jre`. The same file carried a copied Dockerfile that had drifted to a `gradle:8-jdk17` build stage and two CSS bundles where the build produces four.
- **`CLAUDE.md` said the domain has ~27 ports.** There are 43.

The real image size and its causes — JRE base, bundled Swagger, a logstash encoder pulling in an otherwise-unused Jackson runtime — are now recorded under Known Gaps in the roadmap rather than left as a surprise.

### Removing the pattern

Two changes stop this recurring rather than resetting the clock:

- **The copied Dockerfile in `docs/FRONTEND_CSS.md` is replaced with a pointer to the real one.** A second copy of a build file drifts from the first; this one had been wrong for several releases.
- **Library versions are no longer duplicated in prose.** `README.md` and `CLAUDE.md` listed exact Ktor, Exposed and Gradle versions. Those were corrected two days ago and were stale again within 48 hours, because the Dependabot merges landed after — the build is on Ktor 3.5.2 and Exposed 1.5.0, the prose said 3.5.1 and 1.3.1. Both now name the stack and point at `build.gradle.kts`, where the versions are declared and pinned in `gradle.lockfile`.

Every remaining entry in the roadmap's *Decisions without an ADR* table was verified against the code in this pass, not just the one that was wrong. Thirteen of fourteen were accurate.

## Type of change

- [x] Documentation

## How was this tested?

- [ ] Added / updated unit tests
- [ ] Added / updated integration tests
- [x] Tested manually — describe steps below

Documentation only; no code paths touched. `make lint` clean. Each corrected claim was checked against the source it describes: the Swagger assets and the route that serves them, `docker images` output, the `FROM` lines in `Dockerfile`, and a count of `domain/port/*.kt`.

## Checklist

- [x] `make test` passes locally (unchanged — no code in this PR)
- [x] `make lint` passes
- [ ] New domain logic has no framework imports — n/a
- [ ] New database changes include a Flyway migration — n/a
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a
- [x] Security-sensitive changes are noted in the description — none

