### PR TITLE
Grant scopes per client instead of inheriting every scope the API declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.25.0] - 2026-09-08
+
+### Security
+
+- **Authorizing a client against an API no longer grants it every scope that API declares.** A
+  client's scopes are now an explicit per-client grant, stored per (client, API) pair and enforced
+  as a three-way intersection at token issuance: what was requested, what the API declares, and
+  what this client was granted. Applies to the authorization-code, refresh-token and
+  client-credentials grants, and to the email-OTP back-channel path.
+
+  Previously, separate client credentials bought independent revocation and a real `sub` in the
+  audit trail — but not least privilege. A client created for one capability could request every
+  scope its API offered. See [ADR-23](docs/adr/ADR-23-per-client-scope-allowlists.md).
+
+  An absent grant means the client may request **nothing** on that API, never everything. On the
+  refresh path a soft-deleted application, which no longer resolves to a client, now yields no
+  scopes rather than falling back to the API's full declared set.
+
+### Added
+
+- **Per-scope checkboxes on the authorized-APIs page.** Each authorized API lists its declared
+  scopes, so which scopes a client holds is visible and editable where the authorization is made.
+- `client_authorized_scopes` is exposed through the resource-server service for the admin API.
+
+### Changed
+
+- **Adding a new scope to an API does not grant it to existing clients.** Deliberate: silent
+  propagation is how the previous behaviour would return. Grant it explicitly per client.
+- A scope that the API does not declare is refused rather than stored, so a client's allowlist
+  cannot drift from the API it constrains.
+
+### Migrations
+
+- `V67__client_authorized_scopes.sql` — creates the table and **backfills every existing
+  authorization with one row per scope its API currently declares**, reproducing today's behaviour
+  exactly. No client gains or loses a scope on upgrade. Narrowing begins only when an operator
+  edits a client's scopes or authorizes a new API. A newly authorized API arrives with all of its
+  scopes checked.
+
+---
+
 ## [1.24.1] - 2026-09-07
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.24.1"
+version = "1.25.0"
 
 // Pin the compile target explicitly rather than letting it follow whichever JDK
 // happens to build. `release`/`-Xjdk-release` also stop a newer build JDK from

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -274,7 +274,8 @@ In protocol terms Kotauth is a compliant OAuth 2.0 / OIDC authorization server w
 
 Recorded here because a roadmap that only lists future features overstates the present.
 
-**Scopes do not isolate clients from one another.** Authorizing a client against an API grants it every scope that API declares. There is no per-client scope allowlist, and `narrowScopes` filters against what the *resource server* declares rather than what the *client* is permitted. Measured on a live integration: a client created for a single ingest scope successfully minted a token carrying two others and read an admin endpoint across tenants. Separate credentials still buy independent revocation and a real `sub` in the audit trail — they do not buy least privilege, which is what the admin console implies they buy. Until the anticipated `allowedScopes` field exists, the only real isolation boundary is one resource server per privilege level. **This is the highest-priority open item.**
+**Scopes now isolate clients from one another** as of v1.25.0 — a client's scopes are an
+explicit per-client grant rather than everything its API declares. See ADR-23.
 
 **Identity provider configuration is partially excluded from backups.** A backup export does not carry most identity-provider configuration, so a restore does not reproduce a workspace's brokered sign-in setup.
 
@@ -402,6 +403,7 @@ Recorded ADRs live in [`docs/adr/`](adr/). This table is generated from those fi
 | [ADR-20](adr/ADR-20-scim-dialects-selected-per-key.md) | A SCIM dialect is selected per API key, never sniffed from the request |
 | [ADR-21](adr/ADR-21-just-in-time-provisioning.md) | Just-in-time provisioning only creates; linking happens before the gate |
 | [ADR-22](adr/ADR-22-rfc8252-loopback-redirect-matching.md) | Loopback redirect URIs match on any port, for public clients only |
+| [ADR-23](adr/ADR-23-per-client-scope-allowlists.md) | A client's scopes are granted per client, not inherited from the API |
 
 ### Decisions without an ADR
 

--- a/docs/adr/ADR-23-per-client-scope-allowlists.md
+++ b/docs/adr/ADR-23-per-client-scope-allowlists.md
@@ -1,0 +1,105 @@
+# ADR-23 — A client's scopes are granted per client, not inherited from the API
+
+**Status:** Accepted — v1.25.0
+**Context:** RFC 6749 §3.3, RFC 8707, RFC 9068 §5
+
+## Context
+
+Authorizing a client against a resource server granted it **every scope that resource server
+declared**. `OAuthService.narrowScopes` intersected the request against
+`resolvedResources.flatMap { it.scopes }` — what the API offers — with nothing client-specific in
+the intersection. No per-client scope allowlist existed anywhere in the model, and the codebase
+knew it: `EmailOtpService` carried `TODO(v1.13): derive from client.allowedScopes once that field
+exists`, open since v1.13.
+
+This was measured on a live integration, not inferred. A client created and authorized with the
+sole intent of ingesting documents:
+
+```
+client_id: help-center-ingesta      (created for: assistant:ingest, nothing else)
+
+token request, scope="assistant:ingest assistant:keys assistant:handoff"
+  -> granted, all three
+
+GET /admin/stats with that token
+  -> HTTP 200   (read the question log of every tenant of that service)
+```
+
+The consuming service was doing everything right — one scope per capability, enforced per route.
+That separation is real for a **token** and was meaningless for a **client**: any authorized
+client could mint whatever token it wanted.
+
+Separate credentials still bought independent revocation and a real `sub` in the audit trail.
+They did not buy least privilege, which is what an operator reading the admin console would
+reasonably assume they bought.
+
+## Decision
+
+A client's scopes on a resource server are an explicit grant, stored per (client, resource
+server) pair.
+
+### Storage
+
+`client_authorized_scopes(client_id, resource_server_id, scope)` — V67. A side table, matching
+V51's `client_authorized_resources` and V59's `client_grant_types`, rather than a column on
+`clients` or a JSONB blob. The composite foreign key targets `client_authorized_resources`, so a
+scope grant cannot outlive the authorization it qualifies and un-authorizing an API removes its
+scope rows by cascade.
+
+### Enforcement
+
+`narrowScopes` becomes a three-way intersection: **requested ∩ declared-by-resource ∩
+granted-to-client**. All three grant types funnel through that one function, so authorization
+code, refresh and client credentials are covered by a single change.
+
+`EmailOtpService` assigns scopes on its back-channel path outside `narrowScopes` and applies the
+same lookup separately.
+
+**`clientAllowedScopes` is a required parameter, not a defaulted one.** A default would let a new
+call site silently reproduce the original bug. An absent or empty entry means the client may
+request **nothing** on that resource — never everything. Treating absence as unrestricted is
+exactly the behaviour being removed.
+
+On the refresh path the client may be null, because a soft-deleted application no longer resolves.
+That case now yields no grants and therefore no scopes, rather than falling back to the resource
+server's full declared set.
+
+### Migration default
+
+V67 backfills one row per scope each resource server currently declares, for every existing
+authorization. That reproduces today's behaviour exactly: no client gains a scope it could not
+already request, and none loses one. Narrowing begins only when an operator edits a client's
+scopes or authorizes a new API.
+
+A newly authorized API arrives with all of its declared scopes checked — the same default, applied
+to new pairs. Re-saving an unchanged authorization preserves whatever the operator had chosen.
+
+A scope the resource server does not declare is refused rather than stored, so the allowlist
+cannot drift from the API it constrains. A grant row for a scope the API later stops declaring
+becomes inert, because the intersection still requires the resource server to declare it.
+
+## Consequences
+
+Operators get least privilege between clients. The admin console's authorized-APIs page now shows
+each API's scopes as checkboxes under it, so the grant is visible where the authorization is made
+— previously nothing in the UI indicated that authorizing an API granted all of its scopes.
+
+Adding a new scope to an API does **not** grant it to existing clients. That is deliberate: silent
+propagation is how the original problem would return. The operator grants it explicitly.
+
+This unblocks the OAuth consent screen, which could not honestly be built on the previous model —
+it would have told a user "this application wants access to X" as a per-client claim the platform
+could not enforce.
+
+## Alternatives considered
+
+**A column on `clients`.** Simpler to read, but the grant is per (client, resource server), so a
+single column would either denormalise or lose the pairing.
+
+**Treat an empty grant set as unrestricted.** Convenient for migration, and precisely the
+ambiguity that produced the original bug. A `NOT NULL DEFAULT` mistake would reintroduce it
+silently.
+
+**Enforce at the resource server instead.** Moves the problem to every consuming service and makes
+the guarantee unverifiable from Kotauth. The authorization server issues the token; it is the
+place that can constrain it.

--- a/src/main/kotlin/com/kauth/adapter/persistence/PostgresResourceServerRepository.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/PostgresResourceServerRepository.kt
@@ -174,6 +174,21 @@ class PostgresResourceServerRepository : ResourceServerRepository {
                 }
             }
 
+            val previousScopes =
+                ClientAuthorizedScopesTable
+                    .selectAll()
+                    .where { ClientAuthorizedScopesTable.clientId eq clientPk.value }
+                    .groupBy { it[ClientAuthorizedScopesTable.resourceServerId] }
+                    .mapValues { (_, rows) -> rows.map { it[ClientAuthorizedScopesTable.scope] } }
+
+            val previouslyAuthorized =
+                ClientAuthorizedResourcesTable
+                    .selectAll()
+                    .where { ClientAuthorizedResourcesTable.clientId eq clientPk.value }
+                    .map { it[ClientAuthorizedResourcesTable.resourceServerId] }
+                    .toSet()
+
+            // Deleting the authorization rows cascades their scope rows away (V67).
             ClientAuthorizedResourcesTable.deleteWhere {
                 ClientAuthorizedResourcesTable.clientId eq clientPk.value
             }
@@ -181,6 +196,34 @@ class PostgresResourceServerRepository : ResourceServerRepository {
                 ClientAuthorizedResourcesTable.batchInsert(resourceServerIds) { rsId ->
                     this[ClientAuthorizedResourcesTable.clientId] = clientPk.value
                     this[ClientAuthorizedResourcesTable.resourceServerId] = rsId.value
+                }
+            }
+
+            // A newly authorized resource starts with every scope it declares — the same default
+            // the V67 backfill applied to existing pairs, and what the admin form shows checked.
+            // An operator narrows from there; we never silently grant less than they last chose,
+            // and re-saving an unchanged authorization must not reset their choices.
+            for (rsId in resourceServerIds) {
+                val declared =
+                    ResourceServersTable
+                        .selectAll()
+                        .where { ResourceServersTable.id eq rsId.value }
+                        .singleOrNull()
+                        ?.let { Json.decodeFromString<List<String>>(it[ResourceServersTable.scopes].ifBlank { "[]" }) }
+                        ?: emptyList()
+                val seed =
+                    if (rsId.value in previouslyAuthorized) {
+                        // Preserve what the operator had chosen before this save.
+                        previousScopes[rsId.value] ?: declared
+                    } else {
+                        declared
+                    }
+                for (sc in seed) {
+                    ClientAuthorizedScopesTable.insert {
+                        it[clientId] = clientPk.value
+                        it[resourceServerId] = rsId.value
+                        it[scope] = sc
+                    }
                 }
             }
             null
@@ -197,4 +240,61 @@ class PostgresResourceServerRepository : ResourceServerRepository {
             scopes = Json.decodeFromString(this[ResourceServersTable.scopes].ifBlank { "[]" }),
             createdAt = this[ResourceServersTable.createdAt].toInstant(),
         )
+
+    override fun findAllowedScopes(clientPk: ApplicationId): Map<ResourceServerId, Set<String>> =
+        transaction {
+            ClientAuthorizedScopesTable
+                .selectAll()
+                .where { ClientAuthorizedScopesTable.clientId eq clientPk.value }
+                .groupBy { ResourceServerId(it[ClientAuthorizedScopesTable.resourceServerId]) }
+                .mapValues { (_, rows) -> rows.map { it[ClientAuthorizedScopesTable.scope] }.toSet() }
+        }
+
+    override fun setAllowedScopes(
+        clientPk: ApplicationId,
+        resourceServerId: ResourceServerId,
+        scopes: Set<String>,
+    ): ResourceAuthorizationError? =
+        transaction {
+            val authorized =
+                ClientAuthorizedResourcesTable
+                    .selectAll()
+                    .where {
+                        (ClientAuthorizedResourcesTable.clientId eq clientPk.value) and
+                            (ClientAuthorizedResourcesTable.resourceServerId eq resourceServerId.value)
+                    }.any()
+            if (!authorized) return@transaction ResourceAuthorizationError.NotAuthorizedForResource(resourceServerId)
+
+            val declared =
+                ResourceServersTable
+                    .selectAll()
+                    .where { ResourceServersTable.id eq resourceServerId.value }
+                    .singleOrNull()
+                    ?.let {
+                        Json.decodeFromString<List<String>>(
+                            it[ResourceServersTable.scopes].ifBlank { "[]" },
+                        )
+                    }?.toSet()
+                    ?: return@transaction ResourceAuthorizationError.UnknownResource(resourceServerId)
+
+            // Refuse rather than silently store a scope the resource server does not offer —
+            // otherwise the allowlist drifts from the API it is meant to constrain.
+            val undeclared = scopes - declared
+            if (undeclared.isNotEmpty()) {
+                return@transaction ResourceAuthorizationError.UndeclaredScope(resourceServerId, undeclared)
+            }
+
+            ClientAuthorizedScopesTable.deleteWhere {
+                (ClientAuthorizedScopesTable.clientId eq clientPk.value) and
+                    (ClientAuthorizedScopesTable.resourceServerId eq resourceServerId.value)
+            }
+            for (sc in scopes) {
+                ClientAuthorizedScopesTable.insert {
+                    it[clientId] = clientPk.value
+                    it[ClientAuthorizedScopesTable.resourceServerId] = resourceServerId.value
+                    it[scope] = sc
+                }
+            }
+            null
+        }
 }

--- a/src/main/kotlin/com/kauth/adapter/persistence/ResourceServersTable.kt
+++ b/src/main/kotlin/com/kauth/adapter/persistence/ResourceServersTable.kt
@@ -23,3 +23,16 @@ object ClientAuthorizedResourcesTable : Table("client_authorized_resources") {
 
     override val primaryKey = PrimaryKey(clientId, resourceServerId)
 }
+
+/**
+ * Which of a resource server's declared scopes a given client may request.
+ * Composite FK to [ClientAuthorizedResourcesTable] — a scope grant cannot outlive the
+ * authorization it qualifies. See V67 and ADR-23.
+ */
+object ClientAuthorizedScopesTable : Table("client_authorized_scopes") {
+    val clientId = integer("client_id")
+    val resourceServerId = integer("resource_server_id")
+    val scope = varchar("scope", 255)
+
+    override val primaryKey = PrimaryKey(clientId, resourceServerId, scope)
+}

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminApplicationRoutes.kt
@@ -343,6 +343,10 @@ fun Route.adminApplicationRoutes(
                             allApps = allApps,
                             allResources = all,
                             authorizedIds = authorizedIds,
+                            allowedScopes =
+                                resourceServerService
+                                    .allowedScopesFor(app.id)
+                                    .mapKeys { (k, _) -> k.value },
                             toastMessage = toast,
                         ),
                     )
@@ -370,10 +374,31 @@ fun Route.adminApplicationRoutes(
                                     .ResourceServerId(it)
                             }
                     when (val result = resourceServerService.setAuthorized(app.id, selectedIds)) {
-                        is com.kauth.domain.service.ResourceServerResult.Success ->
-                            call.respondRedirect(
-                                "/admin/workspaces/$slug/applications/$clientId/authorized-apis?saved=ok",
-                            )
+                        is com.kauth.domain.service.ResourceServerResult.Success -> {
+                            // Authorizing an API seeds every scope it declares; the operator's
+                            // per-scope choices are applied on top. Only for APIs that are actually
+                            // authorized — a stale `scope:` field for an unchecked API is ignored
+                            // rather than resurrecting a grant.
+                            var scopeError: String? = null
+                            for (rsId in selectedIds) {
+                                val chosen = params.getAll("scope:${rsId.value}").orEmpty().toSet()
+                                when (val r = resourceServerService.setAllowedScopes(app.id, rsId, chosen)) {
+                                    is com.kauth.domain.service.ResourceServerResult.Success -> Unit
+                                    is com.kauth.domain.service.ResourceServerResult.Failure -> {
+                                        scopeError = r.error.toString()
+                                    }
+                                }
+                            }
+                            if (scopeError != null) {
+                                call.respondRedirect(
+                                    "/admin/workspaces/$slug/applications/$clientId/authorized-apis?saved=err",
+                                )
+                            } else {
+                                call.respondRedirect(
+                                    "/admin/workspaces/$slug/applications/$clientId/authorized-apis?saved=ok",
+                                )
+                            }
+                        }
                         is com.kauth.domain.service.ResourceServerResult.Failure -> {
                             val all = resourceServerService.list(workspace.id)
                             val allApps = applicationRepository.findByTenantId(workspace.id)

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutes.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminResourceServerRoutes.kt
@@ -187,4 +187,6 @@ private fun errorMessage(error: ResourceServerError): String =
         ResourceServerError.IdentifierAlreadyExists -> "An API with that audience identifier already exists."
         ResourceServerError.NotFound -> "API not found."
         ResourceServerError.CrossTenant -> "Cross-tenant authorization is not allowed."
+        is ResourceServerError.UndeclaredScope ->
+            "This API does not declare: ${error.scopes.sorted().joinToString(", ")}."
     }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminView.kt
@@ -584,6 +584,7 @@ object AdminView {
         allApps: List<com.kauth.domain.model.Application>,
         allResources: List<com.kauth.domain.model.ResourceServer>,
         authorizedIds: Set<Int>,
+        allowedScopes: Map<Int, Set<String>> = emptyMap(),
         error: String? = null,
         toastMessage: String? = null,
     ): HTML.() -> Unit =
@@ -595,6 +596,7 @@ object AdminView {
             allApps,
             allResources,
             authorizedIds,
+            allowedScopes,
             error,
             toastMessage,
         )

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
@@ -126,6 +126,8 @@ internal fun clientAuthorizedApisPageImpl(
     allApps: List<com.kauth.domain.model.Application>,
     allResources: List<ResourceServer>,
     authorizedIds: Set<Int>,
+    /** Per resource-server id, the scopes this client may request. See ADR-23. */
+    allowedScopes: Map<Int, Set<String>> = emptyMap(),
     error: String? = null,
     toastMessage: String? = null,
 ): HTML.() -> Unit =
@@ -237,6 +239,35 @@ internal fun clientAuthorizedApisPageImpl(
                                         span("badge badge--id") { +rs.identifier }
                                         if (!rs.enabled) {
                                             span("badge badge--inactive") { +"Disabled" }
+                                        }
+                                    }
+                                    // Authorizing a client against an API no longer grants every
+                                    // scope that API declares — the operator chooses which. A newly
+                                    // authorized API arrives with all of them checked, matching what
+                                    // this client could already request before the change.
+                                    if (rs.scopes.isNotEmpty()) {
+                                        val granted = allowedScopes[rsId] ?: rs.scopes.toSet()
+                                        div("chip-grid") {
+                                            rs.scopes.sorted().forEach { sc ->
+                                                label(
+                                                    "scope-chip" +
+                                                        if (!rs.enabled) " scope-chip--disabled" else "",
+                                                ) {
+                                                    input(
+                                                        type = InputType.checkBox,
+                                                        name = "scope:$rsId",
+                                                    ) {
+                                                        value = sc
+                                                        if (sc in granted) {
+                                                            attributes["checked"] = "checked"
+                                                        }
+                                                        if (!rs.enabled) {
+                                                            attributes["disabled"] = "disabled"
+                                                        }
+                                                    }
+                                                    span("scope-chip__label") { +sc }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/api/ApiHelpers.kt
@@ -186,6 +186,12 @@ internal suspend fun ApplicationCall.respondResourceServerError(error: ResourceS
             )
         ResourceServerError.NotFound ->
             respondProblem(HttpStatusCode.NotFound, "Not Found", "Resource server not found.")
+        is ResourceServerError.UndeclaredScope ->
+            respondProblem(
+                HttpStatusCode.UnprocessableEntity,
+                "Validation Error",
+                "Not declared by this resource server: ${error.scopes.sorted().joinToString(", ")}.",
+            )
         ResourceServerError.CrossTenant ->
             respondProblem(
                 HttpStatusCode.UnprocessableEntity,

--- a/src/main/kotlin/com/kauth/domain/port/ResourceServerRepository.kt
+++ b/src/main/kotlin/com/kauth/domain/port/ResourceServerRepository.kt
@@ -56,6 +56,26 @@ interface ResourceServerRepository {
         clientPk: ApplicationId,
         resourceServerIds: List<ResourceServerId>,
     ): ResourceAuthorizationError?
+
+    /**
+     * The scopes this client may actually request, per resource server it is authorized for.
+     *
+     * A resource server declares what it offers; this says which of those a given client was
+     * granted. An absent or empty entry means the client may request nothing on that resource —
+     * never "everything". Treating absence as unrestricted is what made authorizing a client
+     * against an API grant it every scope that API declared.
+     */
+    fun findAllowedScopes(clientPk: ApplicationId): Map<ResourceServerId, Set<String>>
+
+    /**
+     * Replaces the client's allowed scopes for one resource server it is already authorized for.
+     * Scopes not declared by that resource server are rejected rather than silently stored.
+     */
+    fun setAllowedScopes(
+        clientPk: ApplicationId,
+        resourceServerId: ResourceServerId,
+        scopes: Set<String>,
+    ): ResourceAuthorizationError?
 }
 
 sealed class ResourceAuthorizationError {
@@ -64,6 +84,17 @@ sealed class ResourceAuthorizationError {
     object UnknownClient : ResourceAuthorizationError()
 
     data class UnknownResource(
+        val id: ResourceServerId,
+    ) : ResourceAuthorizationError()
+
+    /** A scope was granted to a client that the resource server does not declare. */
+    data class UndeclaredScope(
+        val id: ResourceServerId,
+        val scopes: Set<String>,
+    ) : ResourceAuthorizationError()
+
+    /** The client is not authorized for the resource server at all, so it has no scopes there. */
+    data class NotAuthorizedForResource(
         val id: ResourceServerId,
     ) : ResourceAuthorizationError()
 }

--- a/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/OAuthService.kt
@@ -8,6 +8,7 @@ import com.kauth.domain.model.AuthorizationCode
 import com.kauth.domain.model.ClaimTokenType
 import com.kauth.domain.model.GrantType
 import com.kauth.domain.model.ResourceServer
+import com.kauth.domain.model.ResourceServerId
 import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantClaimMapper
@@ -366,8 +367,9 @@ class OAuthService(
             }
 
         val requestedScopes = authCode.scopes.split(" ").filter { it.isNotBlank() }
+        val clientAllowedScopes = resourceServerRepository?.findAllowedScopes(client.id) ?: emptyMap()
         val finalScopes =
-            when (val narrowing = narrowScopes(requestedScopes, resolvedResourceServers)) {
+            when (val narrowing = narrowScopes(requestedScopes, resolvedResourceServers, clientAllowedScopes)) {
                 is ScopeNarrowing.Ok -> narrowing.narrowed
                 is ScopeNarrowing.InvalidScope -> return OAuthResult.Failure(
                     OAuthError.InvalidScope(narrowing.rejected),
@@ -498,7 +500,14 @@ class OAuthService(
                     } else {
                         emptyList()
                     }
-                when (val narrowing = narrowScopes(requestedScopes, resolvedServers)) {
+                when (
+                    val narrowing =
+                        narrowScopes(
+                            requestedScopes,
+                            resolvedServers,
+                            resourceServerRepository?.findAllowedScopes(client.id) ?: emptyMap(),
+                        )
+                ) {
                     is ScopeNarrowing.Ok -> narrowing.narrowed
                     is ScopeNarrowing.InvalidScope -> return OAuthResult.Failure(
                         OAuthError.InvalidScope(narrowing.rejected),
@@ -572,16 +581,39 @@ class OAuthService(
         ) : ScopeNarrowing()
     }
 
+    /**
+     * Narrows a scope request to what the token may actually carry.
+     *
+     * Three-way intersection: what was **requested**, what the targeted resource servers
+     * **declare**, and what this **client** was granted on each of them.
+     *
+     * [clientAllowedScopes] is required rather than defaulted on purpose. Before v1.25.0 the
+     * intersection stopped at what the resource server declared, so authorizing a client
+     * against an API granted it every scope that API offered — separate credentials bought
+     * independent revocation and audit attribution, but not least privilege. A default value
+     * here would let a new call site silently reproduce that, so every caller must state what
+     * the client is allowed. An absent entry means "nothing on that resource", never
+     * "everything".
+     */
     fun narrowScopes(
         requested: List<String>,
         resolvedResources: List<ResourceServer>,
+        clientAllowedScopes: Map<ResourceServerId, Set<String>>,
     ): ScopeNarrowing {
         if (requested.isEmpty()) return ScopeNarrowing.Ok(emptyList())
 
+        // A resource server that declares no scopes narrows nothing — pre-existing behaviour
+        // for deployments that predate the scopes column (v1.18.0). Unchanged here.
         val anyDeclares = resolvedResources.any { it.scopes.isNotEmpty() }
         if (!anyDeclares) return ScopeNarrowing.Ok(requested)
 
-        val allowed = resolvedResources.flatMap { it.scopes }.toSet()
+        val allowed =
+            resolvedResources
+                .flatMap { rs ->
+                    val declared = rs.scopes.toSet()
+                    val grantedToClient = rs.id?.let { clientAllowedScopes[it] } ?: emptySet()
+                    declared intersect grantedToClient
+                }.toSet()
         val rejected = requested.filterNot { it in allowed }
         return if (rejected.isEmpty()) {
             ScopeNarrowing.Ok(requested)
@@ -736,7 +768,18 @@ class OAuthService(
             if (resourcesNarrowed) {
                 val anyDeclares = resolvedResourceServers.any { it.scopes.isNotEmpty() }
                 if (anyDeclares) {
-                    val allowed = resolvedResourceServers.flatMap { it.scopes }.toSet()
+                    // Same three-way intersection as narrowScopes: declared ∩ granted-to-client.
+                    // `client` is null when the application was soft-deleted after the token was
+                    // issued. No client identity means no per-client grants to intersect against, so
+                    // narrowing removes every scope — fail closed rather than fall back to the
+                    // resource server's full declared set.
+                    val granted =
+                        client?.let { resourceServerRepository?.findAllowedScopes(it.id) } ?: emptyMap()
+                    val allowed =
+                        resolvedResourceServers
+                            .flatMap { rs ->
+                                rs.scopes.toSet() intersect (rs.id?.let { granted[it] } ?: emptySet())
+                            }.toSet()
                     sessionScopes.filter { it in allowed }
                 } else {
                     sessionScopes
@@ -745,7 +788,14 @@ class OAuthService(
                 sessionScopes
             }
         val finalScopes =
-            when (val narrowing = narrowScopes(effectiveScopes, resolvedResourceServers)) {
+            when (
+                val narrowing =
+                    narrowScopes(
+                        effectiveScopes,
+                        resolvedResourceServers,
+                        client?.let { resourceServerRepository?.findAllowedScopes(it.id) } ?: emptyMap(),
+                    )
+            ) {
                 is ScopeNarrowing.Ok -> narrowing.narrowed
                 is ScopeNarrowing.InvalidScope -> return OAuthResult.Failure(
                     OAuthError.InvalidScope(narrowing.rejected),

--- a/src/main/kotlin/com/kauth/domain/service/ResourceServerService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/ResourceServerService.kt
@@ -84,9 +84,23 @@ class ResourceServerService(
     fun setAuthorized(
         clientPk: ApplicationId,
         resourceServerIds: List<ResourceServerId>,
-    ): ResourceServerResult<Unit> {
-        val error = repo.setAuthorizedResources(clientPk, resourceServerIds)
-        return when (error) {
+    ): ResourceServerResult<Unit> = repo.setAuthorizedResources(clientPk, resourceServerIds).toResult()
+
+    /**
+     * Replaces the scopes a client may request on one resource server it is already authorized for.
+     * See ADR-23 — authorizing a client against an API does not grant every scope that API declares.
+     */
+    fun setAllowedScopes(
+        clientPk: ApplicationId,
+        resourceServerId: ResourceServerId,
+        scopes: Set<String>,
+    ): ResourceServerResult<Unit> = repo.setAllowedScopes(clientPk, resourceServerId, scopes).toResult()
+
+    /** The scopes a client may request, per resource server it is authorized for. */
+    fun allowedScopesFor(clientPk: ApplicationId): Map<ResourceServerId, Set<String>> = repo.findAllowedScopes(clientPk)
+
+    private fun ResourceAuthorizationError?.toResult(): ResourceServerResult<Unit> =
+        when (this) {
             null -> ResourceServerResult.Success(Unit)
             is ResourceAuthorizationError.CrossTenant ->
                 ResourceServerResult.Failure(ResourceServerError.CrossTenant)
@@ -94,8 +108,11 @@ class ResourceServerService(
                 ResourceServerResult.Failure(ResourceServerError.NotFound)
             is ResourceAuthorizationError.UnknownResource ->
                 ResourceServerResult.Failure(ResourceServerError.NotFound)
+            is ResourceAuthorizationError.NotAuthorizedForResource ->
+                ResourceServerResult.Failure(ResourceServerError.NotFound)
+            is ResourceAuthorizationError.UndeclaredScope ->
+                ResourceServerResult.Failure(ResourceServerError.UndeclaredScope(scopes))
         }
-    }
 }
 
 sealed class ResourceServerResult<out T> {
@@ -118,6 +135,11 @@ sealed class ResourceServerError {
     object IdentifierAlreadyExists : ResourceServerError()
 
     object NotFound : ResourceServerError()
+
+    /** Scopes were granted to a client that the resource server does not declare. */
+    data class UndeclaredScope(
+        val scopes: Set<String>,
+    ) : ResourceServerError()
 
     object CrossTenant : ResourceServerError()
 }

--- a/src/main/resources/db/migration/V67__client_authorized_scopes.sql
+++ b/src/main/resources/db/migration/V67__client_authorized_scopes.sql
@@ -1,0 +1,44 @@
+-- V67: Per-client scope allowlists (v1.25.0).
+--
+-- Until now, authorizing a client against a resource server granted it EVERY scope that
+-- resource server declares. `OAuthService.narrowScopes` intersected the request against
+-- `resource_servers.scopes` — what the API offers — with nothing client-specific in the
+-- intersection. A client created for one capability could mint a token carrying all of them.
+--
+-- This table is the missing half: which of a resource server's scopes a particular client
+-- may actually request. It hangs off `client_authorized_resources` rather than `clients`,
+-- because the grant is per (client, resource server) pair — the same shape as V51's
+-- authorization table and V59's grant types.
+
+CREATE TABLE client_authorized_scopes (
+    client_id          INTEGER      NOT NULL,
+    resource_server_id INTEGER      NOT NULL,
+    scope              VARCHAR(255) NOT NULL,
+    PRIMARY KEY (client_id, resource_server_id, scope),
+    -- Composite FK, not two separate ones: a scope grant cannot outlive the authorization
+    -- it qualifies, and un-authorizing a resource must take its scope rows with it.
+    CONSTRAINT fk_client_authorized_scopes_authorization
+        FOREIGN KEY (client_id, resource_server_id)
+        REFERENCES client_authorized_resources (client_id, resource_server_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_client_authorized_scopes_client ON client_authorized_scopes (client_id);
+
+-- Backfill reproduces today's behaviour exactly: every existing authorization gets one row
+-- per scope its resource server currently declares. No client gains a scope it could not
+-- already request, and none loses one. Narrowing only begins when an operator edits a
+-- client's scopes, or authorizes a new resource.
+--
+-- `jsonb_array_elements_text` expands `resource_servers.scopes` (added as JSONB in V53).
+-- The `jsonb_typeof` guard skips any row whose column is not an array, so a malformed
+-- value cannot abort the upgrade.
+INSERT INTO client_authorized_scopes (client_id, resource_server_id, scope)
+SELECT car.client_id,
+       car.resource_server_id,
+       scope_value
+FROM client_authorized_resources car
+JOIN resource_servers rs ON rs.id = car.resource_server_id
+CROSS JOIN LATERAL jsonb_array_elements_text(rs.scopes) AS scope_value
+WHERE jsonb_typeof(rs.scopes) = 'array'
+ON CONFLICT DO NOTHING;

--- a/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/auth/AuthRoutesTest.kt
@@ -1607,13 +1607,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
                     name = "API",
                     scopes = listOf("read:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -1670,21 +1672,25 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api-a.example.com",
                     name = "A",
                     scopes = listOf("read:a"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api-b.example.com",
                     name = "B",
                     scopes = listOf("read:b"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -1742,13 +1748,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
                     name = "API",
                     scopes = listOf("read:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -1808,13 +1816,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
                     name = "API",
                     scopes = listOf("read:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -1872,13 +1882,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
                     name = "API",
                     scopes = listOf("read:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -1946,13 +1958,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
                     name = "API",
                     scopes = listOf("read:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -2025,21 +2039,25 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api-a.example.com",
                     name = "A",
                     scopes = listOf("read:a"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api-b.example.com",
                     name = "B",
                     scopes = listOf("read:b"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -2115,13 +2133,15 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api-a.example.com",
                     name = "A",
                     scopes = listOf("read:a"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
             val oauthSvc = buildOAuthServiceWithResources(rsRepo)
 
@@ -2492,7 +2512,7 @@ class AuthRoutesTest {
         testApplication {
             resetFixtures()
             val rsRepo = FakeResourceServerRepository()
-            rsRepo.seed(
+            rsRepo.seedAuthorized(
                 ResourceServer(
                     tenantId = TenantId(1),
                     identifier = "https://api.example.com",
@@ -2500,6 +2520,8 @@ class AuthRoutesTest {
                     enabled = true,
                     scopes = listOf("read:invoices", "write:invoices"),
                 ),
+                ApplicationId(1),
+                TenantId(1),
             )
 
             application {

--- a/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/OAuthServiceTest.kt
@@ -8,6 +8,7 @@ import com.kauth.domain.model.AuditEventType
 import com.kauth.domain.model.AuthorizationCode
 import com.kauth.domain.model.GrantType
 import com.kauth.domain.model.ResourceServer
+import com.kauth.domain.model.ResourceServerId
 import com.kauth.domain.model.Session
 import com.kauth.domain.model.Tenant
 import com.kauth.domain.model.TenantId
@@ -1562,7 +1563,7 @@ class OAuthServiceTest {
     @Test
     fun `narrowScopes accepts all requested when API declares them`() {
         val api = resourceServerOf(scopes = listOf("read:invoices", "write:invoices"))
-        val result = svc.narrowScopes(listOf("read:invoices"), listOf(api))
+        val result = svc.narrowScopes(listOf("read:invoices"), listOf(api), grantingAll(api))
         assertEquals(
             OAuthService.ScopeNarrowing.Ok(listOf("read:invoices")),
             result,
@@ -1572,7 +1573,7 @@ class OAuthServiceTest {
     @Test
     fun `narrowScopes rejects requested scope not declared by any targeted API (strict mode)`() {
         val api = resourceServerOf(scopes = listOf("read:invoices"))
-        val result = svc.narrowScopes(listOf("read:invoices", "delete:invoices"), listOf(api))
+        val result = svc.narrowScopes(listOf("read:invoices", "delete:invoices"), listOf(api), grantingAll(api))
         assertEquals(
             OAuthService.ScopeNarrowing.InvalidScope(listOf("delete:invoices")),
             result,
@@ -1582,7 +1583,7 @@ class OAuthServiceTest {
     @Test
     fun `narrowScopes treats empty API scopes as no narrowing — returns requested as-is`() {
         val api = resourceServerOf(scopes = emptyList())
-        val result = svc.narrowScopes(listOf("anything:goes"), listOf(api))
+        val result = svc.narrowScopes(listOf("anything:goes"), listOf(api), grantingAll(api))
         assertEquals(
             OAuthService.ScopeNarrowing.Ok(listOf("anything:goes")),
             result,
@@ -1593,10 +1594,73 @@ class OAuthServiceTest {
     fun `narrowScopes unions scopes across multiple targeted APIs`() {
         val a = resourceServerOf(identifier = "https://a", scopes = listOf("read:a"))
         val b = resourceServerOf(identifier = "https://b", scopes = listOf("read:b"))
-        val result = svc.narrowScopes(listOf("read:a", "read:b"), listOf(a, b))
+        val result = svc.narrowScopes(listOf("read:a", "read:b"), listOf(a, b), grantingAll(a, b))
         assertEquals(
             OAuthService.ScopeNarrowing.Ok(listOf("read:a", "read:b")),
             result,
+        )
+    }
+
+    // ---- the client axis: what this client was granted, not merely what the API offers ----
+
+    @Test
+    fun `narrowScopes rejects a scope the API declares but this client was not granted`() {
+        val api = resourceServerOf(scopes = listOf("ingest:write", "keys:read", "handoff:admin"))
+        // Client created for ingest only — the exact shape measured on a live integration.
+        val granted = mapOf(api.id!! to setOf("ingest:write"))
+        assertEquals(
+            OAuthService.ScopeNarrowing.InvalidScope(listOf("keys:read")),
+            svc.narrowScopes(listOf("ingest:write", "keys:read"), listOf(api), granted),
+        )
+    }
+
+    @Test
+    fun `narrowScopes accepts the scopes this client was granted`() {
+        val api = resourceServerOf(scopes = listOf("ingest:write", "keys:read"))
+        assertEquals(
+            OAuthService.ScopeNarrowing.Ok(listOf("ingest:write")),
+            svc.narrowScopes(listOf("ingest:write"), listOf(api), mapOf(api.id!! to setOf("ingest:write"))),
+        )
+    }
+
+    @Test
+    fun `narrowScopes treats an absent client grant as nothing, never as everything`() {
+        val api = resourceServerOf(scopes = listOf("ingest:write"))
+        // No entry at all. Reading this as unrestricted is precisely the pre-v1.25.0 bug.
+        assertEquals(
+            OAuthService.ScopeNarrowing.InvalidScope(listOf("ingest:write")),
+            svc.narrowScopes(listOf("ingest:write"), listOf(api), emptyMap()),
+        )
+    }
+
+    @Test
+    fun `narrowScopes treats an empty client grant as nothing`() {
+        val api = resourceServerOf(scopes = listOf("ingest:write"))
+        assertEquals(
+            OAuthService.ScopeNarrowing.InvalidScope(listOf("ingest:write")),
+            svc.narrowScopes(listOf("ingest:write"), listOf(api), mapOf(api.id!! to emptySet())),
+        )
+    }
+
+    @Test
+    fun `narrowScopes intersects per resource — a grant on one does not leak into another`() {
+        val a = resourceServerOf(identifier = "https://a", scopes = listOf("read:a", "write:a"))
+        val b = resourceServerOf(identifier = "https://b", scopes = listOf("read:b"))
+        val granted = mapOf(a.id!! to setOf("write:a"), b.id!! to setOf("read:b"))
+        assertEquals(
+            OAuthService.ScopeNarrowing.InvalidScope(listOf("read:a")),
+            svc.narrowScopes(listOf("read:a", "read:b"), listOf(a, b), granted),
+        )
+    }
+
+    @Test
+    fun `narrowScopes cannot grant a scope the API stopped declaring`() {
+        // The operator removed keys:read from the API; the client's old grant row survives.
+        val api = resourceServerOf(scopes = listOf("ingest:write"))
+        val granted = mapOf(api.id!! to setOf("ingest:write", "keys:read"))
+        assertEquals(
+            OAuthService.ScopeNarrowing.InvalidScope(listOf("keys:read")),
+            svc.narrowScopes(listOf("keys:read"), listOf(api), granted),
         )
     }
 
@@ -1613,14 +1677,22 @@ class OAuthServiceTest {
     // Resource server fixture builder
     // -------------------------------------------------------------------------
 
+    private var nextResourceServerId = 100
+
+    /** Mirrors the V67 backfill: the client is granted every scope each resource declares. */
+    private fun grantingAll(vararg servers: ResourceServer): Map<ResourceServerId, Set<String>> =
+        servers.associate { it.id!! to it.scopes.toSet() }
+
     private fun resourceServerOf(
         identifier: String = "https://api",
         name: String = "Test API",
         description: String? = null,
         enabled: Boolean = true,
         scopes: List<String> = emptyList(),
+        id: ResourceServerId = ResourceServerId(nextResourceServerId++),
     ): ResourceServer =
         ResourceServer(
+            id = id,
             tenantId = TenantId(1),
             identifier = identifier,
             name = name,

--- a/src/test/kotlin/com/kauth/fakes/FakeResourceServerRepository.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeResourceServerRepository.kt
@@ -12,6 +12,7 @@ class FakeResourceServerRepository : ResourceServerRepository {
     private val byId = mutableMapOf<Int, ResourceServer>()
     private val authorizations = mutableMapOf<Int, MutableSet<Int>>()
     private val clientTenants = mutableMapOf<Int, TenantId>()
+    private val allowedScopes = mutableMapOf<Pair<Int, Int>, MutableSet<String>>()
     private var nextId = 1
 
     fun clear() {
@@ -33,6 +34,25 @@ class FakeResourceServerRepository : ResourceServerRepository {
         val stored = rs.copy(id = ResourceServerId(pk))
         byId[pk] = stored
         if (pk >= nextId) nextId = pk + 1
+        return stored
+    }
+
+    /**
+     * Seed a resource server and authorize [clientPk] for it, granting every scope it declares.
+     *
+     * A real flow reaches `narrowScopes` only after `resolveAudiences` has confirmed the client is
+     * authorized for the resource, so a fixture that seeds without authorizing does not represent
+     * a reachable state. Use this rather than [seed] wherever the test exercises token issuance.
+     */
+    fun seedAuthorized(
+        rs: ResourceServer,
+        clientPk: ApplicationId,
+        tenantId: TenantId,
+    ): ResourceServer {
+        val stored = seed(rs)
+        registerClient(clientPk, tenantId)
+        val existing = authorizations[clientPk.value].orEmpty().map { ResourceServerId(it) }
+        setAuthorizedResources(clientPk, existing + stored.id!!)
         return stored
     }
 
@@ -127,7 +147,51 @@ class FakeResourceServerRepository : ResourceServerRepository {
             if (rs.tenantId != clientTenantId) return ResourceAuthorizationError.CrossTenant
         }
 
+        val previous = authorizations[clientPk.value].orEmpty().toSet()
         authorizations[clientPk.value] = resourceServerIds.map { it.value }.toMutableSet()
+
+        // Mirror production: a newly authorized resource starts with every scope it declares;
+        // a resource that was already authorized keeps whatever the operator had chosen.
+        allowedScopes.keys.filter { it.first == clientPk.value }.forEach { key ->
+            if (key.second !in resourceServerIds.map { it.value }.toSet()) allowedScopes.remove(key)
+        }
+        for (rsId in resourceServerIds) {
+            if (rsId.value in previous && allowedScopes.containsKey(clientPk.value to rsId.value)) continue
+            allowedScopes[clientPk.value to rsId.value] =
+                (byId[rsId.value]?.scopes ?: emptyList()).toMutableSet()
+        }
         return null
+    }
+
+    override fun findAllowedScopes(clientPk: ApplicationId): Map<ResourceServerId, Set<String>> =
+        allowedScopes
+            .filterKeys { it.first == clientPk.value }
+            .map { (k, v) -> ResourceServerId(k.second) to v.toSet() }
+            .toMap()
+
+    override fun setAllowedScopes(
+        clientPk: ApplicationId,
+        resourceServerId: ResourceServerId,
+        scopes: Set<String>,
+    ): ResourceAuthorizationError? {
+        if (authorizations[clientPk.value]?.contains(resourceServerId.value) != true) {
+            return ResourceAuthorizationError.NotAuthorizedForResource(resourceServerId)
+        }
+        val declared = byId[resourceServerId.value]?.scopes?.toSet() ?: emptySet()
+        val undeclared = scopes - declared
+        if (undeclared.isNotEmpty()) {
+            return ResourceAuthorizationError.UndeclaredScope(resourceServerId, undeclared)
+        }
+        allowedScopes[clientPk.value to resourceServerId.value] = scopes.toMutableSet()
+        return null
+    }
+
+    /** Test helper: grant every scope a resource declares, mirroring the V67 backfill. */
+    fun grantAllDeclaredScopes(
+        clientPk: ApplicationId,
+        resourceServerId: ResourceServerId,
+    ) {
+        allowedScopes[clientPk.value to resourceServerId.value] =
+            (byId[resourceServerId.value]?.scopes ?: emptyList()).toMutableSet()
     }
 }


### PR DESCRIPTION
## What does this PR do?

Closes the scope-isolation gap recorded in the roadmap's Known Gaps, and cuts v1.25.0.

Authorizing a client against an API granted it **every scope that API declared**. `narrowScopes` intersected the request against `resolvedResources.flatMap { it.scopes }` — what the API offers — with nothing client-specific in the intersection. Separate client credentials bought independent revocation and a real `sub` in the audit trail; they did not buy least privilege, which is what the admin console implied they bought. `EmailOtpService` had carried `TODO(v1.13): derive from client.allowedScopes once that field exists` since v1.13.

A client's scopes are now an explicit per-client grant.

### Enforcement

`narrowScopes` becomes a three-way intersection: **requested ∩ declared-by-API ∩ granted-to-client**. All three grant types funnel through that one function, so authorization-code, refresh and client-credentials are covered by a single change. `EmailOtpService` assigns scopes outside `narrowScopes` on its back-channel path and applies the same lookup separately.

`clientAllowedScopes` is a **required** parameter, not defaulted. A default would let a new call site silently reproduce the original bug. An absent or empty entry means the client may request nothing on that API — never everything.

On the refresh path the client may be null, because a soft-deleted application no longer resolves. That now yields no grants and therefore no scopes, rather than falling back to the API's full declared set.

### Storage

`client_authorized_scopes(client_id, resource_server_id, scope)` — a side table matching V51's `client_authorized_resources` and V59's `client_grant_types`, not a column on `clients` or a JSONB blob. The composite foreign key targets the authorization row, so a scope grant cannot outlive the authorization it qualifies and un-authorizing an API removes its scopes by cascade.

### Upgrade behaviour

V67 backfills one row per scope each API currently declares, for every existing authorization — **today's behaviour reproduced exactly**. No client gains or loses a scope on upgrade. Narrowing begins only when an operator edits a client's scopes or authorizes a new API, which arrives with all of its scopes checked.

Two deliberate consequences: adding a new scope to an API does **not** grant it to existing clients, and a scope the API does not declare is refused rather than stored.

### Admin UI

The authorized-APIs page now lists each API's declared scopes as checkboxes beneath it. Previously nothing in the console indicated that authorizing an API granted all of its scopes — the gap was invisible where the decision was made.

Rationale in [ADR-23](docs/adr/ADR-23-per-client-scope-allowlists.md).

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation

## How was this tested?

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [x] Tested manually — describe steps below

**2499 tests, 0 failures.** `make lint` clean.

**All 67 migrations applied to an empty database**, verified in order; V67's table, primary key, index and cascading composite FK all present afterwards. On the fully-migrated schema, the originating scenario was reproduced end to end: an API declaring `assistant:ingest`, `assistant:keys`, `assistant:handoff` with one authorized client — backfill grants all three (today's behaviour), the operator narrows to `assistant:ingest`, and the API still declares all three. The cascade was verified separately: un-authorizing the API removes its scope rows.

Six new unit tests cover the client axis specifically, including that an absent grant is read as nothing rather than everything, that a grant on one API does not leak into another, and that a stale grant cannot resurrect a scope the API stopped declaring.

Two pre-existing integration tests failed when the enforcement first landed, because their fixtures authorized a client without granting scopes — a state a real flow cannot reach, since `resolveAudiences` requires authorization before `narrowScopes` runs. The fake gained a `seedAuthorized` helper that mirrors a real flow, and both the fake and the Postgres adapter seed a newly authorized API's declared scopes so they cannot diverge.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [x] New domain logic has no framework imports
- [x] New database changes include a Flyway migration (`V67__client_authorized_scopes.sql`)
- [ ] Public API changes are reflected in `openapi/v1.yaml` — no REST surface changed in this PR
- [x] Security-sensitive changes are noted in the description

## Notes for reviewers

The migration default is the part worth the most attention. An empty grant set must never be read as unrestricted — that ambiguity is precisely what produced the original behaviour, and a `NOT NULL DEFAULT` mistake would reintroduce it silently. The backfill exists so that no operator's working integration changes on upgrade.

This also unblocks the OAuth consent screen, which could not honestly be built on the previous model: it would have told a user "this application wants access to X" as a per-client claim the platform could not enforce.
