### PR TITLE
Apply every migration to an empty database in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,54 @@ jobs:
           path: build/reports/tests/test/
           retention-days: 7
 
+  # Docker-backed suites. These cover what the unit suite structurally cannot: the unit
+  # tests run on in-memory fakes, so they never apply a migration, never open a pooled
+  # connection, and never speak to Redis. Before this job, a broken V*.sql passed every
+  # check and failed only on someone's first install, and a Flyway/HikariCP/Lettuce bump
+  # was green on compilation alone.
+  #
+  # Runs on the GitHub-hosted Docker daemon, so Testcontainers needs no extra setup.
+  integration:
+    name: Integration (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [postgresTest, redisTest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v6
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run ${{ matrix.suite }}
+        run: ./gradlew ${{ matrix.suite }} --no-daemon --stacktrace
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: test-report-${{ matrix.suite }}
+          path: build/reports/tests/${{ matrix.suite }}/
+          retention-days: 7
+
   # Separate job — verifies the fat JAR compiles cleanly without running
   # the full Docker build. Catches build-time errors on every PR cheaply.
   build:
     name: Build fat JAR
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, integration]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **CI applies every migration to an empty database.** The unit suite runs on in-memory fakes, so
+  it never sees a migration at all; nothing in CI applied `V1` through the newest file to a fresh
+  database. A broken `V*.sql` therefore passed Flyway's checksum validation, passed the unit tests,
+  and failed only when someone provisioned a new deployment — which has happened here before.
+
+  `MigrationChainTest` starts an empty Postgres, migrates, and asserts the run reached the newest
+  version on disk with every migration applied and none left failed. It then migrates again and
+  asserts the second run is a no-op, which is what an operator's restart does on every deploy.
+- **CI runs the Docker-backed suites.** `postgresTest` and `redisTest` now run on every push and
+  pull request. Both suites and their Testcontainers wiring already existed but were invoked only
+  by hand, so anything reached solely through a database or a Redis connection was unverified —
+  including the Flyway, HikariCP and Lettuce major upgrades in 1.25.1, whose green checks
+  confirmed compilation and nothing more.
+- **Migration filenames are checked without a database**, so a mistake fails in `make test` rather
+  than after a container has booted: no two migrations may claim the same version, every name must
+  match `V<number>__<lower_snake_case>.sql`, and versions must be contiguous from 1. The duplicate
+  check catches two branches independently adding the same number, which Flyway only refuses once
+  someone applies it — by which point the second file is already merged.
+
+---
+
 ## [1.25.1] - 2026-09-08
 
 ### Changed

--- a/src/test/kotlin/com/kauth/infrastructure/MigrationChainTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/MigrationChainTest.kt
@@ -1,0 +1,83 @@
+package com.kauth.infrastructure
+
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.PostgreSQLContainer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Applies every migration to an empty database.
+ *
+ * The unit suite runs on in-memory fakes and cannot see a migration at all. The other Postgres
+ * tests reach the latest schema only as a side effect of `DatabaseFactory.init`, and assert on
+ * repository behaviour rather than on the migration chain — so a broken `V*.sql` passed Flyway's
+ * checksum validation, passed the unit tests, and only failed when someone provisioned a fresh
+ * deployment. That has happened here before (V55, v1.20.1).
+ *
+ * Applying a migration to an *existing* database is checked by hand before a release, which covers
+ * the upgrade path. This covers the fresh path.
+ *
+ * Deliberately does not assert the resulting schema in detail: reaching the newest version without
+ * error is most of the value, and a schema snapshot would need updating on every migration whether
+ * or not anything was wrong.
+ */
+@Tag("postgres")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MigrationChainTest {
+    private lateinit var postgres: PostgreSQLContainer<*>
+
+    @BeforeAll
+    fun startDb() {
+        // Deliberately NOT DatabaseFactory.init — that also seeds an admin and connects Exposed.
+        // This test is about the migration chain alone, on a database nothing else has touched.
+        postgres = PostgreSQLContainer("postgres:15-alpine")
+        postgres.start()
+    }
+
+    @AfterAll
+    fun stopDb() {
+        postgres.stop()
+    }
+
+    private fun flyway() =
+        Flyway
+            .configure()
+            .dataSource(postgres.jdbcUrl, postgres.username, postgres.password)
+            .locations("classpath:db/migration")
+            .load()
+
+    @Test
+    fun `every migration applies to an empty database, reaches the newest version, and re-runs clean`() {
+        // One test rather than two: both assertions describe the same run sequence against the
+        // same database, and splitting them would depend on JUnit method order — the container is
+        // shared, so whichever ran first would migrate it out from under the other.
+        val first = flyway().migrate()
+
+        assertTrue(first.success, "migration run must succeed")
+
+        val expected = MigrationFiles.versionsOnDisk()
+        assertEquals(
+            expected.size,
+            first.migrationsExecuted,
+            "every migration on disk must be applied to an empty database",
+        )
+        assertEquals(
+            expected.max().toString(),
+            first.targetSchemaVersion,
+            "the chain must reach the newest migration on disk",
+        )
+
+        val failed = flyway().info().all().filter { it.state?.isFailed == true }
+        assertTrue(failed.isEmpty(), "no migration may be left in a failed state: $failed")
+
+        // Re-running against an already-migrated database must apply nothing. This is what an
+        // operator's restart does on every deploy.
+        val second = flyway().migrate()
+        assertEquals(0, second.migrationsExecuted, "a second run must be a no-op")
+    }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/MigrationFiles.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/MigrationFiles.kt
@@ -1,0 +1,47 @@
+package com.kauth.infrastructure
+
+import java.io.File
+
+/** Reads the Flyway migration files off disk, so tests can assert on the chain itself. */
+object MigrationFiles {
+    private val NAME = Regex("""^V(\d+)__([a-z0-9_]+)\.sql$""")
+
+    private fun directory(): File {
+        // Walk up from the working directory so this works from the module root or the repo root.
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, "src/main/resources/db/migration")
+            if (candidate.isDirectory) return candidate
+            dir = dir.parentFile
+        }
+        error("could not locate src/main/resources/db/migration")
+    }
+
+    fun files(): List<File> =
+        directory().listFiles()?.filter { it.extension == "sql" }?.sortedBy { it.name } ?: emptyList()
+
+    fun versionsOnDisk(): List<Int> =
+        files().mapNotNull {
+            NAME
+                .find(it.name)
+                ?.groupValues
+                ?.get(1)
+                ?.toInt()
+        }
+
+    /** Names that do not match `V<number>__<lower_snake_case>.sql`. */
+    fun malformedNames(): List<String> = files().map { it.name }.filterNot { NAME.matches(it) }
+
+    /** Version numbers claimed by more than one file. */
+    fun duplicateVersions(): Map<Int, List<String>> =
+        files()
+            .mapNotNull { f ->
+                NAME
+                    .find(f.name)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.toInt()
+                    ?.let { it to f.name }
+            }.groupBy({ it.first }, { it.second })
+            .filterValues { it.size > 1 }
+}

--- a/src/test/kotlin/com/kauth/infrastructure/MigrationNamingTest.kt
+++ b/src/test/kotlin/com/kauth/infrastructure/MigrationNamingTest.kt
@@ -1,0 +1,45 @@
+package com.kauth.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Checks the migration files without starting a database, so these failures land in `make test`
+ * rather than after a container has booted.
+ *
+ * The case worth catching is two branches independently adding the same version number. Flyway
+ * refuses to run in that state, but only once someone applies it — and by then the second file is
+ * already merged. Reading the filenames catches it in seconds, on every PR.
+ */
+class MigrationNamingTest {
+    @Test
+    fun `no two migrations claim the same version number`() {
+        val duplicates = MigrationFiles.duplicateVersions()
+        assertTrue(
+            duplicates.isEmpty(),
+            "each migration version must be unique — two branches adding the same number is the " +
+                "usual cause. Duplicates: $duplicates",
+        )
+    }
+
+    @Test
+    fun `every migration follows the V-number-double-underscore-snake-case convention`() {
+        val malformed = MigrationFiles.malformedNames()
+        assertTrue(
+            malformed.isEmpty(),
+            "migration filenames must match V<number>__<lower_snake_case>.sql. Offenders: $malformed",
+        )
+    }
+
+    @Test
+    fun `migration versions are contiguous from 1`() {
+        val versions = MigrationFiles.versionsOnDisk().sorted()
+        assertTrue(versions.isNotEmpty(), "there must be migrations on disk")
+
+        val gaps = (1..versions.max()).filterNot { it in versions.toSet() }
+        assertTrue(
+            gaps.isEmpty(),
+            "a missing version usually means a migration was deleted or never merged. Gaps: $gaps",
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Closes #137. Nothing in CI applied `V1` through the newest migration to an empty database, so a broken `V*.sql` passed Flyway's checksum validation, passed the unit tests, and failed only when someone provisioned a fresh deployment.

### A migration-chain test

`MigrationChainTest` starts an empty Postgres, migrates, and asserts the run reached the newest version on disk with every migration applied and none left in a failed state. It then migrates a second time and asserts that run is a no-op — what an operator's restart does on every deploy.

It deliberately does not snapshot the resulting schema. Reaching the newest version without error is most of the value, and a schema assertion would need updating on every migration whether or not anything was wrong.

It also does not go through `DatabaseFactory.init`, which seeds an admin and connects Exposed. This is about the migration chain alone, on a database nothing else has touched.

### CI runs the Docker-backed suites

`postgresTest` and `redisTest` now run on every push and pull request, as a matrix job. Both suites and their Testcontainers wiring already existed but were only ever invoked by hand.

That gap was wider than the migration case. The unit suite runs on in-memory fakes, so it never opens a pooled connection and never speaks to Redis — HikariCP and Flyway have **zero** references in it. The Flyway 12→13, HikariCP 5→7 and Lettuce 6→7 upgrades in 1.25.1 were green on four checks that only proved they compiled; they were verified by running these suites by hand. Now the PR checks cover it.

The fat-JAR job now waits on the integration suites as well.

### Filename checks that need no database

Three assertions run inside `make test`, so a mistake fails in seconds rather than after a container boots: no two migrations may claim the same version, every name must match `V<number>__<lower_snake_case>.sql`, and versions must be contiguous from 1.

The duplicate check is the one that earns its place. Two branches independently adding `V68` is a normal thing to happen; Flyway refuses that state, but only when someone applies it — by which point the second file is already merged.

## Type of change

- [x] CI / tooling
- [x] Documentation

## How was this tested?

- [x] Added / updated unit tests
- [x] Added / updated integration tests
- [ ] Tested manually — describe steps below

**2509 unit tests, 0 failures.** `make lint` clean.
**`make test-postgres`: 11/11** — the new chain test plus the contract and repository integration tests.
**`make test-redis`: 23/23**.

**The chain test was verified to catch a broken migration.** Planting a `V68` with an invalid column type fails it and names the file:

```
org.flywaydb.core.internal.exception.FlywayMigrateException:
  Failed to execute script V68__probe_broken.sql
  SQL State : 42704
```

The probe file was removed; 67 migrations remain on disk and the suite is green.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [ ] New domain logic has no framework imports — n/a
- [ ] New database changes include a Flyway migration — n/a, this adds no migration
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a
- [x] Security-sensitive changes are noted in the description — none

## Notes for reviewers

The `integration` job adds roughly a container start to CI on every PR. That is the cost of the previous position, where three major dependency upgrades and every migration were unverified by anything a PR could see.

The CHANGELOG entry is under `Unreleased` — this is tooling, so it can ride with whatever ships next rather than justifying its own version.

