### PR TITLE
Render admin breadcrumb and heading from one title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Seven create-screens disagreed with themselves.** The breadcrumb said "New Role" while the
+  heading said "Create Role" — and the same split existed for applications, groups, users,
+  workspaces, API keys and webhook endpoints. All now read **Create X** in both places, matching
+  the primary button already on those screens. Closes part of #134.
+
 ### Added
 
+- **`adminPage()` renders a page's breadcrumb and heading from one title**, so the trailing crumb
+  cannot silently diverge from the `h1`. Sixteen of thirty-seven admin pages had drifted.
+
+  Where a shorter crumb is genuinely wanted — "MFA" reads better in a trail than "Multi-Factor
+  Authentication" — it is now passed explicitly as `crumb =`, which makes it a decision visible in
+  review rather than an accident indistinguishable from one. Three pages do this.
+- **A ratchet keeps it from coming back.** `AdminPageIdentityTest` records how many direct
+  `breadcrumb()` calls each remaining legacy file makes and fails if any file gains one, if the
+  allowance lists a file that no longer needs it, or if the allowance drifts above the real count.
+  The numbers can only go down.
 - **CI applies every migration to an empty database.** The unit suite runs on in-memory fakes, so
   it never sees a migration at all; nothing in CI applied `V1` through the newest file to a fresh
   database. A broken `V*.sql` therefore passed Flyway's checksum validation, passed the unit tests,

--- a/src/main/kotlin/com/kauth/adapter/web/admin/AdminComponents.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/AdminComponents.kt
@@ -51,6 +51,42 @@ fun DIV.breadcrumb(vararg crumbs: Pair<String, String?>) {
 }
 
 /**
+ * Renders a page's breadcrumb and header together, from one source of truth.
+ *
+ * The trailing crumb defaults to [title], so the two cannot silently disagree. Before this
+ * existed, `breadcrumb()` and `pageHeader()` were independent calls with independently typed
+ * strings, and sixteen of thirty-seven pages had drifted — the console said "New Role" in the
+ * crumb and "Create Role" in the heading.
+ *
+ * Pass [crumb] only where a shorter trailing crumb is deliberate: "MFA" in the trail reads better
+ * than "Multi-Factor Authentication", and a resource's identifier is often the right crumb for a
+ * page titled with its display name. Being explicit makes that a decision a reviewer can see,
+ * rather than an accident that looks identical to one.
+ *
+ * [ancestors] are the crumbs before this page, each a label and its href.
+ */
+fun DIV.adminPage(
+    vararg ancestors: Pair<String, String>,
+    title: String,
+    crumb: String = title,
+    subtitle: String? = null,
+    subtitleContent: (P.() -> Unit)? = null,
+    left: (DIV.() -> Unit)? = null,
+    meta: (DIV.() -> Unit)? = null,
+    actions: (DIV.() -> Unit)? = null,
+) {
+    breadcrumb(*ancestors.map { it.first to it.second as String? }.toTypedArray(), crumb to null)
+    pageHeader(
+        title = title,
+        subtitle = subtitle,
+        subtitleContent = subtitleContent,
+        left = left,
+        meta = meta,
+        actions = actions,
+    )
+}
+
+/**
  * Renders the standard page header with title, optional meta row, and actions.
  *
  * subtitleContent takes precedence over subtitle when both are provided.

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ApplicationViews.kt
@@ -438,7 +438,7 @@ internal fun createApplicationPageImpl(
             breadcrumb(
                 "Workspaces" to "/admin",
                 workspace.slug to "/admin/workspaces/${workspace.slug}",
-                "New Application" to null,
+                "Create Application" to null,
             )
 
             // ── Page header with external submit ───────────────────

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ClaimMapperViews.kt
@@ -30,14 +30,10 @@ internal fun claimMappersListPageImpl(
             toastMessage = toastMessage,
         ) {
             div("content-inner") {
-                breadcrumb(
+                adminPage(
                     "Workspaces" to "/admin",
                     slug to "/admin/workspaces/$slug",
                     "Settings" to "/admin/workspaces/$slug/settings",
-                    "Claim Mappers" to null,
-                )
-
-                pageHeader(
                     title = "Claim Mappers",
                     subtitle =
                         "Control which user attributes appear as claims in access and ID tokens. " +

--- a/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/KeyRotationViews.kt
@@ -28,14 +28,10 @@ internal fun keyManagementPageImpl(
             toastMessage = toastMessage,
         ) {
             div("content-inner") {
-                breadcrumb(
+                adminPage(
                     "Workspaces" to "/admin",
                     slug to "/admin/workspaces/$slug",
                     "Settings" to "/admin/workspaces/$slug/settings",
-                    "Signing Keys" to null,
-                )
-
-                pageHeader(
                     title = "Signing Keys",
                     subtitle = "RS256 key pairs used to sign JWTs for this workspace.",
                     actions = {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/PasskeysAdminPage.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/PasskeysAdminPage.kt
@@ -30,14 +30,10 @@ internal fun HTML.passkeysAdminPage(
         loggedInAs = loggedInAs,
     ) {
         div("content-inner") {
-            breadcrumb(
+            adminPage(
                 "Workspaces" to "/admin",
                 slug to "/admin/workspaces/$slug",
                 "Security" to "/admin/workspaces/$slug/settings/security",
-                EnglishStrings.ADMIN_PASSKEYS_PAGE_TITLE to null,
-            )
-
-            pageHeader(
                 title = EnglishStrings.ADMIN_PASSKEYS_PAGE_TITLE,
                 subtitleContent = {
                     +"Passkey enrollment status for ${workspace.displayName}. Configuration: "

--- a/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
@@ -128,7 +128,7 @@ internal fun createRolePageImpl(
                 "Workspaces" to "/admin",
                 slug to "/admin/workspaces/$slug",
                 "Roles" to "/admin/workspaces/$slug/roles",
-                "New Role" to null,
+                "Create Role" to null,
             )
 
             div("page-header") {
@@ -557,7 +557,7 @@ internal fun createGroupPageImpl(
                 "Workspaces" to "/admin",
                 slug to "/admin/workspaces/$slug",
                 "Groups" to "/admin/workspaces/$slug/groups",
-                "New Group" to null,
+                "Create Group" to null,
             )
 
             div("page-header") {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
@@ -27,13 +27,10 @@ internal fun resourceServersListPageImpl(
             toastMessage = toastMessage,
         ) {
             div("content-inner") {
-                breadcrumb(
+                adminPage(
                     "Workspaces" to "/admin",
                     slug to "/admin/workspaces/$slug",
-                    EnglishStrings.API_NAV_LABEL to null,
-                )
-
-                pageHeader(
+                    crumb = EnglishStrings.API_NAV_LABEL,
                     title = EnglishStrings.API_PAGE_TITLE,
                     subtitle = EnglishStrings.API_PAGE_SUBTITLE,
                     actions = {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ScimProvisioningViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ScimProvisioningViews.kt
@@ -42,13 +42,9 @@ internal fun scimProvisioningPageImpl(
         toastMessage = toastMessage,
     ) {
         div("content-inner") {
-            breadcrumb(
+            adminPage(
                 "Workspaces" to "/admin",
                 slug to "/admin/workspaces/$slug",
-                EnglishStrings.SCIM_PAGE_TITLE to null,
-            )
-
-            pageHeader(
                 title = EnglishStrings.SCIM_PAGE_TITLE,
                 subtitle = EnglishStrings.SCIM_PAGE_SUBTITLE,
                 actions = { primaryLink(createKeyHref, EnglishStrings.SCIM_TOKEN_CREATE_CTA, "plus") },

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
@@ -50,14 +50,11 @@ internal fun mfaSettingsPageImpl(
         ) {
             div("content-inner") {
                 // Breadcrumb
-                breadcrumb(
+                adminPage(
                     "Workspaces" to "/admin",
                     workspace.slug to "/admin/workspaces/${workspace.slug}",
                     "Security" to "/admin/workspaces/${workspace.slug}/settings/security",
-                    "MFA" to null,
-                )
-
-                pageHeader(
+                    crumb = "MFA",
                     title = "Multi-Factor Authentication",
                     subtitleContent = {
                         +"TOTP-based MFA enrollment status for ${workspace.displayName}. Policy: "
@@ -1102,7 +1099,7 @@ internal fun createApiKeyPageImpl(
             slug to "/admin/workspaces/$slug",
             "Settings" to "/admin/workspaces/$slug/settings",
             "API Keys" to "/admin/workspaces/$slug/settings/api-keys",
-            "New API Key" to null,
+            "Create API Key" to null,
         )
 
         // ── Page header ──────────────────────────────────────────

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SessionAndAuditViews.kt
@@ -37,20 +37,18 @@ internal fun activeSessionsPageImpl(
             },
         ) {
             div("content-inner") {
-                breadcrumb(
-                    "Workspaces" to "/admin",
-                    workspace.slug to "/admin/workspaces/${workspace.slug}",
-                    "Security" to "/admin/workspaces/${workspace.slug}/settings/security",
-                    "Sessions" to null,
-                )
-
                 val sessionSubtitle =
                     if (totalCount > sessions.size) {
                         "Showing the ${sessions.size} most recent of $totalCount active sessions"
                     } else {
                         "$totalCount active session${if (totalCount != 1) "s" else ""} in this workspace"
                     }
-                pageHeader(
+                adminPage(
+                    "Workspaces" to "/admin",
+                    workspace.slug to "/admin/workspaces/${workspace.slug}",
+                    "Security" to "/admin/workspaces/${workspace.slug}/settings/security",
+                    // Terse on purpose: the trail reads better than "Active Sessions".
+                    crumb = "Sessions",
                     title = "Active Sessions",
                     subtitle = sessionSubtitle,
                     actions = if (sessions.isNotEmpty()) {
@@ -156,14 +154,10 @@ internal fun auditLogPageImpl(
             showSidebar = false,
         ) {
             div("content-inner content-inner--wide") {
-                breadcrumb(
+                adminPage(
                     "Workspaces" to "/admin",
                     workspace.slug to "/admin/workspaces/${workspace.slug}",
                     "Logs" to "/admin/workspaces/${workspace.slug}/logs",
-                    "Audit Log" to null,
-                )
-
-                pageHeader(
                     title = "Audit Log",
                     subtitle = "Security-relevant events for the ${workspace.displayName} workspace.",
                 )

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SignInMethodsAdminPage.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SignInMethodsAdminPage.kt
@@ -27,13 +27,9 @@ internal fun HTML.signInMethodsAdminPage(
         toastMessage = toastMessage,
     ) {
         div("content-inner") {
-            breadcrumb(
+            adminPage(
                 "Workspaces" to "/admin",
                 slug to "/admin/workspaces/$slug",
-                EnglishStrings.ADMIN_NAV_SIGN_IN_METHODS to null,
-            )
-
-            pageHeader(
                 title = EnglishStrings.ADMIN_NAV_SIGN_IN_METHODS,
                 subtitle = EnglishStrings.SIGN_IN_METHODS_PAGE_SUB,
                 actions = {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -944,7 +944,7 @@ internal fun createUserPageImpl(
                 "Workspaces" to "/admin",
                 workspace.slug to "/admin/workspaces/${workspace.slug}",
                 "Users" to "/admin/workspaces/${workspace.slug}/users",
-                "New User" to null,
+                "Create User" to null,
             )
 
             // ── Page header (narrow form variant) ────────────────────

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WebhookViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WebhookViews.kt
@@ -262,14 +262,14 @@ internal fun createWebhookPageImpl(
                 slug to "/admin/workspaces/$slug",
                 "Settings" to "/admin/workspaces/$slug/settings",
                 "Webhooks" to "/admin/workspaces/$slug/settings/webhooks",
-                "New Endpoint" to null,
+                "Create Webhook Endpoint" to null,
             )
 
             // ── Page header ──────────────────────────────────────────
             div("page-header") {
                 div("page-header__left") {
                     div("page-header__identity") {
-                        h1("page-header__title") { +"Add Webhook Endpoint" }
+                        h1("page-header__title") { +"Create Webhook Endpoint" }
                         p("page-header__sub") {
                             +"KotAuth will POST signed JSON payloads to your endpoint."
                         }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -294,7 +294,7 @@ internal fun createWorkspacePageImpl(
             div("content-inner content-inner--wide") {
             breadcrumb(
                 "Workspaces" to "/admin",
-                "New Workspace" to null,
+                "Create Workspace" to null,
             )
 
             // ── Page header with external submit ───────────────────

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminPageIdentityTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminPageIdentityTest.kt
@@ -1,0 +1,100 @@
+package com.kauth.adapter.web.admin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A ratchet on the breadcrumb/heading split.
+ *
+ * `breadcrumb()` and `pageHeader()` used to be independent calls with independently typed strings,
+ * and sixteen of thirty-seven admin pages had drifted — the console said "New Role" in the trail
+ * and "Create Role" in the heading. `adminPage()` renders both from one source of truth, so the
+ * trailing crumb defaults to the title and the two cannot silently disagree.
+ *
+ * Pages still calling `breadcrumb()` directly are legacy. The counts below only ever go down: a
+ * new page that calls it directly pushes a file over its allowance and fails here. Convert the
+ * page to `adminPage()` and lower the number instead of raising it.
+ *
+ * Reading the source rather than rendering is deliberate. Rendering every admin page would mean
+ * constructing every page's arguments, which is far more code than the property is worth.
+ */
+class AdminPageIdentityTest {
+    /**
+     * Remaining direct `breadcrumb()` call sites per file. Lower these as pages move to
+     * `adminPage()`; never raise one.
+     */
+    private val legacyAllowance =
+        mapOf(
+            "ApplicationViews.kt" to 3,
+            "BackupViews.kt" to 2,
+            "ClaimMapperViews.kt" to 1,
+            "RbacViews.kt" to 6,
+            "ResourceServerViews.kt" to 2,
+            "SecurityViews.kt" to 4,
+            "SettingsViews.kt" to 1,
+            "UserViews.kt" to 4,
+            "WebhookViews.kt" to 2,
+            "WorkspaceViews.kt" to 5,
+        )
+
+    private fun adminViewDir(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, "src/main/kotlin/com/kauth/adapter/web/admin")
+            if (candidate.isDirectory) return candidate
+            dir = dir.parentFile
+        }
+        error("could not locate the admin view directory")
+    }
+
+    private fun directBreadcrumbCalls(): Map<String, Int> =
+        adminViewDir()
+            .listFiles()
+            .orEmpty()
+            .filter { it.extension == "kt" && it.name != "AdminComponents.kt" }
+            .associate { it.name to Regex("""\bbreadcrumb\(""").findAll(it.readText()).count() }
+            .filterValues { it > 0 }
+
+    @Test
+    fun `no file gains a direct breadcrumb call`() {
+        val actual = directBreadcrumbCalls()
+        val regressions =
+            actual.filter { (file, count) -> count > (legacyAllowance[file] ?: 0) }
+
+        assertTrue(
+            regressions.isEmpty(),
+            "these files call breadcrumb() more than their allowance — use adminPage(), which " +
+                "renders the trail and the heading from one title so they cannot disagree. " +
+                "Offenders (file to actual count): $regressions. Allowance: $legacyAllowance",
+        )
+    }
+
+    @Test
+    fun `the allowance does not list files that have already been converted`() {
+        val actual = directBreadcrumbCalls()
+        val stale = legacyAllowance.filterKeys { it !in actual }
+
+        assertTrue(
+            stale.isEmpty(),
+            "these files no longer call breadcrumb() directly — remove them from the allowance " +
+                "so it keeps shrinking: ${stale.keys}",
+        )
+    }
+
+    @Test
+    fun `the allowance is not larger than the code`() {
+        val actual = directBreadcrumbCalls()
+        val loose =
+            legacyAllowance.filter { (file, allowed) ->
+                val real = actual[file]
+                real != null && real < allowed
+            }
+
+        assertTrue(
+            loose.isEmpty(),
+            "the allowance is higher than the actual count for these files — lower it to lock the " +
+                "progress in: ${loose.keys.map { it to (actual[it] to legacyAllowance[it]) }}",
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Addresses #134 at the cause rather than page by page.

`breadcrumb()` and `pageHeader()` were independent calls with independently typed strings, and nothing forced the trailing crumb to match the `h1`. Measuring it: **16 of 37 breadcrumb/heading pairs disagreed.**

### The measurement changed the fix

The 16 are not one problem. They are three, and only one is a defect:

**Genuine drift (7)** — the same inconsistency repeated. The trail said "New Role", the heading said "Create Role"; likewise for applications, groups, users, workspaces, API keys and webhook endpoints.

**Deliberate terseness (4)** — `MFA`/`Multi-Factor Authentication`, `General`/`General Settings`, `Sessions`/`Active Sessions`, `Edit`/`Edit Application`. A breadcrumb reading "Multi-Factor Authentication" would be worse, not better.

**Identity versus label (4)** — `application.clientId`/`application.name`, `workspace.slug`/`workspace.displayName`, and two `*_NAV_LABEL`/`*_PAGE_TITLE` constant pairs.

Forcing the crumb to equal the heading everywhere — the obvious reading of the issue — would have damaged the second and third groups. So:

- The seven genuine mismatches now read **Create X** in both places, matching the primary button already on those screens.
- `adminPage()` renders both from one `title`, so the crumb defaults to it and cannot drift.
- A shorter crumb is passed explicitly as `crumb =`, which turns it into a decision a reviewer can see rather than an accident that looks identical to one. Three pages use it.

### A ratchet, because ten pages still render their own header

Ten admin files build `div("page-header")` by hand and call `breadcrumb()` directly. Converting all of them is a much larger diff than this, and each needs reading rather than a regex — one file's conversion had to be redone by hand here because an automated rewrite spanned intervening code.

`AdminPageIdentityTest` records each remaining file's direct `breadcrumb()` count and fails if a file gains one, if the allowance lists a file that no longer needs it, or if the allowance sits above the real count. The numbers can only go down, and a new page cannot reintroduce the split.

## Type of change

- [x] Bug fix
- [x] Refactor (no behaviour change)

## How was this tested?

- [x] Added / updated unit tests
- [ ] Added / updated integration tests
- [ ] Tested manually — describe steps below

**2512 unit tests, 0 failures.** `make lint` clean.

**The ratchet was verified to catch a regression.** Planting an extra direct `breadcrumb()` call in `SettingsViews.kt` fails it:

```
AdminPageIdentityTest > no file gains a direct breadcrumb call() FAILED
```

The file was restored; the diff contains no change to it.

Re-measuring after the change: mismatches drop from 16 to 8, and every remaining one is a deliberate short crumb or an identifier-versus-name pair — no `"New X"` crumb and no `Add`/`New` heading survives on the create screens.

## Checklist

- [x] `make test` passes locally
- [x] `make lint` passes
- [ ] New domain logic has no framework imports — n/a, view layer only
- [ ] New database changes include a Flyway migration — n/a
- [ ] Public API changes are reflected in `openapi/v1.yaml` — n/a
- [x] Security-sensitive changes are noted in the description — none

## Notes for reviewers

The user-visible change is seven breadcrumbs: `New X` becomes `Create X`. Everything else is structural.

#133 — one row-identity rule across admin tables — is the other half of the UX review's cause-fix and is deliberately not in this PR. It needs a `dataTable` component with a declared identity column, which is its own change.
