### PR TITLE
Move webhook transport behind a port, add a repository contract test, and take the dependency batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signature. Previously the transport was inside `WebhookService` and only delivery rows were
   observable.
 
+### Chore
+
+- Dependency bumps: Flyway 13.5.0, HikariCP 7.1.0, Lettuce 7.7.0, java-jwt 4.6.0,
+  webauthn-server-core 2.9.0.
+
+  Three of these — Flyway, HikariCP and Lettuce — are majors that CI cannot verify: the unit suite
+  runs on fakes and never opens a database or a Redis connection, and CI runs neither
+  `postgresTest` nor `redisTest`. They were checked by running those suites directly, and by
+  reading the class-file version of each published jar to confirm none raises the JDK floor above
+  17.
+
+  Flyway 13 drops the second Jackson generation the build was carrying: Flyway 12 pulled Jackson 3
+  (`tools.jackson.*`) alongside the Jackson 2 already present. It also adds
+  `flyway-database-cockroachdb`, which is dead weight for a Postgres-only product and could be
+  excluded. Lettuce 7 adds Netty's DNS resolver modules.
+
 ---
 
 ## [1.25.0] - 2026-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.25.1] - 2026-09-08
+
+### Changed
+
+- **Webhook delivery moved behind a port.** `WebhookService` opened its own HTTP connections from
+  the domain layer, importing `java.net.HttpURLConnection` — a violation of
+  [ADR-01](docs/adr/ADR-01-hexagonal-architecture.md), which requires `domain/` to depend on no
+  framework or I/O. The transport now sits behind `WebhookSenderPort`, implemented by
+  `HttpUrlConnectionWebhookSender`.
+
+  The move is deliberately behaviour-preserving: same timeouts, same 2xx-is-success rule, same
+  swallow-and-retry on failure. Migrating to a non-blocking client and adding SSRF defence on
+  operator-supplied URLs are separate pieces of work — doing either here would have hidden a
+  behaviour change inside a refactor.
+
+### Added
+
+- **A repository contract test run against both the fake and a real Postgres.** In v1.24.0,
+  `PostgresUserRepository.update` never wrote the `username` column, so admin username renames
+  silently did nothing in production while every test passed — `FakeUserRepository` stores the
+  whole object, and nothing compared the two implementations.
+
+  `UserRepositoryContract` now runs the same assertions against both, in the shape that catches
+  this class of bug: mutate a field, re-read through the repository, and assert on what came back
+  rather than on whatever `update()` returned. Verified by reintroducing the original bug — three
+  contract tests fail against Postgres while the fake stays green.
+
+  The Postgres side is tagged `postgres` and runs under `make test-postgres`, alongside the
+  existing integration tests.
+- `FakeWebhookSender` records outbound webhooks, so a test can assert on a request's headers and
+  signature. Previously the transport was inside `WebhookService` and only delivery rows were
+  observable.
+
+---
+
 ## [1.25.0] - 2026-09-08
 
 ### Security

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.25.0"
+version = "1.25.1"
 
 // Pin the compile target explicitly rather than letting it follow whichever JDK
 // happens to build. `release`/`-Xjdk-release` also stop a newer build JDK from

--- a/src/main/kotlin/com/kauth/adapter/webhook/HttpUrlConnectionWebhookSender.kt
+++ b/src/main/kotlin/com/kauth/adapter/webhook/HttpUrlConnectionWebhookSender.kt
@@ -1,0 +1,46 @@
+package com.kauth.adapter.webhook
+
+import com.kauth.domain.port.WebhookRequest
+import com.kauth.domain.port.WebhookSendResult
+import com.kauth.domain.port.WebhookSenderPort
+import org.slf4j.LoggerFactory
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * Webhook transport over `java.net.HttpURLConnection`.
+ *
+ * Moved out of `WebhookService` unchanged: this code previously ran in the domain layer, which
+ * broke ADR-01's rule that `domain/` imports no framework or I/O. Behaviour is identical — same
+ * timeouts, same 2xx-is-success rule, same swallow-and-report on failure.
+ *
+ * The connection is deliberately blocking, matching what it replaced. Migrating to a non-blocking
+ * client is tracked separately; doing it here would have hidden a behaviour change inside a move.
+ */
+class HttpUrlConnectionWebhookSender(
+    private val connectTimeoutMs: Int = 5_000,
+    private val readTimeoutMs: Int = 10_000,
+) : WebhookSenderPort {
+    private val log = LoggerFactory.getLogger(HttpUrlConnectionWebhookSender::class.java)
+
+    override fun post(request: WebhookRequest): WebhookSendResult =
+        try {
+            val conn = URI(request.url).toURL().openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.connectTimeout = connectTimeoutMs
+            conn.readTimeout = readTimeoutMs
+            request.headers.forEach { (name, value) -> conn.setRequestProperty(name, value) }
+
+            OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(request.payload) }
+
+            val status = conn.responseCode
+            WebhookSendResult(status, status in 200..299)
+        } catch (e: Exception) {
+            // A transport failure is a delivery outcome, not an exception — the caller records it
+            // and retries. The URL is operator-supplied, so it is logged; the payload never is.
+            log.warn("Webhook HTTP error: url=${request.url}: ${e.message}")
+            WebhookSendResult(null, false)
+        }
+}

--- a/src/main/kotlin/com/kauth/config/ServiceGraph.kt
+++ b/src/main/kotlin/com/kauth/config/ServiceGraph.kt
@@ -40,6 +40,7 @@ import com.kauth.adapter.token.JwtTokenAdapter
 import com.kauth.adapter.web.plugin.CorsOriginCache
 import com.kauth.adapter.webauthn.YubicoCredentialRepositoryBridge
 import com.kauth.adapter.webauthn.YubicoRelyingPartyAdapter
+import com.kauth.adapter.webhook.HttpUrlConnectionWebhookSender
 import com.kauth.domain.model.BrokeredReferenceHasher
 import com.kauth.domain.model.ProviderKey
 import com.kauth.domain.port.ApplicationRepository
@@ -293,6 +294,7 @@ data class ServiceGraph(
                 WebhookService(
                     endpointRepository = webhookEndpointRepository,
                     deliveryRepository = webhookDeliveryRepository,
+                    sender = HttpUrlConnectionWebhookSender(),
                     scope = applicationScope,
                 )
             val auditChainHasher = AuditChainHasher(config.secretKey)

--- a/src/main/kotlin/com/kauth/domain/port/WebhookSenderPort.kt
+++ b/src/main/kotlin/com/kauth/domain/port/WebhookSenderPort.kt
@@ -1,0 +1,38 @@
+package com.kauth.domain.port
+
+/**
+ * Delivers one webhook request to an operator-supplied URL.
+ *
+ * The transport lives behind this port so the domain does not open sockets. `WebhookService`
+ * decides *what* to send — payload envelope, HMAC signature, retry schedule — and this decides
+ * *how* it travels.
+ *
+ * The URL comes from an operator and is therefore untrusted: an implementation is the right
+ * place for SSRF defence (refusing loopback, link-local and private ranges, capping redirects)
+ * and for timeouts, none of which the domain can express.
+ *
+ * Implementations must not throw. A transport failure is a delivery outcome, not an exception —
+ * `WebhookService` records it and schedules a retry.
+ */
+interface WebhookSenderPort {
+    fun post(request: WebhookRequest): WebhookSendResult
+}
+
+/**
+ * One outbound webhook. [headers] already carries the signature and event headers the domain
+ * computed; the sender adds only transport concerns such as `Content-Length`.
+ */
+data class WebhookRequest(
+    val url: String,
+    val payload: String,
+    val headers: Map<String, String>,
+)
+
+/**
+ * @param httpStatus the response code, or null when the request never produced one.
+ * @param success true only for a 2xx. Anything else, including a transport failure, is a retry.
+ */
+data class WebhookSendResult(
+    val httpStatus: Int?,
+    val success: Boolean,
+)

--- a/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
+++ b/src/main/kotlin/com/kauth/domain/service/WebhookService.kt
@@ -7,6 +7,8 @@ import com.kauth.domain.model.WebhookEndpoint
 import com.kauth.domain.model.WebhookEventType
 import com.kauth.domain.port.WebhookDeliveryRepository
 import com.kauth.domain.port.WebhookEndpointRepository
+import com.kauth.domain.port.WebhookRequest
+import com.kauth.domain.port.WebhookSenderPort
 import com.kauth.domain.util.SecureTokens
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,9 +16,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.io.OutputStreamWriter
-import java.net.HttpURLConnection
-import java.net.URI
 import java.time.Instant
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -40,6 +39,7 @@ import javax.crypto.spec.SecretKeySpec
 class WebhookService(
     private val endpointRepository: WebhookEndpointRepository,
     private val deliveryRepository: WebhookDeliveryRepository,
+    private val sender: WebhookSenderPort,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -49,8 +49,6 @@ class WebhookService(
     private val maxAttempts = retryDelaysMs.size
 
     // HTTP timeout for each delivery attempt
-    private val connectTimeoutMs = 5_000
-    private val readTimeoutMs = 10_000
 
     // ==========================================================================
     // Public API
@@ -242,36 +240,33 @@ class WebhookService(
     }
 
     /**
-     * Performs one HTTP POST. Returns (httpStatus, isSuccess).
-     * A 2xx response code is considered success; anything else (including exceptions)
-     * is a failure that triggers a retry.
+     * Sends one request through [WebhookSenderPort]. Returns (httpStatus, isSuccess); a 2xx is
+     * success, anything else — including a transport failure — schedules a retry.
+     *
+     * The signature and event headers are computed here because they are domain concerns; the
+     * port only carries them.
      */
     private fun sendRequest(
         endpoint: WebhookEndpoint,
         payload: String,
         eventType: String,
-    ): Pair<Int?, Boolean> =
-        try {
-            val url = URI(endpoint.url).toURL()
-            val conn = url.openConnection() as HttpURLConnection
-            conn.requestMethod = "POST"
-            conn.doOutput = true
-            conn.connectTimeout = connectTimeoutMs
-            conn.readTimeout = readTimeoutMs
-            conn.setRequestProperty("Content-Type", "application/json; charset=utf-8")
-            conn.setRequestProperty("User-Agent", "KotAuth-Webhook/1.0")
-            conn.setRequestProperty("X-KotAuth-Event", eventType)
-            conn.setRequestProperty("X-KotAuth-Signature", computeSignature(endpoint.secret, payload))
-
-            OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(payload) }
-
-            val status = conn.responseCode
-            val success = status in 200..299
-            Pair(status, success)
-        } catch (e: Exception) {
-            log.warn("Webhook HTTP error: endpoint=${endpoint.id} url=${endpoint.url}: ${e.message}")
-            Pair(null, false)
-        }
+    ): Pair<Int?, Boolean> {
+        val result =
+            sender.post(
+                WebhookRequest(
+                    url = endpoint.url,
+                    payload = payload,
+                    headers =
+                        mapOf(
+                            "Content-Type" to "application/json; charset=utf-8",
+                            "User-Agent" to "KotAuth-Webhook/1.0",
+                            "X-KotAuth-Event" to eventType,
+                            "X-KotAuth-Signature" to computeSignature(endpoint.secret, payload),
+                        ),
+                ),
+            )
+        return Pair(result.httpStatus, result.success)
+    }
 
     // ==========================================================================
     // Helpers

--- a/src/test/kotlin/com/kauth/adapter/persistence/FakeUserRepositoryContractTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/persistence/FakeUserRepositoryContractTest.kt
@@ -1,0 +1,12 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.UserRepository
+import com.kauth.fakes.FakeUserRepository
+
+/** [UserRepositoryContract] against the in-memory fake used by every unit test. */
+class FakeUserRepositoryContractTest : UserRepositoryContract() {
+    override val repo: UserRepository = FakeUserRepository()
+
+    override fun tenantId(): TenantId = TenantId(1)
+}

--- a/src/test/kotlin/com/kauth/adapter/persistence/PostgresUserRepositoryContractTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/persistence/PostgresUserRepositoryContractTest.kt
@@ -1,0 +1,56 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.port.UserRepository
+import com.kauth.infrastructure.DatabaseFactory
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * [UserRepositoryContract] against a real Postgres.
+ *
+ * This is the half that matters: the fake and the adapter agreed on everything the unit suite
+ * could observe while `update()` silently dropped the `username` column. Running the same
+ * assertions against both is what makes that class of divergence visible.
+ *
+ * Tagged `postgres` — run with `make test-postgres`, not part of `make test`.
+ */
+@Tag("postgres")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PostgresUserRepositoryContractTest : UserRepositoryContract() {
+    private lateinit var postgres: PostgreSQLContainer<*>
+
+    override val repo: UserRepository = PostgresUserRepository()
+
+    @BeforeAll
+    fun startDb() {
+        postgres = PostgreSQLContainer("postgres:15-alpine")
+        postgres.start()
+        DatabaseFactory.init(
+            url = postgres.jdbcUrl,
+            user = postgres.username,
+            password = postgres.password,
+        )
+    }
+
+    @AfterAll
+    fun stopDb() {
+        postgres.stop()
+    }
+
+    override fun tenantId(): TenantId =
+        TenantId(
+            transaction {
+                TenantsTable
+                    .selectAll()
+                    .where { TenantsTable.slug eq "master" }
+                    .single()[TenantsTable.id]
+            },
+        )
+}

--- a/src/test/kotlin/com/kauth/adapter/persistence/UserRepositoryContract.kt
+++ b/src/test/kotlin/com/kauth/adapter/persistence/UserRepositoryContract.kt
@@ -1,0 +1,169 @@
+package com.kauth.adapter.persistence
+
+import com.kauth.domain.model.RequiredAction
+import com.kauth.domain.model.TenantId
+import com.kauth.domain.model.User
+import com.kauth.domain.port.UserRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The behaviour every [UserRepository] must exhibit, run against each implementation.
+ *
+ * This exists because of a bug that shipped in v1.24.0. `PostgresUserRepository.update` never
+ * wrote the `username` column, so admin username renames silently did nothing against a real
+ * database — the API returned success, the audit event was written, and the row was unchanged.
+ * Every test passed, because `FakeUserRepository` stores the whole `User` object and no test
+ * compared the two implementations.
+ *
+ * The guard is the shape of these tests rather than any single assertion: **mutate a field, then
+ * re-read through the repository and assert on what came back.** A test that asserts on the value
+ * returned by `update()` proves nothing, because an adapter is free to return its own input — and
+ * `PostgresGroupRepository.update` still does exactly that.
+ *
+ * To cover another port, subclass this pattern rather than copying assertions: one abstract
+ * fixture method, two concrete subclasses, one of them tagged `postgres`.
+ */
+abstract class UserRepositoryContract {
+    /** The implementation under test. */
+    protected abstract val repo: UserRepository
+
+    /** A tenant that exists in this implementation's world. */
+    protected abstract fun tenantId(): TenantId
+
+    private var seq = 0
+
+    private fun newUser(tenantId: TenantId): User {
+        seq++
+        return User(
+            tenantId = tenantId,
+            username = "contract.user$seq",
+            email = "contract.user$seq@example.com",
+            fullName = "Contract User $seq",
+            passwordHash = "hash-$seq",
+        )
+    }
+
+    @Test
+    fun `save then findById returns every field that was written`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val id = assertNotNull(saved.id, "save must return a persisted id")
+
+        val found = assertNotNull(repo.findById(id, tid), "the saved user must be findable")
+        assertEquals(saved.username, found.username)
+        assertEquals(saved.email, found.email)
+        assertEquals(saved.fullName, found.fullName)
+        assertEquals(tid, found.tenantId)
+    }
+
+    @Test
+    fun `update persists the username — re-read, never the returned object`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val id = assertNotNull(saved.id)
+
+        repo.update(saved.copy(username = "contract.renamed$seq"))
+
+        // Deliberately ignoring update()'s return value: an adapter may return its input.
+        val reread = assertNotNull(repo.findById(id, tid))
+        assertEquals(
+            "contract.renamed$seq",
+            reread.username,
+            "username must survive a round-trip through the database, not just the returned object",
+        )
+    }
+
+    @Test
+    fun `update persists every mutable profile field`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val id = assertNotNull(saved.id)
+
+        val mutated =
+            saved.copy(
+                username = "contract.mutated$seq",
+                email = "contract.mutated$seq@example.com",
+                fullName = "Mutated Name",
+                givenName = "Given",
+                familyName = "Family",
+                externalId = "ext-$seq",
+                emailVerified = !saved.emailVerified,
+                enabled = !saved.enabled,
+            )
+        repo.update(mutated)
+
+        val reread = assertNotNull(repo.findById(id, tid))
+        assertEquals(mutated.username, reread.username, "username")
+        assertEquals(mutated.email, reread.email, "email")
+        assertEquals(mutated.fullName, reread.fullName, "fullName")
+        assertEquals(mutated.givenName, reread.givenName, "givenName")
+        assertEquals(mutated.familyName, reread.familyName, "familyName")
+        assertEquals(mutated.externalId, reread.externalId, "externalId")
+        assertEquals(mutated.emailVerified, reread.emailVerified, "emailVerified")
+        assertEquals(mutated.enabled, reread.enabled, "enabled")
+    }
+
+    @Test
+    fun `update persists requiredActions`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val id = assertNotNull(saved.id)
+
+        repo.update(saved.copy(requiredActions = setOf(RequiredAction.CHANGE_PASSWORD)))
+
+        val reread = assertNotNull(repo.findById(id, tid))
+        assertEquals(setOf(RequiredAction.CHANGE_PASSWORD), reread.requiredActions)
+    }
+
+    @Test
+    fun `findByUsername locates a renamed user by its new name, not its old one`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val old = saved.username
+        repo.update(saved.copy(username = "contract.after$seq"))
+
+        assertNotNull(
+            repo.findByUsername(tid, "contract.after$seq"),
+            "a rename must be visible to the lookup the sign-in path uses",
+        )
+        assertEquals(null, repo.findByUsername(tid, old), "the old username must no longer resolve")
+    }
+
+    @Test
+    fun `email is stored lowercased`() {
+        val tid = tenantId()
+        seq++
+        val saved =
+            repo.save(
+                User(
+                    tenantId = tid,
+                    username = "contract.case$seq",
+                    email = "Contract.Case$seq@Example.COM",
+                    fullName = "Case Test",
+                    passwordHash = "hash",
+                ),
+            )
+        val reread = assertNotNull(repo.findById(assertNotNull(saved.id), tid))
+        assertEquals(reread.email, reread.email.lowercase(), "stored email must be lowercase")
+        assertNotNull(
+            repo.findByEmail(tid, "contract.case$seq@example.com"),
+            "lookup must find it by the lowercased address",
+        )
+    }
+
+    @Test
+    fun `findById does not cross tenants`() {
+        val tid = tenantId()
+        val saved = repo.save(newUser(tid))
+        val id = assertNotNull(saved.id)
+        val otherTenant = TenantId(tid.value + 9_999)
+
+        assertTrue(
+            repo.findById(id, otherTenant) == null,
+            "a user must not be readable through another tenant's id",
+        )
+    }
+}

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminWebhooksTest.kt
@@ -29,6 +29,7 @@ import com.kauth.fakes.FakeTokenPort
 import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.EncryptionService
 import com.kauth.infrastructure.KeyProvisioningService
 import io.ktor.client.plugins.cookies.HttpCookies
@@ -80,6 +81,7 @@ class AdminWebhooksTest {
         WebhookService(
             endpointRepository = webhookEndpointRepo,
             deliveryRepository = webhookDeliveryRepo,
+            sender = FakeWebhookSender(),
         )
 
     private val masterTenant =

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiApplicationRoutesTest.kt
@@ -38,6 +38,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -632,7 +633,12 @@ class ApiApplicationRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiClaimMapperRoutesTest.kt
@@ -23,6 +23,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -397,7 +398,12 @@ class ApiClaimMapperRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiIdentityProviderRoutesTest.kt
@@ -27,6 +27,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -701,7 +702,12 @@ class ApiIdentityProviderRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiKeyManagementRoutesTest.kt
@@ -36,6 +36,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -181,6 +182,7 @@ class ApiKeyManagementRoutesTest {
         WebhookService(
             endpointRepository = webhookEndpointRepo,
             deliveryRepository = webhookDeliveryRepo,
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiOtpRoutesTest.kt
@@ -28,6 +28,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.post
@@ -421,7 +422,12 @@ class ApiOtpRoutesTest {
                 otpIpRateLimiter = ipLimiter,
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiPasskeyRoutesTest.kt
@@ -38,6 +38,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -193,6 +194,7 @@ class ApiPasskeyRoutesTest {
         WebhookService(
             endpointRepository = webhookEndpointRepo,
             deliveryRepository = webhookDeliveryRepo,
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRateLimitTest.kt
@@ -32,6 +32,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.InMemoryRateLimiter
@@ -446,7 +447,12 @@ class ApiRateLimitTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = apiWriteRateLimiter,
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRbacRoutesTest.kt
@@ -37,6 +37,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -448,7 +449,12 @@ class ApiRbacRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiReadRateLimitTest.kt
@@ -33,6 +33,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.InMemoryRateLimiter
@@ -291,7 +292,12 @@ class ApiReadRateLimitTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = apiWriteRateLimiter,
                 apiReadRateLimiter = apiReadRateLimiter,
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiResourceServerRoutesTest.kt
@@ -39,6 +39,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -199,6 +200,7 @@ class ApiResourceServerRoutesTest {
         WebhookService(
             endpointRepository = webhookEndpointRepo,
             deliveryRepository = webhookDeliveryRepo,
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiRoutesTest.kt
@@ -39,6 +39,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
@@ -1059,7 +1060,12 @@ class ApiRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiSessionAuditRoutesTest.kt
@@ -38,6 +38,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -387,7 +388,12 @@ class ApiSessionAuditRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserAttributeRoutesTest.kt
@@ -24,6 +24,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
@@ -411,7 +412,12 @@ class ApiUserAttributeRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserLifecycleRoutesTest.kt
@@ -36,6 +36,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -428,7 +429,12 @@ class ApiUserLifecycleRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserRoutesTest.kt
@@ -34,6 +34,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -472,7 +473,12 @@ class ApiUserRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiUserStateTest.kt
@@ -38,6 +38,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -566,7 +567,12 @@ class ApiUserStateTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWebhookRoutesTest.kt
@@ -35,6 +35,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -180,6 +181,7 @@ class ApiWebhookRoutesTest {
         WebhookService(
             endpointRepository = webhookEndpointRepo,
             deliveryRepository = webhookDeliveryRepo,
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/api/ApiWorkspaceRoutesTest.kt
@@ -35,6 +35,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -347,7 +348,12 @@ class ApiWorkspaceRoutesTest {
                 otpIpRateLimiter = AlwaysAllowLimiter(),
                 apiWriteRateLimiter = AlwaysAllowLimiter(),
                 apiReadRateLimiter = AlwaysAllowLimiter(),
-                webhookService = WebhookService(FakeWebhookEndpointRepository(), FakeWebhookDeliveryRepository()),
+                webhookService =
+                    WebhookService(
+                        FakeWebhookEndpointRepository(),
+                        FakeWebhookDeliveryRepository(),
+                        FakeWebhookSender(),
+                    ),
                 resourceServerService = ResourceServerService(FakeResourceServerRepository()),
                 webAuthnService =
                     WebAuthnService(

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimDiscoveryRoutesTest.kt
@@ -39,6 +39,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -187,6 +188,7 @@ class ScimDiscoveryRoutesTest {
         WebhookService(
             endpointRepository = FakeWebhookEndpointRepository(),
             deliveryRepository = FakeWebhookDeliveryRepository(),
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimGroupRoutesTest.kt
@@ -43,6 +43,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -199,6 +200,7 @@ class ScimGroupRoutesTest {
         WebhookService(
             endpointRepository = FakeWebhookEndpointRepository(),
             deliveryRepository = FakeWebhookDeliveryRepository(),
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRateLimitTest.kt
@@ -39,6 +39,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.InMemoryRateLimiter
@@ -177,6 +178,7 @@ class ScimRateLimitTest {
         WebhookService(
             endpointRepository = FakeWebhookEndpointRepository(),
             deliveryRepository = FakeWebhookDeliveryRepository(),
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimRequestBodySizeLimitTest.kt
@@ -40,6 +40,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import com.kauth.infrastructure.InMemoryRateLimiter
@@ -189,6 +190,7 @@ class ScimRequestBodySizeLimitTest {
         WebhookService(
             endpointRepository = FakeWebhookEndpointRepository(),
             deliveryRepository = FakeWebhookDeliveryRepository(),
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/scim/ScimUserRoutesTest.kt
@@ -40,6 +40,7 @@ import com.kauth.fakes.FakeUserRepository
 import com.kauth.fakes.FakeWebAuthnCredentialRepository
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import com.kauth.infrastructure.ApiKeyPrincipal
 import com.kauth.infrastructure.CachingClaimMapperService
 import io.ktor.client.request.bearerAuth
@@ -214,6 +215,7 @@ class ScimUserRoutesTest {
         WebhookService(
             endpointRepository = FakeWebhookEndpointRepository(),
             deliveryRepository = FakeWebhookDeliveryRepository(),
+            sender = FakeWebhookSender(),
             scope = CoroutineScope(Dispatchers.Unconfined),
         )
 

--- a/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
+++ b/src/test/kotlin/com/kauth/domain/service/WebhookServiceTest.kt
@@ -4,6 +4,7 @@ import com.kauth.domain.model.TenantId
 import com.kauth.domain.model.WebhookEventType
 import com.kauth.fakes.FakeWebhookDeliveryRepository
 import com.kauth.fakes.FakeWebhookEndpointRepository
+import com.kauth.fakes.FakeWebhookSender
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,6 +30,7 @@ class WebhookServiceTest {
         WebhookService(
             endpointRepository = endpoints,
             deliveryRepository = deliveries,
+            sender = FakeWebhookSender(),
         )
 
     @BeforeTest

--- a/src/test/kotlin/com/kauth/fakes/FakeWebhookSender.kt
+++ b/src/test/kotlin/com/kauth/fakes/FakeWebhookSender.kt
@@ -1,0 +1,37 @@
+package com.kauth.fakes
+
+import com.kauth.domain.port.WebhookRequest
+import com.kauth.domain.port.WebhookSendResult
+import com.kauth.domain.port.WebhookSenderPort
+
+/**
+ * Records every outbound webhook instead of sending it, and lets a test choose the outcome.
+ *
+ * Before the [WebhookSenderPort] extraction the transport was inside `WebhookService`, so a test
+ * could only observe delivery rows — never the request itself, its headers, or its signature.
+ */
+class FakeWebhookSender(
+    private var nextResult: WebhookSendResult = WebhookSendResult(200, true),
+) : WebhookSenderPort {
+    val sent = mutableListOf<WebhookRequest>()
+
+    /** Outcome returned for every subsequent call. */
+    fun respondWith(result: WebhookSendResult) {
+        nextResult = result
+    }
+
+    /** Outcome chosen per call, by attempt index (0-based); falls back to [nextResult]. */
+    var resultsByAttempt: List<WebhookSendResult> = emptyList()
+
+    override fun post(request: WebhookRequest): WebhookSendResult {
+        val index = sent.size
+        sent += request
+        return resultsByAttempt.getOrNull(index) ?: nextResult
+    }
+
+    fun clear() {
+        sent.clear()
+        resultsByAttempt = emptyList()
+        nextResult = WebhookSendResult(200, true)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Two structural fixes plus the dependency batch. Cuts v1.25.1.

### 1. Webhook delivery moved behind a port

`WebhookService` opened its own HTTP connections from the domain layer — `import java.net.HttpURLConnection` at `WebhookService.kt:18`, `url.openConnection()` at `:256`. That violates [ADR-01](docs/adr/ADR-01-hexagonal-architecture.md), the rule that `domain/` depends on no framework or I/O.

The transport now sits behind `WebhookSenderPort`, implemented by `HttpUrlConnectionWebhookSender` in `adapter/webhook/`. `WebhookService` keeps what is genuinely domain — payload envelope, HMAC signature, retry schedule — and no longer knows how the request travels.

**The move is deliberately behaviour-preserving.** Same timeouts, same 2xx-is-success rule, same swallow-and-report on failure. Non-blocking delivery and SSRF defence on operator-supplied URLs both belong in their own change; folding either in here would have hidden a behaviour change inside a refactor.

The domain layer now has no network or file I/O at all. The remaining `java.net.URI` and `java.net.IDN` imports elsewhere in `domain/` are parsing, not I/O — the same class as `MessageDigest` for PKCE.

### 2. A repository contract test run against both implementations

In v1.24.0, `PostgresUserRepository.update` never wrote the `username` column. Admin username renames returned success, wrote an audit event, and changed nothing. Every test passed, because `FakeUserRepository` stores the whole `User` object and nothing compared the two implementations.

`UserRepositoryContract` now runs the same assertions against both. The guard is the *shape*: **mutate a field, re-read through the repository, assert on what came back** — never on what `update()` returned, because an adapter may return its own input, and `PostgresGroupRepository.update` still does.

`ResourceServerRepositoryContractTest` was named like a contract test but only ever exercised the fake. This is what that name should mean.

### 3. Dependency batch

Flyway 13.5.0, HikariCP 7.1.0, Lettuce 7.7.0, java-jwt 4.6.0, webauthn-server-core 2.9.0 — merged separately and included here by rebase.

Three are majors that **CI cannot verify**: the unit suite runs on fakes and never opens a database or Redis connection, and CI runs neither `postgresTest` nor `redisTest`. HikariCP and Flyway have zero references in the unit suite. They were checked by running those suites directly, and by reading the class-file version of each published jar — none raises the JDK floor above 17, so the JVM 17 promise holds.

Worth noting: Flyway 13 drops the second Jackson generation the build was carrying (Flyway 12 pulled Jackson 3 alongside the Jackson 2 already present). It also adds `flyway-database-cockroachdb`, dead weight for a Postgres-only product. Lettuce 7 adds Netty's DNS resolver modules.

## Type of change

- [x] Bug fix
- [x] Refactor (no behaviour change)

## How was this tested?

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

**2506 unit tests, 0 failures.** `make lint` clean.
**`make test-postgres`: 10/10** — 7 contract tests against real Postgres via Testcontainers plus the 3 pre-existing integration tests, with Flyway 13 applying the migrations and HikariCP 7 pooling.
**`make test-redis`: 23/23** on Lettuce 7.

**The contract was verified to catch the original bug.** Reintroducing it — deleting the `username` write from `PostgresUserRepository.update` — fails three contract tests against Postgres while the fake side stays green:

```
> update persists the username — re-read, never the returned object() FAILED
> update persists every mutable profile field() FAILED
> findByUsername locates a renamed user by its new name, not its old one() FAILED
```

The source was restored; the diff contains no change to that file.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [x] New domain logic has no framework imports — this PR removes the ones that existed
- [ ] New database changes include a Flyway migration — n/a
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a
- [x] Security-sensitive changes are noted in the description

## Notes for reviewers

`FakeWebhookSender` records outbound requests, so a test can assert on a webhook's headers and signature. Before the extraction the transport was inside `WebhookService` and only delivery rows were observable.

Covering another port means subclassing the pattern — one abstract fixture method, two concrete subclasses, one tagged `postgres` — not copying assertions. Nine adapters take a whole domain object into `update()`; this covers `UserRepository`, where the bug happened. `PostgresGroupRepository` is the next one worth taking: it still returns its input rather than re-reading, though it currently writes every mutable field, so it is a latent risk rather than a live bug.

CI running `postgresTest` and `redisTest` would close the gap that made this dependency batch unverifiable from the PR checks alone. That is issue #137's neighbourhood and the next piece of work.
