### PR TITLE
Admin tables lead with the row's identity (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [1.25.2] - 2026-09-09
 
 ### Fixed
+
+- **Admin tables linked the wrong word.** The workspace list put the link on the slug and left the
+  display name as inert text beside it; the application list linked the `client_id` and left the
+  application's name dead. The word an operator actually recognises was the one they could not
+  click, and every row read as a database record rather than as a thing.
+
+  Eight tables were changed to follow one rule: the row's identity leads column one and carries the
+  link, with the technical identifier beside it as secondary text. Two of them — workspaces and
+  applications — had their first two columns swapped to do it; the rest already led with the right
+  value and only wore the wrong class. Closes #133.
 
 - **Seven create-screens disagreed with themselves.** The breadcrumb said "New Role" while the
   heading said "Create Role" — and the same split existed for applications, groups, users,
@@ -28,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `breadcrumb()` calls each remaining legacy file makes and fails if any file gains one, if the
   allowance lists a file that no longer needs it, or if the allowance drifts above the real count.
   The numbers can only go down.
+- **`.data-table__id` is retired, and a ratchet keeps it retired.** The class rendered a monospace
+  accent link, so reaching for it meant putting the row's link on a technical identifier — the CSS
+  vocabulary made the wrong layout the easy one. It is deleted; `data-table__name` carries the
+  identity link and `data-table__meta` the identifier beside it. `AdminTableIdentityTest` fails if
+  the class reappears in a view or a stylesheet, or if a link is styled as inert `__meta` text.
+
+  It deliberately does not try to enforce column order: that would mean brace-matching the
+  kotlinx.html DSL, and several of these tables are read-only lists with no row link at all, so the
+  check would need exceptions for exactly the rows most likely to be edited. The rule is documented
+  where an author will hit it, at the top of `table.css`.
 - **CI applies every migration to an empty database.** The unit suite runs on in-memory fakes, so
   it never sees a migration at all; nothing in CI applied `V1` through the newest file to a fresh
   database. A broken `V*.sql` therefore passed Flyway's checksum validation, passed the unit tests,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 }
 
 group = "com.kauth"
-version = "1.25.1"
+version = "1.25.2"
 
 // Pin the compile target explicitly rather than letting it follow whichever JDK
 // happens to build. `release`/`-Xjdk-release` also stop a newer build JDK from

--- a/docs/FRONTEND_CSS.md
+++ b/docs/FRONTEND_CSS.md
@@ -75,7 +75,7 @@ project-root/
 │       │   ├── card.css               ← .card, .card-body, .card-title (legacy)
 │       │   ├── form.css               ← input, select, textarea, label, .field (legacy global)
 │       │   ├── stat-card.css          ← .stat-grid, .stat-card, .stat-label, .stat-value
-│       │   ├── table.css              ← .data-table, .data-table__id/name/actions (BEM)
+│       │   ├── table.css              ← .data-table, .data-table__name/meta/actions (BEM)
 │       │   ├── empty-state.css        ← .empty-state, .empty-state__icon/title/desc/cta (BEM)
 │       │   ├── ov-card.css            ← .ov-card, .ov-card__section-label/row/label/value (BEM)
 │       │   ├── notice.css             ← .notice, .notice--success/error (BEM)
@@ -455,11 +455,16 @@ Used inside ov-cards for settings and edit forms. Grid layout matching ov-card__
 
 ```css
 .data-table              /* full-width bordered table */
-.data-table__id          /* accent link in first column */
-.data-table__name        /* primary text cell */
+.data-table__name        /* the row's identity; on an <a> in column one, the row link */
 .data-table__email       /* secondary text cell */
+.data-table__meta        /* monospace muted technical value (slug, client_id, UUID) */
 .data-table__actions     /* right-aligned action buttons */
 ```
+
+**Row identity rule.** The thing a human uses to tell one row from another leads
+column one and carries the link, as `__name`. Technical identifiers sit beside it
+as inert `__meta`. `AdminTableIdentityTest` guards this; `.data-table__id`, which
+styled the reverse, was retired in v1.25.2.
 
 ### `key-table` — compact sub-table for detail pages
 

--- a/frontend/css/components/table.css
+++ b/frontend/css/components/table.css
@@ -3,10 +3,15 @@
  * Data tables for listing resources (users, apps, sessions, etc.).
  *
  * New BEM block: .data-table (used by new page designs)
- *   .data-table__id      — monospace accent LINK. Only ever on an <a>: it is coloured and
- *                          underlines on hover, so on inert text it promises a click that
- *                          does not exist. A technical value that is not a link is __meta.
- *   .data-table__name    — primary text cell
+ *
+ * ROW IDENTITY RULE: the thing a human uses to tell one row from another leads column one
+ * and carries the row's link, as .data-table__name. Technical identifiers (slug, client_id,
+ * UUID) sit beside it as inert __meta. Tables used to do the reverse — link the client_id
+ * and leave the app name as dead text — which made every row read as a database record
+ * rather than a thing. AdminTableIdentityTest guards this.
+ *
+ *   .data-table__name    — the row's identity. On an <a> in column one it is the row link;
+ *                          elsewhere a primary text cell. Body colour, underline on hover.
  *   .data-table__email   — monospace muted email cell
  *   .data-table__meta    — monospace muted secondary cell (URLs, counts, timestamps)
  *   .data-table__meta--with-icon — meta cell carrying a trailing .inline-help icon
@@ -52,14 +57,6 @@
 .data-table tbody tr:last-child td { border-bottom: none; }
 .data-table tbody tr { transition: background 0.1s; }
 .data-table tbody tr:hover { background: var(--color-row-hover); }
-
-.data-table__id {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--color-accent);
-  text-decoration: none;
-}
-.data-table__id:hover { text-decoration: underline; }
 
 .data-table__name {
   font-size: var(--text-base);

--- a/src/main/kotlin/com/kauth/adapter/web/admin/DashboardViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/DashboardViews.kt
@@ -55,8 +55,8 @@ internal fun workspaceListPageImpl(
                     table("data-table") {
                         thead {
                             tr {
-                                th { style = "width:200px;"; +"Slug" }
                                 th { +EnglishStrings.COL_NAME }
+                                th { style = "width:200px;"; +"Slug" }
                                 th { style = "width:130px;"; +"Registration" }
                                 th { style = "width:70px;" }
                             }
@@ -64,13 +64,15 @@ internal fun workspaceListPageImpl(
                         tbody {
                             workspaces.forEach { ws ->
                                 tr {
+                                    // The row's identity leads and carries the link; the slug is
+                                    // the technical value beside it, not the thing you click.
                                     td {
                                         a(
                                             href = "/admin/workspaces/${ws.slug}",
-                                            classes = "data-table__id",
-                                        ) { +ws.slug }
+                                            classes = "data-table__name",
+                                        ) { +ws.displayName }
                                     }
-                                    td { span("data-table__name") { +ws.displayName } }
+                                    td { span("data-table__meta") { +ws.slug } }
                                     // Open registration is the default, so only a closed
                                     // workspace is worth a badge.
                                     td {

--- a/src/main/kotlin/com/kauth/adapter/web/admin/PasskeysAdminPage.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/PasskeysAdminPage.kt
@@ -140,7 +140,7 @@ internal fun HTML.passkeysAdminPage(
                                     td {
                                         a(
                                             "/admin/workspaces/$slug/users/${u.id?.value}",
-                                            classes = "data-table__id",
+                                            classes = "data-table__name",
                                         ) { +u.username }
                                     }
                                     td { span("data-table__name") { +u.fullName } }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/RbacViews.kt
@@ -71,7 +71,7 @@ internal fun rolesListPageImpl(
                                 td {
                                     a(
                                         href = "/admin/workspaces/$slug/roles/${role.id?.value}",
-                                        classes = "data-table__id",
+                                        classes = "data-table__name",
                                     ) { +role.name }
                                 }
                                 td {
@@ -505,7 +505,7 @@ internal fun groupsListPageImpl(
                                 td {
                                     a(
                                         href = "/admin/workspaces/$slug/groups/${group.id?.value}",
-                                        classes = "data-table__id",
+                                        classes = "data-table__name",
                                     ) { +group.name }
                                 }
                                 td { span("data-table__name") { +(parent?.name ?: "\u2014") } }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/ResourceServerViews.kt
@@ -69,9 +69,10 @@ internal fun resourceServersListPageImpl(
                                 resources.forEach { rs ->
                                     tr {
                                         td {
-                                            a(href = "/admin/workspaces/$slug/apis/${rs.id!!.value}/edit") {
-                                                +rs.name
-                                            }
+                                            a(
+                                                href = "/admin/workspaces/$slug/apis/${rs.id!!.value}/edit",
+                                                classes = "data-table__name",
+                                            ) { +rs.name }
                                         }
                                         td {
                             span("data-table__meta") { +rs.identifier }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/SecurityViews.kt
@@ -165,7 +165,7 @@ internal fun mfaSettingsPageImpl(
                                         td {
                                             a(
                                                 "/admin/workspaces/${workspace.slug}/users/${u.id?.value}",
-                                                classes = "data-table__id",
+                                                classes = "data-table__name",
                                             ) { +u.username }
                                         }
                                         td { span("data-table__name") { +u.fullName } }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/UserViews.kt
@@ -865,7 +865,7 @@ internal fun userListPageImpl(
                                     td {
                                         a(
                                             href = "/admin/workspaces/${workspace.slug}/users/${user.id?.value}",
-                                            classes = "data-table__id",
+                                            classes = "data-table__name",
                                         ) { +user.username }
                                     }
                                     td {
@@ -1364,10 +1364,9 @@ private fun FlowContent.activeImpersonationCard(active: ActiveImpersonation) {
         div("ov-card__section-label") { +EnglishStrings.IMPERSONATION_ACTIVE_HEADING }
         div("ov-card__row") {
             span("ov-card__label") { +EnglishStrings.IMPERSONATION_ACTIVE_USER }
-            span("ov-card__value") {
+            span("ov-card__value ov-card__value--mono") {
                 a(
                     href = "/admin/workspaces/${active.targetWorkspaceSlug}/users/${active.targetUserId}",
-                    classes = "data-table__id",
                 ) { +active.targetUsername }
             }
         }

--- a/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
+++ b/src/main/kotlin/com/kauth/adapter/web/admin/WorkspaceViews.kt
@@ -202,11 +202,11 @@ internal fun workspaceDetailPageImpl(
                     table("data-table") {
                         thead {
                             tr {
+                                th { +EnglishStrings.COL_NAME }
                                 th {
                                     style = "width:210px;"
                                     +"Client ID"
                                 }
-                                th { +EnglishStrings.COL_NAME }
                                 th {
                                     style = "width:110px;"
                                     +"Type"
@@ -221,14 +221,16 @@ internal fun workspaceDetailPageImpl(
                         tbody {
                             apps.forEach { app ->
                                 tr {
+                                    // The application's name is its identity here and carries the
+                                    // link; the client_id is the technical value beside it.
                                     td {
                                         a(
                                             href =
                                                 "/admin/workspaces/${workspace.slug}/applications/${app.clientId}",
-                                            classes = "data-table__id",
-                                        ) { +app.clientId }
+                                            classes = "data-table__name",
+                                        ) { +app.name }
                                     }
-                                    td { span("data-table__name") { +app.name } }
+                                    td { span("data-table__meta") { +app.clientId } }
                                     td { accessTypeLabel(app.accessType) }
                                     td { applicationStatus(app.enabled) }
                                     td {

--- a/src/test/kotlin/com/kauth/adapter/web/admin/AdminTableIdentityTest.kt
+++ b/src/test/kotlin/com/kauth/adapter/web/admin/AdminTableIdentityTest.kt
@@ -1,0 +1,77 @@
+package com.kauth.adapter.web.admin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A ratchet on the row-identity rule for admin tables.
+ *
+ * The workspace list linked the slug and left the display name as dead text; the application
+ * list linked the client_id and left the name dead. Both read as database records rather than
+ * as things, and in both the word an operator actually recognises was the one they could not
+ * click. The rule is now: the row's identity leads column one and carries the link, as
+ * `data-table__name`; the technical identifier sits beside it as inert `data-table__meta`.
+ *
+ * `.data-table__id` was the mechanism. It rendered a monospace accent link, so reaching for it
+ * meant putting the link on the technical value — the class made the wrong layout the easy one.
+ * It is deleted from `table.css`, and this test keeps it deleted.
+ *
+ * What this does NOT check is column order itself. Enforcing "column one carries the link"
+ * would mean brace-matching the kotlinx.html DSL to find each table's first cell, and a number
+ * of these tables are read-only lists (audit log, sessions, key rotation, diagnostics) with no
+ * row link at all — so the check would need exceptions for exactly the rows most likely to be
+ * edited. A brittle test that fails on innocent refactors is worse than the CSS comment
+ * plus review. The two properties below are the ones a regex can hold honestly.
+ */
+class AdminTableIdentityTest {
+    private fun repoRoot(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            if (File(dir, "src/main/kotlin/com/kauth/adapter/web").isDirectory) return dir
+            dir = dir.parentFile
+        }
+        error("could not locate the repository root")
+    }
+
+    private fun sources(vararg relativeDirs: String): List<File> =
+        relativeDirs.flatMap { rel ->
+            File(repoRoot(), rel).walkTopDown().filter { it.isFile }.toList()
+        }
+
+    @Test
+    fun `the retired data-table__id class does not come back`() {
+        val offenders =
+            sources("src/main/kotlin/com/kauth/adapter/web", "frontend/css")
+                .filter { it.extension in setOf("kt", "css") }
+                .filter { it.readText().contains("data-table__id") }
+                .map { it.relativeTo(repoRoot()).path }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "data-table__id is retired: it styled a monospace accent link, so using it put the " +
+                "row's link on a technical identifier instead of on the row's identity. Use " +
+                "data-table__name for the identity link and data-table__meta for the identifier " +
+                "beside it. Offenders: $offenders",
+        )
+    }
+
+    @Test
+    fun `no link is styled as inert meta text`() {
+        // The mirror of the __id problem: __meta is muted, undecorated, and reads as dead text,
+        // so a link wearing it gives the operator no reason to think it is clickable.
+        val anchorWithMeta = Regex("""\ba\((?:[^()]|\([^()]*\))*data-table__meta""", RegexOption.DOT_MATCHES_ALL)
+        val offenders =
+            sources("src/main/kotlin/com/kauth/adapter/web")
+                .filter { it.extension == "kt" }
+                .filter { anchorWithMeta.containsMatchIn(it.readText()) }
+                .map { it.relativeTo(repoRoot()).path }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "data-table__meta is inert secondary text — a link wearing it looks unclickable. " +
+                "If it is the row's identity use data-table__name; otherwise it should not be a " +
+                "link. Offenders: $offenders",
+        )
+    }
+}


### PR DESCRIPTION
Closes #133. Ships as **v1.25.2**, together with the create-screen and CI-migration work already on `main`.

## The problem

The workspace list put the link on the slug and left the display name inert beside it. The application list linked the `client_id` and left the application's name dead. In both, the word an operator actually recognises was the one they could not click, and the row read as a database record rather than as a thing.

## The rule

The row's identity leads column one and carries the link, as `data-table__name`. The technical identifier sits beside it as inert `data-table__meta`.

Eight tables were changed to follow it:

| Table | Change |
|---|---|
| Workspaces (`DashboardViews`) | first two columns swapped — name now leads and links, slug is `__meta` |
| Applications (`WorkspaceViews`) | first two columns swapped — name now leads and links, `client_id` is `__meta` |
| Roles, Groups (`RbacViews`) | already led with the right value; wore the wrong class |
| Users (`UserViews`), MFA (`SecurityViews`), Passkeys (`PasskeysAdminPage`) | same |
| APIs (`ResourceServerViews`) | the issue's own reference table — leads correctly but linked with a bare `<a>`, now carries the identity class like the rest |

## The mechanism, and retiring it

`.data-table__id` rendered a monospace accent link, so reaching for it meant putting the row's link on a technical identifier. The CSS vocabulary made the wrong layout the easy one. It is deleted from `table.css`, and the rule is documented where an author will hit it — at the top of that file.

One non-table site used the class inside an `ov-card`. It moved to `ov-card__value--mono`, which is the same font, size and colour, so that swap is visually a no-op.

## The guard

`AdminTableIdentityTest` fails if `data-table__id` reappears in any view or stylesheet, or if a link is styled as inert `__meta` text. Both assertions were verified by planting the violation and watching them fail.

It deliberately does **not** enforce column order. That would mean brace-matching the kotlinx.html DSL, and a number of these tables are read-only lists (audit log, sessions, key rotation, diagnostics) with no row link at all — so the check would need exceptions for exactly the rows most likely to be edited. A brittle test that fails on innocent refactors is worse than the CSS comment plus review.

## Verification

- `make lint` — clean
- `make test` — 2514 tests, 0 failures
- `make css` — bundles rebuild; `data-table__id` gone, `data-table__name` present
- `./gradlew buildFatJar` — `kotauth-1.25.2.jar` builds clean